### PR TITLE
Restrict Claude Code Action to owner comments only

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,10 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.user.login == 'NakaokaRei') ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.user.login == 'NakaokaRei') ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && github.event.review.user.login == 'NakaokaRei') ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && github.event.issue.user.login == 'NakaokaRei')
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Modified Claude GitHub Action workflow to only respond to @claude mentions from repository owner
- Added user login check for NakaokaRei to prevent Claude from responding to other users' comments

## Why this change?
Since this is a public repository, we want to ensure Claude only responds to the repository owner's commands to:
- Prevent unauthorized usage
- Maintain control over Claude's actions
- Avoid potential spam or misuse

## Test plan
- [x] Verify workflow file syntax is correct
- [ ] Test that Claude responds to @claude mentions from NakaokaRei
- [ ] Verify Claude ignores @claude mentions from other users

🤖 Generated with [Claude Code](https://claude.ai/code)