### PR TITLE
Add AI-powered action generation with @Generable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 .vscode/settings.json
+**/.build

--- a/README.md
+++ b/README.md
@@ -334,6 +334,34 @@ Task {
 ```
 
 
+## AI Action Generation
+
+SwiftAutoGUI can generate automation actions from natural language prompts using Apple's Foundation Models framework (on-device LLM). Requires macOS 26.0+ with Apple Intelligence enabled.
+
+```swift
+import SwiftAutoGUI
+
+// Check if AI generation is available
+guard ActionGenerator.isAvailable else {
+    print(ActionGenerator.unavailableReason ?? "Model unavailable")
+    return
+}
+
+// Generate a single action
+let action = try await ActionGenerator.generateAction(from: "click at 300, 400")
+await action.execute()
+
+// Generate a sequence of actions
+let actions = try await ActionGenerator.generateActionSequence(
+    from: "Move to 200, 200, click, wait 0.5 seconds, then type 'Hello'"
+)
+await actions.execute()
+
+// Convenience method on Action
+let copyAction = try await Action.fromPrompt("press Command+C to copy")
+await copyAction.execute()
+```
+
 ## AppleScript Execution
 SwiftAutoGUI can execute AppleScript code to control macOS applications and system features.
 

--- a/Sample/Sample/Common/DemoTab.swift
+++ b/Sample/Sample/Common/DemoTab.swift
@@ -18,7 +18,8 @@ enum DemoTab: String, CaseIterable {
     case dialog
     case appleScript
     case actions
-    
+    case aiGeneration
+
     var title: String {
         switch self {
         case .keyboard: return "Keyboard"
@@ -31,9 +32,10 @@ enum DemoTab: String, CaseIterable {
         case .dialog: return "Dialog"
         case .appleScript: return "AppleScript"
         case .actions: return "Actions"
+        case .aiGeneration: return "AI Generation"
         }
     }
-    
+
     var icon: String {
         switch self {
         case .keyboard: return "keyboard"
@@ -46,6 +48,7 @@ enum DemoTab: String, CaseIterable {
         case .dialog: return "message"
         case .appleScript: return "applescript"
         case .actions: return "play.circle"
+        case .aiGeneration: return "sparkles"
         }
     }
 }

--- a/Sample/Sample/ContentView.swift
+++ b/Sample/Sample/ContentView.swift
@@ -102,6 +102,8 @@ struct ContentView: View {
                             AppleScriptView()
                         case .actions:
                             ActionsDemoView()
+                        case .aiGeneration:
+                            AIGenerationDemoView()
                         }
                     }
                     .padding(24)

--- a/Sample/Sample/Features/AIGeneration/AIGenerationDemoView.swift
+++ b/Sample/Sample/Features/AIGeneration/AIGenerationDemoView.swift
@@ -1,0 +1,209 @@
+//
+//  AIGenerationDemoView.swift
+//  Sample
+//
+
+import SwiftUI
+import SwiftAutoGUI
+
+struct AIGenerationDemoView: View {
+    @StateObject private var viewModel = AIGenerationDemoViewModel()
+    @Environment(\.colorScheme) var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            // Header
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Image(systemName: "sparkles")
+                        .font(.title)
+                        .foregroundColor(.purple)
+                    Text("AI Action Generation")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                }
+                Text("Generate automation actions from natural language prompts")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+
+            Divider()
+
+            // Input Section
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Prompt")
+                    .font(.headline)
+
+                TextEditor(text: $viewModel.prompt)
+                    .frame(height: 80)
+                    .padding(8)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(colorScheme == .dark ? Color.gray.opacity(0.2) : Color.white)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+                    )
+
+                // Sample Prompts
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Sample Prompts")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 8) {
+                            ForEach(viewModel.samplePrompts, id: \.self) { sample in
+                                Button(action: {
+                                    viewModel.useSamplePrompt(sample)
+                                }) {
+                                    Text(sample)
+                                        .font(.caption)
+                                        .padding(.horizontal, 12)
+                                        .padding(.vertical, 6)
+                                        .background(Capsule().fill(Color.purple.opacity(0.1)))
+                                        .foregroundColor(.purple)
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                    }
+                }
+
+                // Buttons
+                HStack(spacing: 12) {
+                    Button(action: {
+                        Task { await viewModel.generateActions() }
+                    }) {
+                        HStack {
+                            if viewModel.isGenerating {
+                                ProgressView()
+                                    .scaleEffect(0.8)
+                                    .frame(width: 16, height: 16)
+                            } else {
+                                Image(systemName: "wand.and.stars")
+                            }
+                            Text(viewModel.isGenerating ? "Generating..." : "Generate Actions")
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(RoundedRectangle(cornerRadius: 10).fill(Color.purple))
+                        .foregroundColor(.white)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(viewModel.isGenerating || viewModel.prompt.isEmpty)
+                    .opacity(viewModel.prompt.isEmpty ? 0.5 : 1.0)
+
+                    if !viewModel.generatedActions.isEmpty {
+                        Button(action: {
+                            Task { await viewModel.executeGeneratedActions() }
+                        }) {
+                            HStack {
+                                if viewModel.isExecuting {
+                                    ProgressView()
+                                        .scaleEffect(0.8)
+                                        .frame(width: 16, height: 16)
+                                } else {
+                                    Image(systemName: "play.fill")
+                                }
+                                Text(viewModel.isExecuting ? "Executing..." : "Execute")
+                            }
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(RoundedRectangle(cornerRadius: 10).fill(Color.green))
+                            .foregroundColor(.white)
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(viewModel.isExecuting)
+                    }
+                }
+
+                // Error Message
+                if let error = viewModel.error {
+                    HStack {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundColor(.orange)
+                        Text(error)
+                            .font(.caption)
+                            .foregroundColor(.orange)
+                    }
+                    .padding(12)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(RoundedRectangle(cornerRadius: 8).fill(Color.orange.opacity(0.1)))
+                }
+            }
+
+            // Generated Actions
+            if !viewModel.generatedActions.isEmpty {
+                Divider()
+
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Generated Actions (\(viewModel.generatedActions.count))")
+                        .font(.headline)
+
+                    ForEach(Array(viewModel.generatedActions.enumerated()), id: \.offset) { index, _ in
+                        HStack {
+                            Text("\(index + 1)")
+                                .font(.caption)
+                                .fontWeight(.bold)
+                                .foregroundColor(.white)
+                                .frame(width: 24, height: 24)
+                                .background(Circle().fill(Color.purple))
+
+                            Text(viewModel.actionDescription(for: viewModel.generatedActions[index]))
+                                .font(.caption)
+
+                            Spacer()
+                        }
+                        .padding(8)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(colorScheme == .dark ? Color.gray.opacity(0.2) : Color.gray.opacity(0.1))
+                        )
+                    }
+                }
+            }
+
+            // Execution Log
+            if !viewModel.executionLog.isEmpty {
+                Divider()
+
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack {
+                        Text("Execution Log")
+                            .font(.headline)
+                        Spacer()
+                        Button("Clear") { viewModel.clearLog() }
+                            .buttonStyle(.plain)
+                            .foregroundColor(.red)
+                    }
+
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 4) {
+                            ForEach(viewModel.executionLog, id: \.self) { log in
+                                Text(log)
+                                    .font(.system(.caption, design: .monospaced))
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .frame(maxHeight: 200)
+                    .padding(12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(colorScheme == .dark ? Color.black.opacity(0.3) : Color.gray.opacity(0.1))
+                    )
+                }
+            }
+        }
+    }
+}
+
+struct AIGenerationDemoView_Previews: PreviewProvider {
+    static var previews: some View {
+        AIGenerationDemoView()
+            .frame(width: 800, height: 600)
+    }
+}

--- a/Sample/Sample/Features/AIGeneration/AIGenerationDemoViewModel.swift
+++ b/Sample/Sample/Features/AIGeneration/AIGenerationDemoViewModel.swift
@@ -1,0 +1,167 @@
+//
+//  AIGenerationDemoViewModel.swift
+//  Sample
+//
+
+import SwiftUI
+import SwiftAutoGUI
+
+@MainActor
+class AIGenerationDemoViewModel: ObservableObject {
+    @Published var prompt: String = ""
+    @Published var generatedActions: [Action] = []
+    @Published var executionLog: [String] = []
+    @Published var isGenerating = false
+    @Published var isExecuting = false
+    @Published var error: String?
+
+    let samplePrompts: [String] = [
+        "Click at 300, 400",
+        "Type 'Hello, AI!'",
+        "Scroll down 5 clicks",
+        "Press Command+C to copy",
+        "Move to 200, 200, click, wait 0.5 seconds, then type 'test'"
+    ]
+
+    func generateActions() async {
+        guard !prompt.isEmpty else {
+            error = "Please enter a prompt"
+            return
+        }
+
+        guard ActionGenerator.isAvailable else {
+            error = ActionGenerator.unavailableReason ?? "Model is unavailable."
+            addToLog("Model unavailable: \(error!)")
+            return
+        }
+
+        isGenerating = true
+        error = nil
+        generatedActions = []
+        executionLog.removeAll()
+
+        do {
+            addToLog("Generating actions from prompt...")
+            addToLog("Prompt: \"\(prompt)\"")
+
+            let actions = try await ActionGenerator.generateActionSequence(from: prompt)
+
+            if actions.isEmpty {
+                error = "Could not generate actions from prompt"
+                addToLog("No actions generated")
+            } else {
+                generatedActions = actions
+                addToLog("Generated \(actions.count) action(s)")
+                for (index, action) in actions.enumerated() {
+                    addToLog("  [\(index + 1)] \(actionDescription(for: action))")
+                }
+            }
+        } catch {
+            self.error = error.localizedDescription
+            addToLog("Error: \(error.localizedDescription)")
+        }
+
+        isGenerating = false
+    }
+
+    func executeGeneratedActions() async {
+        guard !generatedActions.isEmpty else { return }
+
+        isExecuting = true
+        addToLog("--- Executing generated actions ---")
+
+        for (index, action) in generatedActions.enumerated() {
+            addToLog("Executing [\(index + 1)]: \(actionDescription(for: action))")
+            _ = await action.execute()
+        }
+
+        addToLog("Execution completed!")
+        isExecuting = false
+    }
+
+    func clearLog() {
+        executionLog.removeAll()
+    }
+
+    func useSamplePrompt(_ sample: String) {
+        prompt = sample
+    }
+
+    private func addToLog(_ message: String) {
+        let timestamp = DateFormatter.localizedString(from: Date(), dateStyle: .none, timeStyle: .medium)
+        executionLog.append("[\(timestamp)] \(message)")
+    }
+
+    func actionDescription(for action: Action) -> String {
+        switch action {
+        case .keyDown(let key):
+            return "Key Down: \(key)"
+        case .keyUp(let key):
+            return "Key Up: \(key)"
+        case .write(let text, let interval):
+            return "Write: \"\(text)\" (interval: \(interval)s)"
+        case .keyShortcut(let keys):
+            return "Shortcut: \(keys.map { "\($0)" }.joined(separator: "+"))"
+        case .move(let point):
+            return "Move to: (\(Int(point.x)), \(Int(point.y)))"
+        case .moveSmooth(let point, let duration, let tweening, _):
+            return "Smooth move to: (\(Int(point.x)), \(Int(point.y))) in \(duration)s (\(tweening))"
+        case .moveMouse(let dx, let dy):
+            return "Move by: (dx: \(dx), dy: \(dy))"
+        case .leftClick:
+            return "Left Click"
+        case .rightClick:
+            return "Right Click"
+        case .doubleClick(let button):
+            return "Double Click (\(button == .left ? "left" : "right"))"
+        case .doubleClickAt(let position, let button):
+            return "Double Click at (\(Int(position.x)), \(Int(position.y))) (\(button == .left ? "left" : "right"))"
+        case .tripleClick(let button):
+            return "Triple Click (\(button == .left ? "left" : "right"))"
+        case .tripleClickAt(let position, let button):
+            return "Triple Click at (\(Int(position.x)), \(Int(position.y))) (\(button == .left ? "left" : "right"))"
+        case .drag(let from, let to):
+            return "Drag from (\(Int(from.x)), \(Int(from.y))) to (\(Int(to.x)), \(Int(to.y)))"
+        case .vscroll(let clicks):
+            return "Vertical scroll: \(clicks) clicks"
+        case .hscroll(let clicks):
+            return "Horizontal scroll: \(clicks) clicks"
+        case .smoothVScroll(let clicks, let duration, let tweening, _):
+            return "Smooth V-scroll: \(clicks) clicks in \(duration)s (\(tweening))"
+        case .smoothHScroll(let clicks, let duration, let tweening, _):
+            return "Smooth H-scroll: \(clicks) clicks in \(duration)s (\(tweening))"
+        case .screenshot:
+            return "Take screenshot"
+        case .screenshotRegion(let rect):
+            return "Screenshot region: \(rect)"
+        case .screenshotToFile(let filename, _):
+            return "Screenshot to file: \(filename)"
+        case .getScreenSize:
+            return "Get screen size"
+        case .getPixel(let x, let y):
+            return "Get pixel at (\(x), \(y))"
+        case .locateOnScreen(let path, _, _, _):
+            return "Locate image: \(path)"
+        case .locateCenterOnScreen(let path, _, _, _):
+            return "Locate image center: \(path)"
+        case .locateAllOnScreen(let path, _, _, _):
+            return "Locate all images: \(path)"
+        case .alert(let message, _, _):
+            return "Alert: \(message)"
+        case .confirm(let message, _, _):
+            return "Confirm: \(message)"
+        case .prompt(let message, _, _, _):
+            return "Prompt: \(message)"
+        case .password(let message, _, _, _):
+            return "Password: \(message)"
+        case .executeAppleScript(let script):
+            return "Execute AppleScript: \(script.prefix(30))..."
+        case .executeAppleScriptFile(let path):
+            return "Execute AppleScript file: \(path)"
+        case .wait(let duration):
+            return "Wait \(duration)s"
+        case .sequence(let actions):
+            return "Sequence with \(actions.count) actions"
+        }
+    }
+}

--- a/Sources/SwiftAutoGUI/ActionGenerator.swift
+++ b/Sources/SwiftAutoGUI/ActionGenerator.swift
@@ -1,0 +1,172 @@
+//
+//  ActionGenerator.swift
+//  SwiftAutoGUI
+//
+
+import Foundation
+import FoundationModels
+
+// MARK: - BasicAction (Lightweight @Generable type for on-device model)
+
+/// A lightweight action type for AI generation.
+///
+/// This type is intentionally kept small to fit within the on-device model's
+/// context window. It covers common automation operations and converts to
+/// the full ``Action`` type via ``toAction()``.
+@Generable
+enum BasicAction: Sendable {
+    /// Type text.
+    case write(text: String)
+
+    /// Move mouse to absolute position.
+    case move(x: Double, y: Double)
+
+    /// Left click at current position.
+    case leftClick
+
+    /// Right click at current position.
+    case rightClick
+
+    /// Double click at current position.
+    case doubleClick
+
+    /// Scroll vertically. Positive values scroll up, negative values scroll down.
+    case vscroll(clicks: Int)
+
+    /// Scroll horizontally. Positive values scroll right, negative values scroll left.
+    case hscroll(clicks: Int)
+
+    /// Wait for a duration in seconds.
+    case wait(duration: Double)
+
+    /// Press a keyboard shortcut. Use key names like "command", "shift", "a", "c", "returnKey", "space", "delete", "tab", "escape", "upArrow", "downArrow", "leftArrow", "rightArrow".
+    case keyShortcut(keys: [String])
+
+    /// Drag mouse from one position to another.
+    case drag(fromX: Double, fromY: Double, toX: Double, toY: Double)
+
+    /// Convert to an executable ``Action``.
+    func toAction() -> Action {
+        switch self {
+        case .write(let text):
+            return .write(text)
+        case .move(let x, let y):
+            return .move(to: CGPoint(x: x, y: y))
+        case .leftClick:
+            return .leftClick
+        case .rightClick:
+            return .rightClick
+        case .doubleClick:
+            return .doubleClick()
+        case .vscroll(let clicks):
+            return .vscroll(clicks: clicks)
+        case .hscroll(let clicks):
+            return .hscroll(clicks: clicks)
+        case .wait(let duration):
+            return .wait(duration)
+        case .keyShortcut(let keys):
+            let mapped = keys.compactMap { Key(rawValue: $0) }
+            guard !mapped.isEmpty else { return .wait(0) }
+            return .keyShortcut(mapped)
+        case .drag(let fromX, let fromY, let toX, let toY):
+            return .drag(from: CGPoint(x: fromX, y: fromY), to: CGPoint(x: toX, y: toY))
+        }
+    }
+}
+
+// MARK: - ActionGenerator
+
+/// Generates automation actions from natural language prompts using AI.
+///
+/// `ActionGenerator` uses the Foundation Models framework to convert natural language
+/// descriptions into executable ``Action`` instances. This enables AI-powered automation
+/// where users can describe what they want to do in plain language.
+///
+/// ## Example Usage
+///
+/// ```swift
+/// // Generate a single action from a prompt
+/// let action = try await ActionGenerator.generateAction(from: "click at position 100, 200")
+/// await action.execute()
+///
+/// // Generate multiple actions for a complex task
+/// let actions = try await ActionGenerator.generateActionSequence(
+///     from: "Click at 100, 100, wait 1 second, then type 'test'"
+/// )
+/// await actions.execute()
+/// ```
+///
+/// ## Requirements
+///
+/// - macOS 26.0 or later
+/// - Apple Intelligence enabled
+///
+@MainActor
+public struct ActionGenerator: Sendable {
+
+    /// Checks if the on-device language model is available.
+    ///
+    /// Use this method to verify model availability before attempting to generate actions.
+    public static var isAvailable: Bool {
+        if case .available = SystemLanguageModel.default.availability {
+            return true
+        }
+        return false
+    }
+
+    /// Returns a human-readable message describing why the model is unavailable.
+    ///
+    /// - Returns: A message string if the model is unavailable, `nil` if available.
+    public static var unavailableReason: String? {
+        switch SystemLanguageModel.default.availability {
+        case .available:
+            return nil
+        case .unavailable(.deviceNotEligible):
+            return "This device does not support Apple Intelligence."
+        case .unavailable(.appleIntelligenceNotEnabled):
+            return "Apple Intelligence is not enabled. Please enable it in System Settings."
+        case .unavailable(.modelNotReady):
+            return "The model is still downloading or initializing. Please try again later."
+        case .unavailable:
+            return "The model is unavailable."
+        }
+    }
+
+    /// Generates a single action from a natural language prompt.
+    ///
+    /// - Parameter prompt: A natural language description of the desired action.
+    /// - Returns: An ``Action`` instance.
+    /// - Throws: Any errors from the Foundation Models framework.
+    public static func generateAction(from prompt: String) async throws -> Action {
+        let session = LanguageModelSession(model: .default)
+        let response = try await session.respond(to: prompt, generating: BasicAction.self)
+        return response.content.toAction()
+    }
+
+    /// Generates multiple actions from a natural language prompt describing a sequence.
+    ///
+    /// - Parameter prompt: A natural language description of a multi-step task.
+    /// - Returns: An array of ``Action`` instances representing the sequence.
+    /// - Throws: Any errors from the Foundation Models framework.
+    public static func generateActionSequence(from prompt: String) async throws -> [Action] {
+        let session = LanguageModelSession(model: .default)
+        let response = try await session.respond(to: prompt, generating: [BasicAction].self)
+        return response.content.map { $0.toAction() }
+    }
+}
+
+// MARK: - Convenience Extensions
+
+extension Action {
+    /// Generates an action from a natural language prompt.
+    ///
+    /// This is a convenience method that uses ``ActionGenerator`` to generate a single action.
+    ///
+    /// - Parameter prompt: A natural language description of the desired action.
+    /// - Returns: An ``Action`` instance.
+    /// - Throws: Any errors from the Foundation Models framework.
+    @MainActor
+    public static func fromPrompt(_ prompt: String) async throws -> Action {
+        return try await ActionGenerator.generateAction(from: prompt)
+    }
+}

--- a/Sources/SwiftAutoGUI/Documentation.docc/SwiftAutoGUI.md
+++ b/Sources/SwiftAutoGUI/Documentation.docc/SwiftAutoGUI.md
@@ -141,6 +141,30 @@ let formActions = fillForm(name: "John Doe", email: "john@example.com")
 await formActions.execute()
 ```
 
+### AI Action Generation
+
+Generate automation actions from natural language using Apple's Foundation Models framework:
+
+```swift
+// Check availability
+guard ActionGenerator.isAvailable else {
+    print(ActionGenerator.unavailableReason ?? "Model unavailable")
+    return
+}
+
+// Generate and execute actions from a prompt
+let actions = try await ActionGenerator.generateActionSequence(
+    from: "Click at 100, 200, wait 1 second, then type 'Hello'"
+)
+await actions.execute()
+
+// Or use the convenience method
+let action = try await Action.fromPrompt("scroll down 5 clicks")
+await action.execute()
+```
+
+> Note: Requires macOS 26.0+ with Apple Intelligence enabled.
+
 ### Direct Method Calls (Alternative)
 
 While the Action pattern is recommended, you can also use SwiftAutoGUI methods directly for simple operations:
@@ -162,12 +186,12 @@ Task {
 }
 
 // Screenshots
-if let screenshot = SwiftAutoGUI.screenshot() {
+if let screenshot = try await SwiftAutoGUI.screenshot() {
     // Process NSImage
 }
 
 // Image recognition
-if let location = SwiftAutoGUI.locateOnScreen("button.png") {
+if let location = try await SwiftAutoGUI.locateOnScreen("button.png") {
     let center = CGPoint(x: location.midX, y: location.midY)
     await SwiftAutoGUI.move(to: center, duration: 0)
     SwiftAutoGUI.leftClick()
@@ -201,5 +225,6 @@ The sample app demonstrates all SwiftAutoGUI features with interactive examples.
 
 - ``SwiftAutoGUI/SwiftAutoGUI``
 - ``Action``
+- ``ActionGenerator``
 - ``Key``
 - ``TweeningFunction``


### PR DESCRIPTION
## Summary
- Add `ActionGenerator` that converts natural language prompts into executable `Action` sequences using Apple's FoundationModels framework (on-device LLM)
- Introduce lightweight `BasicAction` enum (10 cases) with `@Generable` to stay within the on-device model's context window, instead of marking the full `Action` enum (30+ cases)
- Add model availability checks (`ActionGenerator.isAvailable` / `.unavailableReason`) with user-friendly messages for each unavailability reason
- Add AI Generation demo to the Sample app with sample prompts and execution log
- Update `Action` enum to use explicit argument labels for all cases

## Test plan
- [x] `swift build` succeeds
- [x] `swift test` passes all 50 tests
- [ ] Run Sample app → AI Generation demo with Apple Intelligence enabled
- [ ] Verify availability check shows appropriate message when Apple Intelligence is disabled
- [ ] Test sample prompts: "Click at 300, 400", "Type 'Hello, AI!'", "Press Command+C to copy"

🤖 Generated with [Claude Code](https://claude.com/claude-code)