### PR TITLE
feat: add AppleScript execution functionality #41

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,69 @@ let topRegion = CGRect(x: 0, y: 0, width: 1920, height: 100)
 let menuItems = SwiftAutoGUI.locateAllOnScreen("menu_item.png", region: topRegion)
 ```
 
+## AppleScript Execution
+SwiftAutoGUI can execute AppleScript code to control macOS applications and system features.
+
+```swift
+import SwiftAutoGUI
+
+// Execute AppleScript code
+let script = """
+tell application "Safari"
+    activate
+    make new document
+    set URL of current tab of front window to "https://github.com/NakaokaRei/SwiftAutoGUI"
+end tell
+"""
+try SwiftAutoGUI.executeAppleScript(script)
+
+// Execute and get return value
+let systemInfo = """
+tell application "System Events"
+    return system version of (system info)
+end tell
+"""
+if let version = try SwiftAutoGUI.executeAppleScript(systemInfo) {
+    print("macOS version: \(version)")
+}
+
+// Control system volume
+try SwiftAutoGUI.executeAppleScript("set volume output volume 50")
+
+// Display notification
+let notification = """
+display notification "Task completed!" with title "SwiftAutoGUI"
+"""
+try SwiftAutoGUI.executeAppleScript(notification)
+
+// Execute AppleScript from file
+try SwiftAutoGUI.executeAppleScriptFile("/path/to/script.applescript")
+```
+
+### Important Notes for AppleScript
+
+When using AppleScript functionality in macOS applications, you need to configure the following:
+
+1. **Disable App Sandbox**: In your app's `.entitlements` file, set:
+   ```xml
+   <key>com.apple.security.app-sandbox</key>
+   <false/>
+   ```
+   
+2. **Enable Automation Permission**: Add to your `.entitlements` file:
+   ```xml
+   <key>com.apple.security.automation.apple-events</key>
+   <true/>
+   ```
+
+3. **Add Usage Description**: In your app's `Info.plist`, add:
+   ```xml
+   <key>NSAppleEventsUsageDescription</key>
+   <string>Your app needs permission to control other applications.</string>
+   ```
+
+⚠️ **Note**: Disabling the sandbox reduces your app's security isolation. Only disable it if absolutely necessary for your app's functionality.
+
 # Contributors
 
 - [NakaokaRei](https://github.com/NakaokaRei)

--- a/Sample/Sample.xcodeproj/project.pbxproj
+++ b/Sample/Sample.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		5C3CE0282973398400D9CE50 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		5C3CE02A2973398400D9CE50 /* Sample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Sample.entitlements; sourceTree = "<group>"; };
 		5C3E344A2C3030D600BAD11F /* SwiftAutoGUI */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = SwiftAutoGUI; path = ../..; sourceTree = "<group>"; };
+		5CBA7E592E2B7D3700CBB992 /* SwiftAutoGUITestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = SwiftAutoGUITestPlan.xctestplan; path = Sample/SwiftAutoGUITestPlan.xctestplan; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -44,6 +45,7 @@
 		5C3CE0152973398300D9CE50 = {
 			isa = PBXGroup;
 			children = (
+				5CBA7E592E2B7D3700CBB992 /* SwiftAutoGUITestPlan.xctestplan */,
 				5C3CE0202973398300D9CE50 /* Sample */,
 				5C3CE01F2973398300D9CE50 /* Products */,
 				5C3CE030297339AA00D9CE50 /* Frameworks */,
@@ -300,6 +302,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Demo App Send AppleEvent";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -327,6 +330,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Demo App Send AppleEvent";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Sample/Sample.xcodeproj/xcshareddata/xcschemes/Sample.xcscheme
+++ b/Sample/Sample.xcodeproj/xcshareddata/xcschemes/Sample.xcscheme
@@ -27,8 +27,12 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Sample/SwiftAutoGUITestPlan.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Sample/Sample/Common/DemoTab.swift
+++ b/Sample/Sample/Common/DemoTab.swift
@@ -16,6 +16,7 @@ enum DemoTab: String, CaseIterable {
     case pixelDetection
     case scrolling
     case dialog
+    case appleScript
     
     var title: String {
         switch self {
@@ -27,6 +28,7 @@ enum DemoTab: String, CaseIterable {
         case .pixelDetection: return "Pixel Detection"
         case .scrolling: return "Scrolling"
         case .dialog: return "Dialog"
+        case .appleScript: return "AppleScript"
         }
     }
     
@@ -40,6 +42,7 @@ enum DemoTab: String, CaseIterable {
         case .pixelDetection: return "eyedropper"
         case .scrolling: return "arrow.up.and.down"
         case .dialog: return "message"
+        case .appleScript: return "applescript"
         }
     }
 }

--- a/Sample/Sample/ContentView.swift
+++ b/Sample/Sample/ContentView.swift
@@ -98,6 +98,8 @@ struct ContentView: View {
                             ScrollingDemoView()
                         case .dialog:
                             DialogDemoView()
+                        case .appleScript:
+                            AppleScriptView()
                         }
                     }
                     .padding(24)

--- a/Sample/Sample/Features/AppleScript/AppleScriptView.swift
+++ b/Sample/Sample/Features/AppleScript/AppleScriptView.swift
@@ -1,0 +1,162 @@
+//
+//  AppleScriptView.swift
+//  Sample
+//
+//  Created by SwiftAutoGUI on 2025/07/19.
+//
+
+import SwiftUI
+
+struct AppleScriptView: View {
+    @StateObject private var viewModel = AppleScriptViewModel()
+    @Environment(\.colorScheme) var colorScheme
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            // Header
+            VStack(alignment: .leading, spacing: 8) {
+                Label("AppleScript Execution", systemImage: "applescript")
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                
+                Text("Execute AppleScript code to automate macOS applications and system features.")
+                    .font(.callout)
+                    .foregroundColor(.secondary)
+            }
+            
+            // Sample Scripts Menu
+            HStack {
+                Text("Sample Scripts:")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                
+                Menu {
+                    ForEach(AppleScriptViewModel.SampleScript.allCases, id: \.self) { sample in
+                        Button(sample.rawValue) {
+                            viewModel.loadSampleScript(sample)
+                        }
+                    }
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "doc.text")
+                        Text("Load Sample")
+                        Image(systemName: "chevron.down")
+                            .font(.caption)
+                    }
+                    .font(.subheadline)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(Color.accentColor.opacity(0.1))
+                    .cornerRadius(6)
+                }
+                
+                Spacer()
+            }
+            
+            // Script Editor
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Label("Script Editor", systemImage: "pencil.and.scribble")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                    
+                    Spacer()
+                    
+                    if viewModel.isExecuting {
+                        ProgressView()
+                            .scaleEffect(0.8)
+                    }
+                }
+                
+                ScrollView {
+                    TextEditor(text: $viewModel.scriptText)
+                        .font(.custom("SF Mono", size: 13))
+                        .padding(8)
+                        .background(colorScheme == .dark ? Color(white: 0.1) : Color(white: 0.95))
+                        .cornerRadius(8)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+                        )
+                        .frame(minHeight: 200, maxHeight: 300)
+                }
+            }
+            
+            // Execute Button
+            Button(action: {
+                viewModel.executeScript()
+            }) {
+                HStack {
+                    Image(systemName: "play.fill")
+                    Text("Execute Script")
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .background(viewModel.isExecuting ? Color.gray : Color.accentColor)
+                .foregroundColor(.white)
+                .cornerRadius(8)
+            }
+            .disabled(viewModel.isExecuting || viewModel.scriptText.isEmpty)
+            
+            // Result/Error Display
+            if !viewModel.result.isEmpty || viewModel.errorMessage != nil {
+                VStack(alignment: .leading, spacing: 8) {
+                    if let error = viewModel.errorMessage {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Label("Error", systemImage: "exclamationmark.triangle.fill")
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                                .foregroundColor(.red)
+                            
+                            Text(error)
+                                .font(.caption)
+                                .foregroundColor(.red)
+                                .padding(8)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .background(Color.red.opacity(0.1))
+                                .cornerRadius(6)
+                        }
+                    } else {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Label("Result", systemImage: "checkmark.circle.fill")
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                                .foregroundColor(.green)
+                            
+                            Text(viewModel.result)
+                                .font(.caption)
+                                .foregroundColor(.primary)
+                                .padding(8)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .background(Color.green.opacity(0.1))
+                                .cornerRadius(6)
+                        }
+                    }
+                }
+                .transition(.opacity.combined(with: .move(edge: .top)))
+                .animation(.easeInOut(duration: 0.3), value: viewModel.result)
+                .animation(.easeInOut(duration: 0.3), value: viewModel.errorMessage)
+            }
+            
+            // Info Box
+            HStack(spacing: 12) {
+                Image(systemName: "info.circle")
+                    .foregroundColor(.blue)
+                
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Note")
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                    Text("AppleScript execution may require additional permissions. Some scripts may prompt for access to control other applications.")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .padding(12)
+            .background(Color.blue.opacity(0.1))
+            .cornerRadius(8)
+            
+            Spacer()
+        }
+    }
+}

--- a/Sample/Sample/Features/AppleScript/AppleScriptViewModel.swift
+++ b/Sample/Sample/Features/AppleScript/AppleScriptViewModel.swift
@@ -1,0 +1,125 @@
+//
+//  AppleScriptViewModel.swift
+//  Sample
+//
+//  Created by SwiftAutoGUI on 2025/07/19.
+//
+
+import Foundation
+import SwiftAutoGUI
+
+@MainActor
+final class AppleScriptViewModel: ObservableObject {
+    @Published var scriptText: String
+    @Published var result: String = ""
+    @Published var isExecuting: Bool = false
+    @Published var errorMessage: String?
+    
+    init() {
+        // Initial sample script
+        self.scriptText = """
+tell application "Safari"
+    activate
+    make new document
+    set URL of current tab of front window to "https://github.com/NakaokaRei/SwiftAutoGUI"
+end tell
+"""
+    }
+    
+    func executeScript() {
+        isExecuting = true
+        errorMessage = nil
+        result = ""
+        
+        Task {
+            do {
+                print("Executing AppleScript:")
+                print(scriptText)
+                print("---")
+                
+                if let output = try SwiftAutoGUI.executeAppleScript(scriptText) {
+                    print("Script output: \(output)")
+                    await MainActor.run {
+                        self.result = output
+                        self.isExecuting = false
+                    }
+                } else {
+                    print("Script completed with no output")
+                    await MainActor.run {
+                        self.result = "Script executed successfully (no output)"
+                        self.isExecuting = false
+                    }
+                }
+            } catch let error as SwiftAutoGUI.AppleScriptError {
+                print("AppleScript error: \(error)")
+                await MainActor.run {
+                    self.errorMessage = error.errorDescription
+                    self.isExecuting = false
+                }
+            } catch {
+                print("Unexpected error: \(error)")
+                await MainActor.run {
+                    self.errorMessage = "Unexpected error: \(error.localizedDescription)"
+                    self.isExecuting = false
+                }
+            }
+        }
+    }
+    
+    func loadSampleScript(_ sample: SampleScript) {
+        scriptText = sample.script
+        result = ""
+        errorMessage = nil
+    }
+    
+    enum SampleScript: String, CaseIterable {
+        case safariSearch = "Safari Search"
+        case systemInfo = "System Info"
+        case volumeControl = "Volume Control"
+        case notification = "Notification"
+        case calculator = "Calculator"
+        
+        var script: String {
+            switch self {
+            case .safariSearch:
+                return """
+tell application "Safari"
+    activate
+    make new document
+    set URL of current tab of front window to "https://github.com/NakaokaRei/SwiftAutoGUI"
+end tell
+"""
+            case .systemInfo:
+                return """
+tell application "System Events"
+    set userName to name of current user
+    set osVersion to system version of (system info)
+    return "User: " & userName & ", macOS: " & osVersion
+end tell
+"""
+            case .volumeControl:
+                return """
+-- Get current volume
+set currentVolume to output volume of (get volume settings)
+
+-- Set volume to 50%
+set volume output volume 50
+
+-- Return the previous volume
+return "Previous volume was: " & currentVolume & "%"
+"""
+            case .notification:
+                return """
+display notification "Hello from SwiftAutoGUI!" with title "AppleScript Demo" subtitle "This is a test notification"
+return "Notification sent!"
+"""
+            case .calculator:
+                return """
+-- Simple calculation
+set result to (25 * 4) + (100 / 2)
+return "25 × 4 + 100 ÷ 2 = " & result
+"""
+            }
+        }
+    }
+}

--- a/Sample/Sample/Sample.entitlements
+++ b/Sample/Sample/Sample.entitlements
@@ -2,9 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.security.app-sandbox</key>
-    <true/>
-    <key>com.apple.security.files.user-selected.read-only</key>
-    <true/>
+	<key>com.apple.security.app-sandbox</key>
+	<false/>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
 </dict>
 </plist>

--- a/Sample/Sample/SwiftAutoGUITestPlan.xctestplan
+++ b/Sample/Sample/SwiftAutoGUITestPlan.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "193D5AFA-AA2E-4C31-BA1E-26A723072DA3",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:..",
+        "identifier" : "SwiftAutoGUITests",
+        "name" : "SwiftAutoGUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Sources/SwiftAutoGUI/AppleScript.swift
+++ b/Sources/SwiftAutoGUI/AppleScript.swift
@@ -1,0 +1,192 @@
+import Foundation
+
+/// AppleScript execution functionality for SwiftAutoGUI.
+///
+/// This extension provides methods to execute AppleScript code, enabling control of macOS applications
+/// and system features through Apple Events.
+///
+/// ## Important Configuration Requirements
+///
+/// To use AppleScript functionality in your macOS application, you must configure the following:
+///
+/// ### 1. Disable App Sandbox
+/// In your app's `.entitlements` file:
+/// ```xml
+/// <key>com.apple.security.app-sandbox</key>
+/// <false/>
+/// ```
+///
+/// ### 2. Enable Automation Permission
+/// In your app's `.entitlements` file:
+/// ```xml
+/// <key>com.apple.security.automation.apple-events</key>
+/// <true/>
+/// ```
+///
+/// ### 3. Add Usage Description
+/// In your app's `Info.plist`:
+/// ```xml
+/// <key>NSAppleEventsUsageDescription</key>
+/// <string>This app needs permission to control other applications.</string>
+/// ```
+///
+/// ## Security Considerations
+///
+/// - Disabling the sandbox reduces your app's security isolation
+/// - Users will be prompted to grant permission when your app first attempts to control another application
+/// - The permission dialog will show the usage description from your Info.plist
+///
+/// ## Example Usage
+///
+/// ```swift
+/// // Control Safari
+/// let script = """
+/// tell application "Safari"
+///     activate
+///     make new document
+///     set URL of current tab of front window to "https://example.com"
+/// end tell
+/// """
+/// try SwiftAutoGUI.executeAppleScript(script)
+///
+/// // Get system information
+/// let systemVersion = """
+/// tell application "System Events"
+///     return system version of (system info)
+/// end tell
+/// """
+/// if let version = try SwiftAutoGUI.executeAppleScript(systemVersion) {
+///     print("macOS version: \(version)")
+/// }
+/// ```
+extension SwiftAutoGUI {
+    
+    /// Executes an AppleScript string and returns the result.
+    ///
+    /// This method executes the provided AppleScript code synchronously and returns
+    /// the script's output as a string. Useful for automating macOS applications
+    /// and system features that expose AppleScript interfaces.
+    ///
+    /// - Parameter script: The AppleScript code to execute
+    /// - Returns: The script's output as a string, or nil if the script produces no output
+    /// - Throws: An error if the script fails to compile or execute
+    ///
+    /// ## Example
+    /// ```swift
+    /// // Get current Safari URL
+    /// let script = """
+    ///     tell application "Safari"
+    ///         return URL of current tab of front window
+    ///     end tell
+    /// """
+    /// if let url = try SwiftAutoGUI.executeAppleScript(script) {
+    ///     print("Current URL: \(url)")
+    /// }
+    ///
+    /// // Control system volume
+    /// try SwiftAutoGUI.executeAppleScript("set volume output volume 50")
+    /// ```
+    public static func executeAppleScript(_ script: String) throws -> String? {
+        guard let appleScript = NSAppleScript(source: script) else {
+            throw AppleScriptError.compilationFailed("Failed to create NSAppleScript instance")
+        }
+        
+        var compileErrorInfo: NSDictionary?
+        if !appleScript.compileAndReturnError(&compileErrorInfo) {
+            if let error = compileErrorInfo {
+                throw AppleScriptError.compilationFailed(parseAppleScriptError(error))
+            }
+            throw AppleScriptError.compilationFailed("Unknown compilation error")
+        }
+        
+        var executeErrorInfo: NSDictionary?
+        let eventDescriptor = appleScript.executeAndReturnError(&executeErrorInfo)
+        
+        if let error = executeErrorInfo {
+            throw AppleScriptError.executionFailed(parseAppleScriptError(error))
+        }
+        
+        // Return nil if the script returns nothing
+        if eventDescriptor.descriptorType == typeNull {
+            return nil
+        }
+        
+        // Handle list results
+        if eventDescriptor.descriptorType == typeAEList {
+            var items: [String] = []
+            for i in 1...eventDescriptor.numberOfItems {
+                if let item = eventDescriptor.atIndex(i) {
+                    if let stringValue = item.stringValue {
+                        items.append(stringValue)
+                    }
+                }
+            }
+            return items.joined(separator: ", ")
+        }
+        
+        return eventDescriptor.stringValue
+    }
+    
+    /// Executes an AppleScript from a file.
+    ///
+    /// This method loads and executes an AppleScript from the specified file path.
+    /// Useful for organizing complex scripts in separate files.
+    ///
+    /// - Parameter filePath: The absolute path to the AppleScript file (.scpt or .applescript)
+    /// - Returns: The script's output as a string, or nil if the script produces no output
+    /// - Throws: An error if the file cannot be read or the script fails to execute
+    ///
+    /// ## Example
+    /// ```swift
+    /// // Execute a script file
+    /// let scriptPath = "/Users/username/Scripts/backup.applescript"
+    /// try SwiftAutoGUI.executeAppleScriptFile(scriptPath)
+    /// ```
+    public static func executeAppleScriptFile(_ filePath: String) throws -> String? {
+        let fileURL = URL(fileURLWithPath: filePath)
+        
+        guard FileManager.default.fileExists(atPath: filePath) else {
+            throw AppleScriptError.fileNotFound(filePath)
+        }
+        
+        let scriptContent = try String(contentsOf: fileURL, encoding: .utf8)
+        return try executeAppleScript(scriptContent)
+    }
+    
+    /// Represents errors that can occur during AppleScript execution.
+    public enum AppleScriptError: LocalizedError {
+        case compilationFailed(String)
+        case executionFailed(String)
+        case fileNotFound(String)
+        
+        public var errorDescription: String? {
+            switch self {
+            case .compilationFailed(let details):
+                return "AppleScript compilation failed: \(details)"
+            case .executionFailed(let details):
+                return "AppleScript execution failed: \(details)"
+            case .fileNotFound(let path):
+                return "AppleScript file not found: \(path)"
+            }
+        }
+    }
+    
+    /// Parses AppleScript error dictionary into a readable error message
+    private static func parseAppleScriptError(_ errorInfo: NSDictionary) -> String {
+        var errorMessage = ""
+        
+        if let errorNumber = errorInfo[NSAppleScript.errorNumber] as? Int {
+            errorMessage += "Error \(errorNumber): "
+        }
+        
+        if let errorString = errorInfo[NSAppleScript.errorMessage] as? String {
+            errorMessage += errorString
+        }
+        
+        if let errorRange = errorInfo[NSAppleScript.errorRange] as? NSRange {
+            errorMessage += " at position \(errorRange.location)"
+        }
+        
+        return errorMessage.isEmpty ? "Unknown AppleScript error" : errorMessage
+    }
+}

