### PR TITLE
feat!: migrate to ScreenCaptureKit and Swift 6 concurrency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   build-and-test:
     name: Build and Test on macOS
-    runs-on: macos-15
+    runs-on: macos-26
     
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,9 +7,9 @@ on:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-26
     env:
-      DEVELOPER_DIR: /Applications/Xcode_15.4.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_26.0.app/Contents/Developer
     steps:
       - uses: actions/checkout@v4
       - name: build docc
@@ -37,7 +37,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: macos-14
+    runs-on: ubuntu-latest
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "SwiftAutoGUI",
     platforms: [
-        .macOS(.v13)
+        .macOS(.v26)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ This repository is inspired by [pyautogui](https://github.com/asweigart/pyautogu
 
 # Requirements
 
-- macOS 13.0+
-- Swift 5.7+
+- macOS 26.0+
+- Swift 6.0+
 
 # Installation
 
@@ -212,27 +212,35 @@ Task {
 ```
 
 ## Screenshot
-SwiftAutoGUI can take screenshots of the entire screen or specific regions, save them to files, and get pixel colors.
+SwiftAutoGUI can take screenshots of the entire screen or specific regions, save them to files, and get pixel colors. Screenshot operations are async and use ScreenCaptureKit for modern macOS compatibility.
 
 ```swift
 import SwiftAutoGUI
 
 // Take a screenshot of the entire screen
-if let screenshot = SwiftAutoGUI.screenshot() {
-    // Use the NSImage object
+Task {
+    if let screenshot = try await SwiftAutoGUI.screenshot() {
+        // Use the NSImage object
+    }
 }
 
 // Take a screenshot of a specific region
 let region = CGRect(x: 100, y: 100, width: 200, height: 200)
-if let regionScreenshot = SwiftAutoGUI.screenshot(region: region) {
-    // Use the NSImage object
+Task {
+    if let regionScreenshot = try await SwiftAutoGUI.screenshot(region: region) {
+        // Use the NSImage object
+    }
 }
 
 // Save a screenshot directly to a file
-SwiftAutoGUI.screenshot(imageFilename: "screenshot.png")
+Task {
+    try await SwiftAutoGUI.screenshot(imageFilename: "screenshot.png")
+}
 
 // Save a region screenshot to a file
-SwiftAutoGUI.screenshot(imageFilename: "region.jpg", region: region)
+Task {
+    try await SwiftAutoGUI.screenshot(imageFilename: "region.jpg", region: region)
+}
 
 // Get screen size
 let (width, height) = SwiftAutoGUI.size()
@@ -245,48 +253,53 @@ if let color = SwiftAutoGUI.pixel(x: 100, y: 200) {
 ```
 
 ## Image Recognition
-SwiftAutoGUI can locate images on the screen using OpenCV template matching, similar to PyAutoGUI.
+SwiftAutoGUI can locate images on the screen using OpenCV template matching, similar to PyAutoGUI. Image recognition operations are async and use ScreenCaptureKit for capturing screenshots.
 
 ```swift
 import SwiftAutoGUI
 
 // Locate an image on the screen
-if let location = SwiftAutoGUI.locateOnScreen("button.png") {
-    print("Found at: \(location)")
-    // location is a CGRect with the position and size
-    
-    // Click at the center of the found image
-    let center = CGPoint(x: location.midX, y: location.midY)
-    Task {
+Task {
+    if let location = try await SwiftAutoGUI.locateOnScreen("button.png") {
+        print("Found at: \(location)")
+        // location is a CGRect with the position and size
+
+        // Click at the center of the found image
+        let center = CGPoint(x: location.midX, y: location.midY)
         await SwiftAutoGUI.move(to: center, duration: 0)
         SwiftAutoGUI.leftClick()
     }
 }
 
 // Search with confidence threshold (0.0-1.0)
-if let location = SwiftAutoGUI.locateOnScreen("button.png", confidence: 0.9) {
-    // Found with 90% confidence
+Task {
+    if let location = try await SwiftAutoGUI.locateOnScreen("button.png", confidence: 0.9) {
+        // Found with 90% confidence
+    }
 }
 
 // Search in a specific region for better performance
-let searchRegion = CGRect(x: 0, y: 0, width: 500, height: 500)
-if let location = SwiftAutoGUI.locateOnScreen("button.png", region: searchRegion) {
-    // Found within the specified region
+Task {
+    let searchRegion = CGRect(x: 0, y: 0, width: 500, height: 500)
+    if let location = try await SwiftAutoGUI.locateOnScreen("button.png", region: searchRegion) {
+        // Found within the specified region
+    }
 }
 
 // Locate and get the center point directly
-if let buttonCenter = SwiftAutoGUI.locateCenterOnScreen("button.png") {
-    // buttonCenter is a CGPoint with x,y coordinates of the center
-    Task {
+Task {
+    if let buttonCenter = try await SwiftAutoGUI.locateCenterOnScreen("button.png") {
+        // buttonCenter is a CGPoint with x,y coordinates of the center
         await SwiftAutoGUI.move(to: buttonCenter, duration: 0)
         SwiftAutoGUI.leftClick()
     }
 }
 
 // locateCenterOnScreen also supports confidence and region parameters
-if let center = SwiftAutoGUI.locateCenterOnScreen("target.png", confidence: 0.8, region: searchRegion) {
-    // Click at the center of the found image
-    Task {
+Task {
+    let searchRegion = CGRect(x: 0, y: 0, width: 500, height: 500)
+    if let center = try await SwiftAutoGUI.locateCenterOnScreen("target.png", confidence: 0.8, region: searchRegion) {
+        // Click at the center of the found image
         await SwiftAutoGUI.move(to: center, duration: 0)
         SwiftAutoGUI.leftClick()
     }
@@ -294,7 +307,7 @@ if let center = SwiftAutoGUI.locateCenterOnScreen("target.png", confidence: 0.8,
 
 // Find all occurrences of an image on screen
 Task {
-    let buttons = SwiftAutoGUI.locateAllOnScreen("button.png")
+    let buttons = try await SwiftAutoGUI.locateAllOnScreen("button.png")
     print("Found \(buttons.count) buttons")
     for (index, button) in buttons.enumerated() {
         print("Button \(index): \(button)")
@@ -305,15 +318,19 @@ Task {
 }
 
 // locateAllOnScreen with confidence threshold for flexible matching
-let icons = SwiftAutoGUI.locateAllOnScreen("app_icon.png", confidence: 0.85)
-for icon in icons {
-    // Process each found icon
-    print("Found icon at: \(icon)")
+Task {
+    let icons = try await SwiftAutoGUI.locateAllOnScreen("app_icon.png", confidence: 0.85)
+    for icon in icons {
+        // Process each found icon
+        print("Found icon at: \(icon)")
+    }
 }
 
 // Search for multiple matches in a specific region
-let topRegion = CGRect(x: 0, y: 0, width: 1920, height: 100)
-let menuItems = SwiftAutoGUI.locateAllOnScreen("menu_item.png", region: topRegion)
+Task {
+    let topRegion = CGRect(x: 0, y: 0, width: 1920, height: 100)
+    let menuItems = try await SwiftAutoGUI.locateAllOnScreen("menu_item.png", region: topRegion)
+}
 ```
 
 

--- a/Sample/Sample.xcodeproj/project.pbxproj
+++ b/Sample/Sample.xcodeproj/project.pbxproj
@@ -308,11 +308,12 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.me.n.rei.Sample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
@@ -336,11 +337,12 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.me.n.rei.Sample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
 		};

--- a/Sample/Sample/Features/Actions/ActionsDemoViewModel.swift
+++ b/Sample/Sample/Features/Actions/ActionsDemoViewModel.swift
@@ -101,7 +101,7 @@ class ActionsDemoViewModel: ObservableObject {
         
         for (index, action) in selectedExample.actions.enumerated() {
             addToLog("[\(index + 1)] Executing: \(actionDescription(for: action))")
-            await action.execute()
+            _ = await action.execute()
         }
         
         addToLog("Execution completed!")

--- a/Sample/Sample/Features/ImageRecognition/ImageRecognitionViewModel.swift
+++ b/Sample/Sample/Features/ImageRecognition/ImageRecognitionViewModel.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import SwiftAutoGUI
 
+@MainActor
 class ImageRecognitionViewModel: ObservableObject {
     @Published var imageRecognitionResult: String = ""
     @Published var testImagePath: String = ""

--- a/Sample/Sample/Features/Keyboard/KeyboardDemoViewModel.swift
+++ b/Sample/Sample/Features/Keyboard/KeyboardDemoViewModel.swift
@@ -8,21 +8,22 @@
 import SwiftUI
 import SwiftAutoGUI
 
+@MainActor
 class KeyboardDemoViewModel: ObservableObject {
     
     func sendKeyShortcut() {
         Task {
-            await Action.keyShortcut([.control, .leftArrow]).execute()
+            _ = await Action.keyShortcut([.control, .leftArrow]).execute()
         }
     }
-    
+
     func sendSpecialKeyEvent() {
         Task {
             let actions: [Action] = [
                 .keyDown(.soundUp),
                 .keyUp(.soundUp)
             ]
-            await actions.execute()
+            _ = await actions.execute()
         }
     }
 }

--- a/Sample/Sample/Features/Mouse/MouseControlViewModel.swift
+++ b/Sample/Sample/Features/Mouse/MouseControlViewModel.swift
@@ -8,36 +8,37 @@
 import SwiftUI
 import SwiftAutoGUI
 
+@MainActor
 class MouseControlViewModel: ObservableObject {
     @Published var mousePosition: String = ""
     @Published var isAnimating: Bool = false
     
     func moveMouse() {
         Task {
-            await Action.moveMouse(dx: 10, dy: 10).execute()
+            _ = await Action.moveMouse(dx: 10, dy: 10).execute()
         }
     }
-    
+
     func getMousePosition() {
         let pos = SwiftAutoGUI.position()
         mousePosition = "Mouse at: x=\(Int(pos.x)), y=\(Int(pos.y))"
     }
-    
+
     func leftClick() {
         Task {
-            await Action.leftClick.execute()
+            _ = await Action.leftClick.execute()
         }
     }
-    
+
     func doubleClick() {
         Task {
-            await Action.doubleClick().execute()
+            _ = await Action.doubleClick().execute()
         }
     }
-    
+
     func tripleClick() {
         Task {
-            await Action.tripleClick().execute()
+            _ = await Action.tripleClick().execute()
         }
     }
     
@@ -47,41 +48,41 @@ class MouseControlViewModel: ObservableObject {
             await animateMovement {
                 let startPos = SwiftAutoGUI.position()
                 let targetPos = CGPoint(x: startPos.x + 200, y: startPos.y + 100)
-                await Action.moveSmooth(to: targetPos, duration: 2.0, tweening: .linear).execute()
+                _ = await Action.moveSmooth(to: targetPos, duration: 2.0, tweening: .linear).execute()
             }
         }
     }
-    
+
     func performEaseInOutMove() {
         Task {
             await animateMovement {
                 let startPos = SwiftAutoGUI.position()
                 let targetPos = CGPoint(x: startPos.x - 150, y: startPos.y + 150)
-                await Action.moveSmooth(to: targetPos, duration: 1.5, tweening: .easeInOutQuad).execute()
+                _ = await Action.moveSmooth(to: targetPos, duration: 1.5, tweening: .easeInOutQuad).execute()
             }
         }
     }
-    
+
     func performElasticMove() {
         Task {
             await animateMovement {
                 let startPos = SwiftAutoGUI.position()
                 let targetPos = CGPoint(x: startPos.x + 250, y: startPos.y - 100)
-                await Action.moveSmooth(to: targetPos, duration: 2.0, tweening: .easeOutElastic).execute()
+                _ = await Action.moveSmooth(to: targetPos, duration: 2.0, tweening: .easeOutElastic).execute()
             }
         }
     }
-    
+
     func performBounceMove() {
         Task {
             await animateMovement {
                 let startPos = SwiftAutoGUI.position()
                 let targetPos = CGPoint(x: startPos.x - 200, y: startPos.y - 150)
-                await Action.moveSmooth(to: targetPos, duration: 2.0, tweening: .easeOutBounce).execute()
+                _ = await Action.moveSmooth(to: targetPos, duration: 2.0, tweening: .easeOutBounce).execute()
             }
         }
     }
-    
+
     func performCirclePattern() {
         Task {
             await animateMovement {
@@ -90,50 +91,48 @@ class MouseControlViewModel: ObservableObject {
                 let steps = 60
                 let duration = 3.0
                 let stepDuration = duration / Double(steps)
-                
+
                 var actions: [Action] = []
                 for i in 0...steps {
                     let angle = (Double(i) / Double(steps)) * 2 * Double.pi
                     let x = center.x + radius * cos(angle)
                     let y = center.y + radius * sin(angle)
-                    
+
                     actions.append(.moveSmooth(to: CGPoint(x: x, y: y), duration: stepDuration, tweening: .easeInOutSine))
                 }
-                await actions.execute()
+                _ = await actions.execute()
             }
         }
     }
-    
+
     func performLowFPSMove() {
         Task {
             await animateMovement {
                 let startPos = SwiftAutoGUI.position()
                 let targetPos = CGPoint(x: startPos.x + 300, y: startPos.y)
                 // 24 FPS creates visible stepping effect
-                await Action.moveSmooth(to: targetPos, duration: 2.0, tweening: .linear, fps: 24).execute()
+                _ = await Action.moveSmooth(to: targetPos, duration: 2.0, tweening: .linear, fps: 24).execute()
             }
         }
     }
-    
+
     func performHighFPSMove() {
         Task {
             await animateMovement {
                 let startPos = SwiftAutoGUI.position()
                 let targetPos = CGPoint(x: startPos.x - 300, y: startPos.y)
                 // 120 FPS creates ultra-smooth movement
-                await Action.moveSmooth(to: targetPos, duration: 2.0, tweening: .linear, fps: 120).execute()
+                _ = await Action.moveSmooth(to: targetPos, duration: 2.0, tweening: .linear, fps: 120).execute()
             }
         }
     }
     
     @MainActor
-    private func animateMovement(animation: @escaping () async -> Void) async {
+    private func animateMovement(animation: @escaping @MainActor () async -> Void) async {
         isAnimating = true
-        
-        await Task.detached {
-            await animation()
-        }.value
-        
+
+        await animation()
+
         isAnimating = false
         getMousePosition()
     }

--- a/Sample/Sample/Features/PixelDetection/PixelDetectionViewModel.swift
+++ b/Sample/Sample/Features/PixelDetection/PixelDetectionViewModel.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import SwiftAutoGUI
 
+@MainActor
 class PixelDetectionViewModel: ObservableObject {
     @Published var pixelColor: NSColor?
     @Published var screenSize: String = ""

--- a/Sample/Sample/Features/Screenshot/ScreenshotViewModel.swift
+++ b/Sample/Sample/Features/Screenshot/ScreenshotViewModel.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import SwiftAutoGUI
 
+@MainActor
 class ScreenshotViewModel: ObservableObject {
     @Published var screenshotImage: NSImage?
     

--- a/Sample/Sample/Features/Scrolling/ScrollingDemoView.swift
+++ b/Sample/Sample/Features/Scrolling/ScrollingDemoView.swift
@@ -9,324 +9,334 @@ import SwiftUI
 
 struct ScrollingDemoView: View {
     @StateObject private var viewModel = ScrollingDemoViewModel()
-    
+
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
-            // Header
-            VStack(alignment: .leading, spacing: 8) {
-                Text("Scrolling Demo")
-                    .font(.largeTitle)
-                    .fontWeight(.bold)
-                
-                Text("Click the buttons inside the scrollable areas to test scrolling")
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
-            }
-            
-            // Vertical Scrolling Demo
-            VStack(alignment: .leading, spacing: 12) {
-                Label("Vertical Scrolling", systemImage: "arrow.up.arrow.down")
-                    .font(.headline)
-                
-                // Large scrollable area with visible content
-                ScrollView {
-                    VStack(spacing: 20) {
-                        // Top section
-                        ForEach(0..<10) { index in
-                            HStack {
-                                Text("Row \(index)")
-                                    .font(.title2)
-                                    .fontWeight(.medium)
-                                
-                                Spacer()
-                                
-                                RoundedRectangle(cornerRadius: 8)
-                                    .fill(Color.blue.opacity(0.3))
-                                    .frame(width: 60, height: 30)
-                                    .overlay(
-                                        Text("\(index)")
-                                            .foregroundColor(.blue)
-                                    )
-                            }
-                            .padding(.horizontal, 20)
-                            .padding(.vertical, 15)
-                            .background(
-                                index % 2 == 0 ? Color.gray.opacity(0.1) : Color.clear
-                            )
-                        }
-                        
-                        // Control buttons in the middle
-                        VStack(spacing: 20) {
-                            Text("⬇️ Scroll Control Center ⬇️")
-                                .font(.headline)
-                                .padding()
-                                .frame(maxWidth: .infinity)
-                                .background(Color.yellow.opacity(0.2))
-                                .cornerRadius(12)
-                            
-                            // Instant scroll buttons
-                            VStack(spacing: 8) {
-                                Text("Instant Scroll (5 clicks)")
-                                    .font(.caption)
-                                    .fontWeight(.semibold)
-                                
-                                HStack(spacing: 12) {
-                                    Button(action: { viewModel.verticalScrollUp() }) {
-                                        Label("Instant Up", systemImage: "arrow.up")
-                                            .frame(width: 120)
-                                    }
-                                    .buttonStyle(.borderedProminent)
-                                    
-                                    Button(action: { viewModel.verticalScrollDown() }) {
-                                        Label("Instant Down", systemImage: "arrow.down")
-                                            .frame(width: 120)
-                                    }
-                                    .buttonStyle(.borderedProminent)
-                                }
-                            }
-                            .padding()
-                            .background(Color.blue.opacity(0.1))
-                            .cornerRadius(12)
-                            
-                            // Smooth scroll buttons
-                            VStack(spacing: 12) {
-                                Text("Smooth Animated Scroll")
-                                    .font(.caption)
-                                    .fontWeight(.semibold)
-                                
-                                HStack(spacing: 12) {
-                                    Button(action: { viewModel.smoothVerticalScrollUp() }) {
-                                        VStack(spacing: 4) {
-                                            Image(systemName: "arrow.up.circle.fill")
-                                                .font(.title2)
-                                            Text("Smooth Up")
-                                            Text("(3s)")
-                                                .font(.caption2)
-                                                .foregroundColor(.secondary)
-                                        }
-                                        .frame(width: 100)
-                                    }
-                                    .buttonStyle(.bordered)
-                                    .controlSize(.large)
-                                    
-                                    Button(action: { viewModel.smoothVerticalScrollDown() }) {
-                                        VStack(spacing: 4) {
-                                            Image(systemName: "arrow.down.circle.fill")
-                                                .font(.title2)
-                                            Text("Smooth Down")
-                                            Text("(3s)")
-                                                .font(.caption2)
-                                                .foregroundColor(.secondary)
-                                        }
-                                        .frame(width: 100)
-                                    }
-                                    .buttonStyle(.bordered)
-                                    .controlSize(.large)
-                                }
-                                
-                                // Special effects
-                                Text("Special Effects")
-                                    .font(.caption)
-                                    .fontWeight(.semibold)
-                                    .padding(.top, 8)
-                                
-                                HStack(spacing: 8) {
-                                    Button(action: { viewModel.smoothScrollWithBounce() }) {
-                                        VStack(spacing: 2) {
-                                            Image(systemName: "arrowshape.bounce.down")
-                                            Text("Bounce")
-                                                .font(.caption)
-                                        }
-                                        .frame(width: 80)
-                                    }
-                                    .buttonStyle(.bordered)
-                                    .tint(.purple)
-                                    
-                                    Button(action: { viewModel.smoothScrollWithElastic() }) {
-                                        VStack(spacing: 2) {
-                                            Image(systemName: "arrowshape.zigzag.forward")
-                                            Text("Elastic")
-                                                .font(.caption)
-                                        }
-                                        .frame(width: 80)
-                                    }
-                                    .buttonStyle(.bordered)
-                                    .tint(.orange)
-                                    
-                                    Button(action: { viewModel.smoothScrollCustomEasing() }) {
-                                        VStack(spacing: 2) {
-                                            Image(systemName: "waveform.path")
-                                            Text("Smooth")
-                                                .font(.caption)
-                                        }
-                                        .frame(width: 80)
-                                    }
-                                    .buttonStyle(.bordered)
-                                    .tint(.green)
-                                }
-                            }
-                            .padding()
-                            .background(Color.green.opacity(0.1))
-                            .cornerRadius(12)
-                        }
-                        .padding(.vertical, 40)
-                        
-                        // Bottom section
-                        ForEach(10..<30) { index in
-                            HStack {
-                                Text("Row \(index)")
-                                    .font(.title2)
-                                    .fontWeight(.medium)
-                                
-                                Spacer()
-                                
-                                RoundedRectangle(cornerRadius: 8)
-                                    .fill(Color.blue.opacity(0.3))
-                                    .frame(width: 60, height: 30)
-                                    .overlay(
-                                        Text("\(index)")
-                                            .foregroundColor(.blue)
-                                    )
-                            }
-                            .padding(.horizontal, 20)
-                            .padding(.vertical, 15)
-                            .background(
-                                index % 2 == 0 ? Color.gray.opacity(0.1) : Color.clear
-                            )
-                        }
-                    }
-                }
-                .frame(height: 400)
-                .background(Color.gray.opacity(0.05))
-                .cornerRadius(12)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12)
-                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                )
-            }
-            
+            headerSection
+            verticalScrollingSection
             Divider()
-            
-            // Horizontal Scrolling Demo
-            VStack(alignment: .leading, spacing: 12) {
-                Label("Horizontal Scrolling", systemImage: "arrow.left.arrow.right")
-                    .font(.headline)
-                
-                ScrollView(.horizontal) {
-                    HStack(spacing: 20) {
-                        // Left content
-                        ForEach(0..<10) { index in
-                            VStack {
-                                RoundedRectangle(cornerRadius: 12)
-                                    .fill(Color.indigo.opacity(0.3))
-                                    .frame(width: 120, height: 80)
-                                    .overlay(
-                                        VStack {
-                                            Image(systemName: "square.grid.2x2")
-                                                .font(.title)
-                                            Text("Item \(index)")
-                                                .font(.caption)
-                                        }
-                                        .foregroundColor(.indigo)
-                                    )
-                                
-                                Text("Column \(index)")
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                            }
-                        }
-                        
-                        // Control buttons in the middle
-                        VStack(spacing: 16) {
-                            Text("↔️ Horizontal Controls ↔️")
-                                .font(.caption)
-                                .fontWeight(.bold)
-                                .padding(.horizontal)
-                                .padding(.vertical, 8)
-                                .background(Color.orange.opacity(0.2))
-                                .cornerRadius(8)
-                            
-                            // Instant
-                            VStack(spacing: 8) {
-                                Text("Instant")
-                                    .font(.caption2)
-                                    .fontWeight(.semibold)
-                                
-                                HStack(spacing: 8) {
-                                    Button(action: { viewModel.horizontalScrollLeft() }) {
-                                        Label("Left", systemImage: "arrow.left")
-                                    }
-                                    .buttonStyle(.borderedProminent)
-                                    .controlSize(.small)
-                                    
-                                    Button(action: { viewModel.horizontalScrollRight() }) {
-                                        Label("Right", systemImage: "arrow.right")
-                                    }
-                                    .buttonStyle(.borderedProminent)
-                                    .controlSize(.small)
-                                }
-                            }
-                            
-                            // Smooth
-                            VStack(spacing: 8) {
-                                Text("Smooth (2.5s)")
-                                    .font(.caption2)
-                                    .fontWeight(.semibold)
-                                
-                                VStack(spacing: 8) {
-                                    Button(action: { viewModel.smoothHorizontalScrollLeft() }) {
-                                        Label("Smooth Left", systemImage: "arrow.left.circle")
-                                    }
-                                    .buttonStyle(.bordered)
-                                    .controlSize(.small)
-                                    
-                                    Button(action: { viewModel.smoothHorizontalScrollRight() }) {
-                                        Label("Smooth Right", systemImage: "arrow.right.circle")
-                                    }
-                                    .buttonStyle(.bordered)
-                                    .controlSize(.small)
-                                }
-                            }
-                        }
-                        .padding()
-                        .background(Color.indigo.opacity(0.1))
-                        .cornerRadius(12)
-                        
-                        // Right content
-                        ForEach(10..<20) { index in
-                            VStack {
-                                RoundedRectangle(cornerRadius: 12)
-                                    .fill(Color.indigo.opacity(0.3))
-                                    .frame(width: 120, height: 80)
-                                    .overlay(
-                                        VStack {
-                                            Image(systemName: "square.grid.2x2")
-                                                .font(.title)
-                                            Text("Item \(index)")
-                                                .font(.caption)
-                                        }
-                                        .foregroundColor(.indigo)
-                                    )
-                                
-                                Text("Column \(index)")
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                            }
-                        }
-                    }
-                    .padding()
-                }
-                .frame(height: 180)
-                .background(Color.gray.opacity(0.05))
-                .cornerRadius(12)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12)
-                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                )
-            }
-            
+            horizontalScrollingSection
             Spacer()
         }
         .padding()
+    }
+
+    private var headerSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Scrolling Demo")
+                .font(.largeTitle)
+                .fontWeight(.bold)
+
+            Text("Click the buttons inside the scrollable areas to test scrolling")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    private var verticalScrollingSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("Vertical Scrolling", systemImage: "arrow.up.arrow.down")
+                .font(.headline)
+
+            ScrollView {
+                VStack(spacing: 20) {
+                    verticalScrollTopRows
+                    verticalScrollControlCenter
+                    verticalScrollBottomRows
+                }
+            }
+            .frame(height: 400)
+            .background(Color.gray.opacity(0.05))
+            .cornerRadius(12)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+            )
+        }
+    }
+
+    private var verticalScrollTopRows: some View {
+        ForEach(0..<10) { index in
+            scrollRowView(index: index)
+        }
+    }
+
+    private var verticalScrollBottomRows: some View {
+        ForEach(10..<30) { index in
+            scrollRowView(index: index)
+        }
+    }
+
+    private func scrollRowView(index: Int) -> some View {
+        HStack {
+            Text("Row \(index)")
+                .font(.title2)
+                .fontWeight(.medium)
+
+            Spacer()
+
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.blue.opacity(0.3))
+                .frame(width: 60, height: 30)
+                .overlay(
+                    Text("\(index)")
+                        .foregroundColor(.blue)
+                )
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 15)
+        .background(
+            index % 2 == 0 ? Color.gray.opacity(0.1) : Color.clear
+        )
+    }
+
+    private var verticalScrollControlCenter: some View {
+        VStack(spacing: 20) {
+            Text("⬇️ Scroll Control Center ⬇️")
+                .font(.headline)
+                .padding()
+                .frame(maxWidth: .infinity)
+                .background(Color.yellow.opacity(0.2))
+                .cornerRadius(12)
+
+            instantScrollButtons
+            smoothScrollButtons
+        }
+        .padding(.vertical, 40)
+    }
+
+    private var instantScrollButtons: some View {
+        VStack(spacing: 8) {
+            Text("Instant Scroll (5 clicks)")
+                .font(.caption)
+                .fontWeight(.semibold)
+
+            HStack(spacing: 12) {
+                Button(action: { viewModel.verticalScrollUp() }) {
+                    Label("Instant Up", systemImage: "arrow.up")
+                        .frame(width: 120)
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button(action: { viewModel.verticalScrollDown() }) {
+                    Label("Instant Down", systemImage: "arrow.down")
+                        .frame(width: 120)
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding()
+        .background(Color.blue.opacity(0.1))
+        .cornerRadius(12)
+    }
+
+    private var smoothScrollButtons: some View {
+        VStack(spacing: 12) {
+            Text("Smooth Animated Scroll")
+                .font(.caption)
+                .fontWeight(.semibold)
+
+            HStack(spacing: 12) {
+                smoothUpButton
+                smoothDownButton
+            }
+
+            Text("Special Effects")
+                .font(.caption)
+                .fontWeight(.semibold)
+                .padding(.top, 8)
+
+            specialEffectsButtons
+        }
+        .padding()
+        .background(Color.green.opacity(0.1))
+        .cornerRadius(12)
+    }
+
+    private var smoothUpButton: some View {
+        Button(action: { viewModel.smoothVerticalScrollUp() }) {
+            VStack(spacing: 4) {
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.title2)
+                Text("Smooth Up")
+                Text("(3s)")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+            .frame(width: 100)
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.large)
+    }
+
+    private var smoothDownButton: some View {
+        Button(action: { viewModel.smoothVerticalScrollDown() }) {
+            VStack(spacing: 4) {
+                Image(systemName: "arrow.down.circle.fill")
+                    .font(.title2)
+                Text("Smooth Down")
+                Text("(3s)")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+            .frame(width: 100)
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.large)
+    }
+
+    private var specialEffectsButtons: some View {
+        HStack(spacing: 8) {
+            Button(action: { viewModel.smoothScrollWithBounce() }) {
+                VStack(spacing: 2) {
+                    Image(systemName: "arrowshape.bounce.down")
+                    Text("Bounce")
+                        .font(.caption)
+                }
+                .frame(width: 80)
+            }
+            .buttonStyle(.bordered)
+            .tint(.purple)
+
+            Button(action: { viewModel.smoothScrollWithElastic() }) {
+                VStack(spacing: 2) {
+                    Image(systemName: "arrowshape.zigzag.forward")
+                    Text("Elastic")
+                        .font(.caption)
+                }
+                .frame(width: 80)
+            }
+            .buttonStyle(.bordered)
+            .tint(.orange)
+
+            Button(action: { viewModel.smoothScrollCustomEasing() }) {
+                VStack(spacing: 2) {
+                    Image(systemName: "waveform.path")
+                    Text("Smooth")
+                        .font(.caption)
+                }
+                .frame(width: 80)
+            }
+            .buttonStyle(.bordered)
+            .tint(.green)
+        }
+    }
+
+    private var horizontalScrollingSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("Horizontal Scrolling", systemImage: "arrow.left.arrow.right")
+                .font(.headline)
+
+            ScrollView(.horizontal) {
+                HStack(spacing: 20) {
+                    horizontalLeftContent
+                    horizontalControlButtons
+                    horizontalRightContent
+                }
+                .padding()
+            }
+            .frame(height: 180)
+            .background(Color.gray.opacity(0.05))
+            .cornerRadius(12)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+            )
+        }
+    }
+
+    private var horizontalLeftContent: some View {
+        ForEach(0..<10) { index in
+            horizontalItemView(index: index)
+        }
+    }
+
+    private var horizontalRightContent: some View {
+        ForEach(10..<20) { index in
+            horizontalItemView(index: index)
+        }
+    }
+
+    private func horizontalItemView(index: Int) -> some View {
+        VStack {
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color.indigo.opacity(0.3))
+                .frame(width: 120, height: 80)
+                .overlay(
+                    VStack {
+                        Image(systemName: "square.grid.2x2")
+                            .font(.title)
+                        Text("Item \(index)")
+                            .font(.caption)
+                    }
+                    .foregroundColor(.indigo)
+                )
+
+            Text("Column \(index)")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    private var horizontalControlButtons: some View {
+        VStack(spacing: 16) {
+            Text("↔️ Horizontal Controls ↔️")
+                .font(.caption)
+                .fontWeight(.bold)
+                .padding(.horizontal)
+                .padding(.vertical, 8)
+                .background(Color.orange.opacity(0.2))
+                .cornerRadius(8)
+
+            horizontalInstantButtons
+            horizontalSmoothButtons
+        }
+        .padding()
+        .background(Color.indigo.opacity(0.1))
+        .cornerRadius(12)
+    }
+
+    private var horizontalInstantButtons: some View {
+        VStack(spacing: 8) {
+            Text("Instant")
+                .font(.caption2)
+                .fontWeight(.semibold)
+
+            HStack(spacing: 8) {
+                Button(action: { viewModel.horizontalScrollLeft() }) {
+                    Label("Left", systemImage: "arrow.left")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+
+                Button(action: { viewModel.horizontalScrollRight() }) {
+                    Label("Right", systemImage: "arrow.right")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+        }
+    }
+
+    private var horizontalSmoothButtons: some View {
+        VStack(spacing: 8) {
+            Text("Smooth (2.5s)")
+                .font(.caption2)
+                .fontWeight(.semibold)
+
+            VStack(spacing: 8) {
+                Button(action: { viewModel.smoothHorizontalScrollLeft() }) {
+                    Label("Smooth Left", systemImage: "arrow.left.circle")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
+                Button(action: { viewModel.smoothHorizontalScrollRight() }) {
+                    Label("Smooth Right", systemImage: "arrow.right.circle")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+        }
     }
 }

--- a/Sample/Sample/Features/Scrolling/ScrollingDemoViewModel.swift
+++ b/Sample/Sample/Features/Scrolling/ScrollingDemoViewModel.swift
@@ -8,72 +8,73 @@
 import SwiftUI
 import SwiftAutoGUI
 
+@MainActor
 class ScrollingDemoViewModel: ObservableObject {
     
     func verticalScrollDown() {
         Task {
-            await Action.vscroll(clicks: -5).execute()
+            _ = await Action.vscroll(clicks: -5).execute()
         }
     }
-    
+
     func verticalScrollUp() {
         Task {
-            await Action.vscroll(clicks: 5).execute()
+            _ = await Action.vscroll(clicks: 5).execute()
         }
     }
-    
+
     func horizontalScrollLeft() {
         Task {
-            await Action.hscroll(clicks: 5).execute()
+            _ = await Action.hscroll(clicks: 5).execute()
         }
     }
-    
+
     func horizontalScrollRight() {
         Task {
-            await Action.hscroll(clicks: -5).execute()
+            _ = await Action.hscroll(clicks: -5).execute()
         }
     }
-    
+
     // Smooth scrolling methods
     func smoothVerticalScrollDown() {
         Task {
-            await Action.smoothVScroll(clicks: -150, duration: 3.0, tweening: .easeInOutQuad).execute()
+            _ = await Action.smoothVScroll(clicks: -150, duration: 3.0, tweening: .easeInOutQuad).execute()
         }
     }
-    
+
     func smoothVerticalScrollUp() {
         Task {
-            await Action.smoothVScroll(clicks: 150, duration: 3.0, tweening: .easeInOutQuad).execute()
+            _ = await Action.smoothVScroll(clicks: 150, duration: 3.0, tweening: .easeInOutQuad).execute()
         }
     }
-    
+
     func smoothHorizontalScrollLeft() {
         Task {
-            await Action.smoothHScroll(clicks: 100, duration: 2.5, tweening: .easeInOutQuad).execute()
+            _ = await Action.smoothHScroll(clicks: 100, duration: 2.5, tweening: .easeInOutQuad).execute()
         }
     }
-    
+
     func smoothHorizontalScrollRight() {
         Task {
-            await Action.smoothHScroll(clicks: -100, duration: 2.5, tweening: .easeInOutQuad).execute()
+            _ = await Action.smoothHScroll(clicks: -100, duration: 2.5, tweening: .easeInOutQuad).execute()
         }
     }
-    
+
     func smoothScrollWithBounce() {
         Task {
-            await Action.smoothVScroll(clicks: -200, duration: 4.0, tweening: .easeOutBounce).execute()
+            _ = await Action.smoothVScroll(clicks: -200, duration: 4.0, tweening: .easeOutBounce).execute()
         }
     }
-    
+
     func smoothScrollWithElastic() {
         Task {
-            await Action.smoothVScroll(clicks: 180, duration: 3.5, tweening: .easeOutElastic).execute()
+            _ = await Action.smoothVScroll(clicks: 180, duration: 3.5, tweening: .easeOutElastic).execute()
         }
     }
-    
+
     func smoothScrollCustomEasing() {
         Task {
-            await Action.smoothVScroll(clicks: -120, duration: 3.0, tweening: .custom({ t in
+            _ = await Action.smoothVScroll(clicks: -120, duration: 3.0, tweening: .custom({ t in
                 return t * t * (3 - 2 * t) // Smooth step
             })).execute()
         }

--- a/Sample/Sample/Features/TextTyping/TextTypingViewModel.swift
+++ b/Sample/Sample/Features/TextTyping/TextTypingViewModel.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import SwiftAutoGUI
 
+@MainActor
 class TextTypingViewModel: ObservableObject {
     @Published var textToType: String = ""
     @Published var typingSpeed: Double = 0.0

--- a/Sample/Sample/SwiftAutoGUITestPlan.xctestplan
+++ b/Sample/Sample/SwiftAutoGUITestPlan.xctestplan
@@ -13,6 +13,7 @@
   },
   "testTargets" : [
     {
+      "parallelizable" : false,
       "target" : {
         "containerPath" : "container:..",
         "identifier" : "SwiftAutoGUITests",

--- a/Sources/SwiftAutoGUI/Action.swift
+++ b/Sources/SwiftAutoGUI/Action.swift
@@ -318,28 +318,28 @@ public enum Action {
             return nil
             
         case .screenshot:
-            return SwiftAutoGUI.screenshot()
-            
+            return try? await SwiftAutoGUI.screenshot()
+
         case .screenshotRegion(let region):
-            return SwiftAutoGUI.screenshot(region: region)
-            
+            return try? await SwiftAutoGUI.screenshot(region: region)
+
         case .screenshotToFile(let filename, let region):
-            return SwiftAutoGUI.screenshot(imageFilename: filename, region: region)
-            
+            return try? await SwiftAutoGUI.screenshot(imageFilename: filename, region: region)
+
         case .getScreenSize:
             return SwiftAutoGUI.size()
-            
+
         case .getPixel(let x, let y):
-            return SwiftAutoGUI.pixel(x: x, y: y)
+            return try? await SwiftAutoGUI.pixel(x: x, y: y)
             
         case .locateOnScreen(let image, let grayscale, let confidence, let region):
-            return SwiftAutoGUI.locateOnScreen(image, grayscale: grayscale, confidence: confidence, region: region)
-            
+            return try? await SwiftAutoGUI.locateOnScreen(image, grayscale: grayscale, confidence: confidence, region: region)
+
         case .locateCenterOnScreen(let image, let grayscale, let confidence, let region):
-            return SwiftAutoGUI.locateCenterOnScreen(image, grayscale: grayscale, confidence: confidence, region: region)
-            
+            return try? await SwiftAutoGUI.locateCenterOnScreen(image, grayscale: grayscale, confidence: confidence, region: region)
+
         case .locateAllOnScreen(let image, let grayscale, let confidence, let region):
-            return SwiftAutoGUI.locateAllOnScreen(image, grayscale: grayscale, confidence: confidence, region: region)
+            return try? await SwiftAutoGUI.locateAllOnScreen(image, grayscale: grayscale, confidence: confidence, region: region)
             
         case .alert(let text, let title, let button):
             return SwiftAutoGUI.alert(text, title: title, button: button)

--- a/Sources/SwiftAutoGUI/ImageRecognition.swift
+++ b/Sources/SwiftAutoGUI/ImageRecognition.swift
@@ -47,26 +47,26 @@ extension SwiftAutoGUI {
         grayscale: Bool = false,
         confidence: Double? = nil,
         region: CGRect? = nil
-    ) -> CGRect? {
+    ) async throws -> CGRect? {
         // Load the needle image
         guard let needleImage = NSImage(contentsOfFile: imagePath) else {
             print("SwiftAutoGUI: Could not load image from path: \(imagePath)")
             return nil
         }
-        
+
         // Take screenshot of the region or entire screen
         let screenshot: NSImage?
         if let region = region {
-            screenshot = self.screenshot(region: region)
+            screenshot = try await self.screenshot(region: region)
         } else {
-            screenshot = self.screenshot()
+            screenshot = try await self.screenshot()
         }
-        
+
         guard let haystackImage = screenshot else {
             print("SwiftAutoGUI: Could not capture screenshot")
             return nil
         }
-        
+
         // Perform image matching
         return findImageInImage(needle: needleImage, haystack: haystackImage, confidence: confidence, searchRegion: region)
     }
@@ -110,12 +110,12 @@ extension SwiftAutoGUI {
         grayscale: Bool = false,
         confidence: Double? = nil,
         region: CGRect? = nil
-    ) -> CGPoint? {
+    ) async throws -> CGPoint? {
         // Use locateOnScreen to find the image
-        guard let rect = locateOnScreen(imagePath, grayscale: grayscale, confidence: confidence, region: region) else {
+        guard let rect = try await locateOnScreen(imagePath, grayscale: grayscale, confidence: confidence, region: region) else {
             return nil
         }
-        
+
         // Return the center point of the found rectangle
         return CGPoint(x: rect.midX, y: rect.midY)
     }
@@ -156,26 +156,26 @@ extension SwiftAutoGUI {
         grayscale: Bool = false,
         confidence: Double? = nil,
         region: CGRect? = nil
-    ) -> [CGRect] {
+    ) async throws -> [CGRect] {
         // Load the needle image
         guard let needleImage = NSImage(contentsOfFile: imagePath) else {
             print("SwiftAutoGUI: Could not load image from path: \(imagePath)")
             return []
         }
-        
+
         // Take screenshot of the region or entire screen
         let screenshot: NSImage?
         if let region = region {
-            screenshot = self.screenshot(region: region)
+            screenshot = try await self.screenshot(region: region)
         } else {
-            screenshot = self.screenshot()
+            screenshot = try await self.screenshot()
         }
-        
+
         guard let haystackImage = screenshot else {
             print("SwiftAutoGUI: Could not capture screenshot")
             return []
         }
-        
+
         // Perform image matching to find all instances
         return findAllImagesInImage(needle: needleImage, haystack: haystackImage, confidence: confidence, searchRegion: region)
     }

--- a/Sources/SwiftAutoGUI/ImageRecognition.swift
+++ b/Sources/SwiftAutoGUI/ImageRecognition.swift
@@ -243,22 +243,21 @@ extension SwiftAutoGUI {
             
             // Convert OpenCV coordinates to CGRect
             // OpenCV works with actual pixels, we need to convert to points for macOS
-            let pixelRect = CGRect(
-                x: CGFloat(maxLoc.x) + regionOffset.x,
-                y: CGFloat(maxLoc.y) + regionOffset.y,
-                width: CGFloat(needleMat.cols()),
-                height: CGFloat(needleMat.rows())
-            )
-            
-            // Convert from pixels to points (logical coordinates)
+            // First convert OpenCV pixel coordinates to points
+            let pointX = CGFloat(maxLoc.x) / scaleFactor
+            let pointY = CGFloat(maxLoc.y) / scaleFactor
+            let pointWidth = CGFloat(needleMat.cols()) / scaleFactor
+            let pointHeight = CGFloat(needleMat.rows()) / scaleFactor
+
+            // Then add region offset (which is already in points)
             let pointRect = CGRect(
-                x: pixelRect.origin.x / scaleFactor,
-                y: pixelRect.origin.y / scaleFactor,
-                width: pixelRect.width / scaleFactor,
-                height: pixelRect.height / scaleFactor
+                x: pointX + regionOffset.x,
+                y: pointY + regionOffset.y,
+                width: pointWidth,
+                height: pointHeight
             )
             
-            print("SwiftAutoGUI: OpenCV found image at pixels: \(pixelRect), points: \(pointRect)")
+            print("SwiftAutoGUI: OpenCV found image at points: \(pointRect)")
             return pointRect
         }
         
@@ -345,19 +344,18 @@ extension SwiftAutoGUI {
             let x = maxIdx % Int(result.cols())
             
             // Convert OpenCV coordinates to CGRect
-            let pixelRect = CGRect(
-                x: CGFloat(x) + regionOffset.x,
-                y: CGFloat(y) + regionOffset.y,
-                width: CGFloat(templateWidth),
-                height: CGFloat(templateHeight)
-            )
-            
-            // Convert from pixels to points (logical coordinates)
+            // First convert OpenCV pixel coordinates to points
+            let pointX = CGFloat(x) / scaleFactor
+            let pointY = CGFloat(y) / scaleFactor
+            let pointWidth = CGFloat(templateWidth) / scaleFactor
+            let pointHeight = CGFloat(templateHeight) / scaleFactor
+
+            // Then add region offset (which is already in points)
             let pointRect = CGRect(
-                x: pixelRect.origin.x / scaleFactor,
-                y: pixelRect.origin.y / scaleFactor,
-                width: pixelRect.width / scaleFactor,
-                height: pixelRect.height / scaleFactor
+                x: pointX + regionOffset.x,
+                y: pointY + regionOffset.y,
+                width: pointWidth,
+                height: pointHeight
             )
             
             matches.append(pointRect)

--- a/Sources/SwiftAutoGUI/Keycode.swift
+++ b/Sources/SwiftAutoGUI/Keycode.swift
@@ -12,7 +12,7 @@ import CoreGraphics
 /// SwiftAutoGUI.keyDown(.soundUp)
 /// SwiftAutoGUI.keyUp(.soundUp)
 /// ```
-public enum Key: String {
+public enum Key: String, Sendable {
 
     // normal keycode
     case returnKey

--- a/Sources/SwiftAutoGUI/Screenshot.swift
+++ b/Sources/SwiftAutoGUI/Screenshot.swift
@@ -36,8 +36,9 @@ extension SwiftAutoGUI {
 
         // Create configuration
         let config = SCStreamConfiguration()
-        config.width = display.width
-        config.height = display.height
+        // display.width and display.height are in logical points, convert to pixels
+        config.width = Int(CGFloat(display.width) * screen.backingScaleFactor)
+        config.height = Int(CGFloat(display.height) * screen.backingScaleFactor)
         config.scalesToFit = false
         config.showsCursor = false
 

--- a/Sources/SwiftAutoGUI/SwiftAutoGUI.swift
+++ b/Sources/SwiftAutoGUI/SwiftAutoGUI.swift
@@ -76,7 +76,7 @@ import AppKit
 public class SwiftAutoGUI {
     
     /// Represents mouse buttons that can be clicked.
-    public enum MouseButton {
+    public enum MouseButton: Sendable {
         case left
         case right
         

--- a/Sources/SwiftAutoGUI/TweeningFunction.swift
+++ b/Sources/SwiftAutoGUI/TweeningFunction.swift
@@ -4,7 +4,7 @@ import Foundation
 ///
 /// These functions create natural-looking transitions by varying the speed of movement over time.
 /// Each function takes a progress value (0.0 to 1.0) and returns a modified progress value.
-public enum TweeningFunction {
+public enum TweeningFunction: Sendable {
     // Quad functions (t^2)
     case linear
     case easeInQuad
@@ -57,7 +57,7 @@ public enum TweeningFunction {
     case easeInOutBounce
     
     /// Custom tweening function
-    case custom((Double) -> Double)
+    case custom(@Sendable (Double) -> Double)
     
     /// Applies the easing function to a progress value.
     ///

--- a/Tests/SwiftAutoGUITests/ImageRecognitionTests.swift
+++ b/Tests/SwiftAutoGUITests/ImageRecognitionTests.swift
@@ -5,225 +5,225 @@ import CoreGraphics
 
 @Suite("Image Recognition Tests")
 struct ImageRecognitionTests {
-    
+
     @Test("locateOnScreen with valid image path")
-    func testLocateOnScreenValidPath() {
+    func testLocateOnScreenValidPath() async throws {
         // Create a test image
         let testImagePath = createTestImage()
         defer { try? FileManager.default.removeItem(atPath: testImagePath) }
-        
+
         // Try to locate the image (may fail if no screen access)
-        let result = SwiftAutoGUI.locateOnScreen(testImagePath)
-        
+        let result = try await SwiftAutoGUI.locateOnScreen(testImagePath)
+
         // Test passes whether or not the image is found (depends on permissions)
         #expect(true)
     }
-    
+
     @Test("locateOnScreen with invalid image path")
-    func testLocateOnScreenInvalidPath() {
-        let result = SwiftAutoGUI.locateOnScreen("/nonexistent/image.png")
-        
+    func testLocateOnScreenInvalidPath() async throws {
+        let result = try await SwiftAutoGUI.locateOnScreen("/nonexistent/image.png")
+
         // Should return nil for invalid path
         #expect(result == nil)
     }
-    
+
     @Test("locateOnScreen with region")
-    func testLocateOnScreenWithRegion() {
+    func testLocateOnScreenWithRegion() async throws {
         // Create a test image
         let testImagePath = createTestImage()
         defer { try? FileManager.default.removeItem(atPath: testImagePath) }
-        
+
         // Search in a specific region
         let region = CGRect(x: 0, y: 0, width: 200, height: 200)
-        let result = SwiftAutoGUI.locateOnScreen(testImagePath, region: region)
-        
+        let result = try await SwiftAutoGUI.locateOnScreen(testImagePath, region: region)
+
         // Test passes whether or not the image is found
         #expect(true)
     }
-    
+
     @Test("locateOnScreen with confidence parameter")
-    func testLocateOnScreenWithConfidence() {
+    func testLocateOnScreenWithConfidence() async throws {
         // Create a test image
         let testImagePath = createTestImage()
         defer { try? FileManager.default.removeItem(atPath: testImagePath) }
-        
+
         // Search with different confidence levels
-        let highConfidence = SwiftAutoGUI.locateOnScreen(testImagePath, confidence: 0.95)
-        let lowConfidence = SwiftAutoGUI.locateOnScreen(testImagePath, confidence: 0.5)
-        
+        let highConfidence = try await SwiftAutoGUI.locateOnScreen(testImagePath, confidence: 0.95)
+        let lowConfidence = try await SwiftAutoGUI.locateOnScreen(testImagePath, confidence: 0.5)
+
         // Low confidence might find more matches than high confidence
         // But both could be nil if no screen access
         #expect(true)
     }
-    
+
     @Test("locateCenterOnScreen with valid image path")
-    func testLocateCenterOnScreenValidPath() {
+    func testLocateCenterOnScreenValidPath() async throws {
         // Create a test image
         let testImagePath = createTestImage()
         defer { try? FileManager.default.removeItem(atPath: testImagePath) }
-        
+
         // Try to locate the center of the image
-        let center = SwiftAutoGUI.locateCenterOnScreen(testImagePath)
-        
+        let center = try await SwiftAutoGUI.locateCenterOnScreen(testImagePath)
+
         // If an image is found, verify we get a valid center point
         if let center = center {
             #expect(center.x > 0)
             #expect(center.y > 0)
         }
-        
+
         // Test passes whether or not the image is found (depends on permissions)
         #expect(true)
     }
-    
+
     @Test("locateCenterOnScreen with invalid image path")
-    func testLocateCenterOnScreenInvalidPath() {
-        let center = SwiftAutoGUI.locateCenterOnScreen("/nonexistent/image.png")
-        
+    func testLocateCenterOnScreenInvalidPath() async throws {
+        let center = try await SwiftAutoGUI.locateCenterOnScreen("/nonexistent/image.png")
+
         // Should return nil for invalid path
         #expect(center == nil)
     }
-    
+
     @Test("locateCenterOnScreen returns center of located rectangle")
-    func testLocateCenterOnScreenReturnsCenter() {
+    func testLocateCenterOnScreenReturnsCenter() async throws {
         // Create a test image
         let testImagePath = createTestImage()
         defer { try? FileManager.default.removeItem(atPath: testImagePath) }
-        
+
         // Get both rectangle and center
-        let rect = SwiftAutoGUI.locateOnScreen(testImagePath)
-        let center = SwiftAutoGUI.locateCenterOnScreen(testImagePath)
-        
+        let rect = try await SwiftAutoGUI.locateOnScreen(testImagePath)
+        let center = try await SwiftAutoGUI.locateCenterOnScreen(testImagePath)
+
         // If both are found, verify center matches rectangle's center
         if let rect = rect, let center = center {
             #expect(center.x == rect.midX)
             #expect(center.y == rect.midY)
         }
-        
+
         // Test passes whether or not the image is found
         #expect(true)
     }
-    
+
     @Test("locateCenterOnScreen with region")
-    func testLocateCenterOnScreenWithRegion() {
+    func testLocateCenterOnScreenWithRegion() async throws {
         // Create a test image
         let testImagePath = createTestImage()
         defer { try? FileManager.default.removeItem(atPath: testImagePath) }
-        
+
         // Search in a specific region
         let region = CGRect(x: 0, y: 0, width: 200, height: 200)
-        let center = SwiftAutoGUI.locateCenterOnScreen(testImagePath, region: region)
-        
+        let center = try await SwiftAutoGUI.locateCenterOnScreen(testImagePath, region: region)
+
         // If found, verify center is within the search region
         if let center = center {
             #expect(region.contains(center))
         }
-        
+
         // Test passes whether or not the image is found
         #expect(true)
     }
-    
+
     @Test("locateCenterOnScreen with confidence parameter")
-    func testLocateCenterOnScreenWithConfidence() {
+    func testLocateCenterOnScreenWithConfidence() async throws {
         // Create a test image
         let testImagePath = createTestImage()
         defer { try? FileManager.default.removeItem(atPath: testImagePath) }
-        
+
         // Search with different confidence levels
-        let highConfidenceCenter = SwiftAutoGUI.locateCenterOnScreen(testImagePath, confidence: 0.95)
-        let lowConfidenceCenter = SwiftAutoGUI.locateCenterOnScreen(testImagePath, confidence: 0.5)
-        
+        let highConfidenceCenter = try await SwiftAutoGUI.locateCenterOnScreen(testImagePath, confidence: 0.95)
+        let lowConfidenceCenter = try await SwiftAutoGUI.locateCenterOnScreen(testImagePath, confidence: 0.5)
+
         // Test passes whether or not the images are found
         #expect(true)
     }
-    
+
     @Test("locateAllOnScreen with valid image path")
-    func testLocateAllOnScreenValidPath() {
+    func testLocateAllOnScreenValidPath() async throws {
         // Create a test image
         let testImagePath = createTestImage()
         defer { try? FileManager.default.removeItem(atPath: testImagePath) }
-        
+
         // Try to locate all instances of the image
-        let results = SwiftAutoGUI.locateAllOnScreen(testImagePath)
-        
+        let results = try await SwiftAutoGUI.locateAllOnScreen(testImagePath)
+
         // Results should be an array (possibly empty)
         #expect(results.count >= 0)
-        
+
         // If any images are found, verify they have valid dimensions
         for rect in results {
             #expect(rect.width > 0)
             #expect(rect.height > 0)
         }
-        
+
         // Test passes whether or not images are found (depends on permissions)
         #expect(true)
     }
-    
+
     @Test("locateAllOnScreen with invalid image path")
-    func testLocateAllOnScreenInvalidPath() {
-        let results = SwiftAutoGUI.locateAllOnScreen("/nonexistent/image.png")
-        
+    func testLocateAllOnScreenInvalidPath() async throws {
+        let results = try await SwiftAutoGUI.locateAllOnScreen("/nonexistent/image.png")
+
         // Should return empty array for invalid path
         #expect(results.isEmpty)
     }
-    
+
     @Test("locateAllOnScreen with region")
-    func testLocateAllOnScreenWithRegion() {
+    func testLocateAllOnScreenWithRegion() async throws {
         // Create a test image
         let testImagePath = createTestImage()
         defer { try? FileManager.default.removeItem(atPath: testImagePath) }
-        
+
         // Search in a specific region
         let region = CGRect(x: 0, y: 0, width: 400, height: 400)
-        let results = SwiftAutoGUI.locateAllOnScreen(testImagePath, region: region)
-        
+        let results = try await SwiftAutoGUI.locateAllOnScreen(testImagePath, region: region)
+
         // If found, verify all results are within the search region
         for rect in results {
             // The found rectangle should at least partially overlap with the search region
             #expect(region.intersects(rect))
         }
-        
+
         // Test passes whether or not images are found
         #expect(true)
     }
-    
+
     @Test("locateAllOnScreen with confidence parameter")
-    func testLocateAllOnScreenWithConfidence() {
+    func testLocateAllOnScreenWithConfidence() async throws {
         // Create a test image
         let testImagePath = createTestImage()
         defer { try? FileManager.default.removeItem(atPath: testImagePath) }
-        
+
         // Search with different confidence levels
-        let highConfidenceResults = SwiftAutoGUI.locateAllOnScreen(testImagePath, confidence: 0.95)
-        let lowConfidenceResults = SwiftAutoGUI.locateAllOnScreen(testImagePath, confidence: 0.5)
-        
+        let highConfidenceResults = try await SwiftAutoGUI.locateAllOnScreen(testImagePath, confidence: 0.95)
+        let lowConfidenceResults = try await SwiftAutoGUI.locateAllOnScreen(testImagePath, confidence: 0.5)
+
         // Lower confidence should find same or more matches
         // But both could be empty if no screen access
         #expect(highConfidenceResults.count <= lowConfidenceResults.count)
-        
+
         // Test passes whether or not images are found
         #expect(true)
     }
-    
+
     @Test("locateAllOnScreen returns non-overlapping results")
-    func testLocateAllOnScreenNonOverlapping() {
+    func testLocateAllOnScreenNonOverlapping() async throws {
         // Create a test image
         let testImagePath = createTestImage()
         defer { try? FileManager.default.removeItem(atPath: testImagePath) }
-        
+
         // Find all instances
-        let results = SwiftAutoGUI.locateAllOnScreen(testImagePath, confidence: 0.8)
-        
+        let results = try await SwiftAutoGUI.locateAllOnScreen(testImagePath, confidence: 0.8)
+
         // Verify that results don't significantly overlap (due to non-maximum suppression)
         for i in 0..<results.count {
             for j in (i+1)..<results.count {
                 let rect1 = results[i]
                 let rect2 = results[j]
-                
+
                 // Calculate overlap
                 let intersection = rect1.intersection(rect2)
                 let overlap = intersection.width * intersection.height
                 let minArea = min(rect1.width * rect1.height, rect2.width * rect2.height)
-                
+
                 // Overlap should be less than 50% of the smaller rectangle
                 if minArea > 0 {
                     let overlapRatio = overlap / minArea
@@ -231,36 +231,36 @@ struct ImageRecognitionTests {
                 }
             }
         }
-        
+
         // Test passes
         #expect(true)
     }
-    
+
     // Helper function to create a test image
     private func createTestImage() -> String {
         let size = NSSize(width: 50, height: 50)
         let image = NSImage(size: size)
-        
+
         image.lockFocus()
         NSColor.blue.setFill()
         NSRect(origin: .zero, size: size).fill()
-        
+
         // Draw a simple pattern
         NSColor.white.setFill()
         NSRect(x: 10, y: 10, width: 30, height: 30).fill()
-        
+
         image.unlockFocus()
-        
+
         // Save to temp directory
         let tempDir = FileManager.default.temporaryDirectory
         let path = tempDir.appendingPathComponent("test_locate_image.png").path
-        
+
         if let tiffData = image.tiffRepresentation,
            let bitmapImage = NSBitmapImageRep(data: tiffData),
            let pngData = bitmapImage.representation(using: .png, properties: [:]) {
             try? pngData.write(to: URL(fileURLWithPath: path))
         }
-        
+
         return path
     }
 }

--- a/Tests/SwiftAutoGUITests/ScreenshotTests.swift
+++ b/Tests/SwiftAutoGUITests/ScreenshotTests.swift
@@ -5,52 +5,52 @@ import CoreGraphics
 
 @Suite("Screenshot Tests")
 struct ScreenshotTests {
-    
+
     @Test("Full screen screenshot")
-    func testFullScreenScreenshot() {
+    func testFullScreenScreenshot() async throws {
         // Take a screenshot of the entire screen
-        let screenshot = SwiftAutoGUI.screenshot()
-        
+        let screenshot = try await SwiftAutoGUI.screenshot()
+
         // Verify screenshot was captured (may be nil if no screen access)
         if let screenshot = screenshot {
             #expect(screenshot.size.width > 0)
             #expect(screenshot.size.height > 0)
         }
-        
+
         // Test should pass even if screenshot is nil (no permissions)
         #expect(true)
     }
-    
+
     @Test("Region screenshot")
-    func testRegionScreenshot() {
+    func testRegionScreenshot() async throws {
         // Define a test region
         let region = CGRect(x: 100, y: 100, width: 200, height: 200)
-        
+
         // Take a screenshot of the region
-        let screenshot = SwiftAutoGUI.screenshot(region: region)
-        
+        let screenshot = try await SwiftAutoGUI.screenshot(region: region)
+
         // Verify screenshot was captured (may be nil if no screen access)
         if let screenshot = screenshot {
             #expect(screenshot.size.width > 0)
             #expect(screenshot.size.height > 0)
         }
-        
+
         // Test should pass even if screenshot is nil (no permissions)
         #expect(true)
     }
-    
+
     @Test("Screenshot save to file")
-    func testScreenshotSaveToFile() {
+    func testScreenshotSaveToFile() async throws {
         // Create a temporary file path
         let tempDir = FileManager.default.temporaryDirectory
         let testPath = tempDir.appendingPathComponent("test_screenshot.png").path
-        
+
         // Clean up any existing file
         try? FileManager.default.removeItem(atPath: testPath)
-        
+
         // Take and save screenshot
-        let saved = SwiftAutoGUI.screenshot(imageFilename: testPath)
-        
+        let saved = try await SwiftAutoGUI.screenshot(imageFilename: testPath)
+
         // If saved successfully, verify file exists
         if saved {
             let fileExists = FileManager.default.fileExists(atPath: testPath)
@@ -60,28 +60,28 @@ struct ScreenshotTests {
                 try? FileManager.default.removeItem(atPath: testPath)
             }
         }
-        
+
         // Test should pass even if save failed (no permissions)
         // This is expected in CI environments
         #expect(true)
     }
-    
+
     @Test("Screenshot save with different formats")
-    func testScreenshotSaveFormats() {
+    func testScreenshotSaveFormats() async throws {
         let tempDir = FileManager.default.temporaryDirectory
         let formats = ["png", "jpg", "jpeg", "gif", "bmp", "tiff"]
-        
+
         var successCount = 0
-        
+
         for format in formats {
             let testPath = tempDir.appendingPathComponent("test_screenshot.\(format)").path
-            
+
             // Clean up any existing file
             try? FileManager.default.removeItem(atPath: testPath)
-            
+
             // Take and save screenshot
-            let saved = SwiftAutoGUI.screenshot(imageFilename: testPath)
-            
+            let saved = try await SwiftAutoGUI.screenshot(imageFilename: testPath)
+
             // If saved successfully, verify file exists
             if saved {
                 let fileExists = FileManager.default.fileExists(atPath: testPath)
@@ -92,16 +92,16 @@ struct ScreenshotTests {
                 }
             }
         }
-        
+
         // Test passes if we can't take screenshots (CI environment) or if we can save at least one format
         // In CI environments without screen access, successCount will be 0 which is acceptable
         #expect(true)
     }
-    
+
     @Test("Screen size function")
     func testScreenSize() {
         let (width, height) = SwiftAutoGUI.size()
-        
+
         // If we have screen access, dimensions should be positive
         if width > 0 && height > 0 {
             #expect(width > 0)
@@ -112,32 +112,32 @@ struct ScreenshotTests {
             #expect(height == 0)
         }
     }
-    
+
     @Test("Pixel color function")
-    func testPixelColor() {
+    func testPixelColor() async throws {
         // Test getting pixel color at origin
-        _ = SwiftAutoGUI.pixel(x: 0, y: 0)
-        
+        _ = try await SwiftAutoGUI.pixel(x: 0, y: 0)
+
         // Test getting pixel color at another point
-        _ = SwiftAutoGUI.pixel(x: 100, y: 100)
-        
+        _ = try await SwiftAutoGUI.pixel(x: 100, y: 100)
+
         // Colors may be nil if no screen access
         // Just verify the function can be called without crashing
         #expect(true)
     }
-    
+
     @Test("Screenshot with region save")
-    func testScreenshotRegionSave() {
+    func testScreenshotRegionSave() async throws {
         let tempDir = FileManager.default.temporaryDirectory
         let testPath = tempDir.appendingPathComponent("test_region.png").path
         let region = CGRect(x: 0, y: 0, width: 100, height: 100)
-        
+
         // Clean up any existing file
         try? FileManager.default.removeItem(atPath: testPath)
-        
+
         // Take and save region screenshot
-        let saved = SwiftAutoGUI.screenshot(imageFilename: testPath, region: region)
-        
+        let saved = try await SwiftAutoGUI.screenshot(imageFilename: testPath, region: region)
+
         // If saved successfully, verify file exists
         if saved {
             let fileExists = FileManager.default.fileExists(atPath: testPath)
@@ -147,7 +147,7 @@ struct ScreenshotTests {
                 try? FileManager.default.removeItem(atPath: testPath)
             }
         }
-        
+
         // Test should pass even if save failed (no permissions)
         // This is expected in CI environments
         #expect(true)


### PR DESCRIPTION
- Replace deprecated CGWindowListCreateImage with ScreenCaptureKit API
- Update screenshot and image recognition methods to async/await
- Add Sendable conformance to TweeningFunction and MouseButton
- Update all ViewModels with @MainActor for Swift 6 concurrency
- Refactor ScrollingDemoView to fix compiler timeout
- Update all 50 tests to async throws
- Bump minimum macOS version to 26.0

BREAKING CHANGE: Screenshot and image recognition methods are now async

🤖 Generated with [Claude Code](https://claude.com/claude-code)