### PR TITLE
fix: update GitHub Actions versions to fix CI error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode_15.4.app/Contents/Developer
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: build docc
         run: |
           swift package --allow-writing-to-directory ./docs generate-documentation \
@@ -20,7 +20,7 @@ jobs:
           --output-path ./docs \
           --transform-for-static-hosting \
           --hosting-base-path SwiftAutoGUI
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: docs
 
@@ -36,4 +36,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
Updated GitHub Actions versions in the DocC deployment workflow to fix the deprecated artifact actions error.

## Changes
- `actions/checkout`: v3 → v4
- `actions/upload-pages-artifact`: v1 → v3  
- `actions/deploy-pages`: v1 → v4

## Context
The CI was failing with the error:
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`.
```

This PR updates all actions to their latest stable versions to resolve the issue.

## Test Plan
- [ ] CI workflow runs successfully on merge
- [ ] DocC documentation deploys correctly to GitHub Pages

🤖 Generated with [Claude Code](https://claude.ai/code)