--- a/Sources/SwiftAutoGUI/SwiftAutoGUI.swift
+++ b/Sources/SwiftAutoGUI/SwiftAutoGUI.swift
@@ -66,6 +66,11 @@ import AppKit
 /// - ``confirm(_:title:buttons:)``
 /// - ``prompt(_:title:defaultAnswer:button:)``
 /// - ``password(_:title:defaultAnswer:button:)``
+///
+/// ### AppleScript Execution
+/// - ``executeAppleScript(_:)``
+/// - ``executeAppleScriptFile(_:)``
+/// - ``AppleScriptError``
 public class SwiftAutoGUI {
     
     /// Represents mouse buttons that can be clicked.

--- a/Tests/SwiftAutoGUITests/AppleScriptTests.swift
+++ b/Tests/SwiftAutoGUITests/AppleScriptTests.swift
@@ -1,0 +1,59 @@
+import Testing
+import Foundation
+@testable import SwiftAutoGUI
+
+@Suite("AppleScript Tests")
+struct AppleScriptTests {
+    
+    @Test("Execute invalid AppleScript throws error")
+    func testInvalidAppleScript() {
+        // Invalid script
+        let script = "this is not valid AppleScript"
+        
+        #expect(throws: SwiftAutoGUI.AppleScriptError.self) {
+            _ = try SwiftAutoGUI.executeAppleScript(script)
+        }
+    }
+    
+    @Test("Execute AppleScript from file")
+    func testExecuteAppleScriptFile() throws {
+        // Create a temporary AppleScript file
+        let tempDir = FileManager.default.temporaryDirectory
+        let scriptPath = tempDir.appendingPathComponent("test_script.applescript").path
+        
+        let scriptContent = """
+        on run
+            return "Hello from file"
+        end run
+        """
+        
+        try scriptContent.write(toFile: scriptPath, atomically: true, encoding: .utf8)
+        defer {
+            try? FileManager.default.removeItem(atPath: scriptPath)
+        }
+        
+        let result = try SwiftAutoGUI.executeAppleScriptFile(scriptPath)
+        #expect(result == "Hello from file")
+    }
+    
+    @Test("Execute AppleScript from non-existent file throws error")
+    func testExecuteAppleScriptFileNotFound() {
+        let nonExistentPath = "/tmp/non_existent_script.applescript"
+        
+        #expect(throws: SwiftAutoGUI.AppleScriptError.self) {
+            _ = try SwiftAutoGUI.executeAppleScriptFile(nonExistentPath)
+        }
+    }
+    
+    @Test("AppleScriptError descriptions")
+    func testAppleScriptErrorDescriptions() {
+        let compilationError = SwiftAutoGUI.AppleScriptError.compilationFailed("Syntax error")
+        #expect(compilationError.errorDescription == "AppleScript compilation failed: Syntax error")
+        
+        let executionError = SwiftAutoGUI.AppleScriptError.executionFailed("Runtime error")
+        #expect(executionError.errorDescription == "AppleScript execution failed: Runtime error")
+        
+        let fileNotFoundError = SwiftAutoGUI.AppleScriptError.fileNotFound("/path/to/script")
+        #expect(fileNotFoundError.errorDescription == "AppleScript file not found: /path/to/script")
+    }
+}


### PR DESCRIPTION
## Summary
- Add AppleScript execution functionality to SwiftAutoGUI
- Implement `executeAppleScript()` and `executeAppleScriptFile()` methods using NSAppleScript
- Add comprehensive error handling with custom error types

## Changes
- **Core Implementation**: Add AppleScript.swift with execution methods and error handling
- **Tests**: Add comprehensive test suite for AppleScript functionality
- **Demo App**: Add AppleScript feature view with sample scripts
- **Documentation**: Update README and DocC documentation with usage examples and configuration requirements
- **Configuration**: Update entitlements to support AppleScript automation

## Configuration Requirements
To use AppleScript functionality, macOS apps need:
1. Disable App Sandbox: `com.apple.security.app-sandbox = false`
2. Enable Automation: `com.apple.security.automation.apple-events = true`
3. Add Info.plist description: `NSAppleEventsUsageDescription`

## Test Plan
- [x] Unit tests pass
- [x] Demo app successfully executes sample scripts
- [x] Documentation is clear and complete
- [x] Safari automation script works correctly

Closes #41

🤖 Generated with [Claude Code](https://claude.ai/code)