### PR TITLE
Migrate Sample app ViewModels to @Observable macro

### DIFF
--- a/Sample/Sample/Features/AIGeneration/AIGenerationDemoView.swift
+++ b/Sample/Sample/Features/AIGeneration/AIGenerationDemoView.swift
@@ -7,7 +7,7 @@ import SwiftUI
 import SwiftAutoGUI
 
 struct AIGenerationDemoView: View {
-    @StateObject private var viewModel = AIGenerationDemoViewModel()
+    @State private var viewModel = AIGenerationDemoViewModel()
     @Environment(\.colorScheme) var colorScheme
 
     var body: some View {

--- a/Sample/Sample/Features/AIGeneration/AIGenerationDemoViewModel.swift
+++ b/Sample/Sample/Features/AIGeneration/AIGenerationDemoViewModel.swift
@@ -7,13 +7,14 @@ import SwiftUI
 import SwiftAutoGUI
 
 @MainActor
-class AIGenerationDemoViewModel: ObservableObject {
-    @Published var prompt: String = ""
-    @Published var generatedActions: [Action] = []
-    @Published var executionLog: [String] = []
-    @Published var isGenerating = false
-    @Published var isExecuting = false
-    @Published var error: String?
+@Observable
+class AIGenerationDemoViewModel {
+    var prompt: String = ""
+    var generatedActions: [Action] = []
+    var executionLog: [String] = []
+    var isGenerating = false
+    var isExecuting = false
+    var error: String?
 
     let samplePrompts: [String] = [
         "Click at 300, 400",

--- a/Sample/Sample/Features/Actions/ActionsDemoView.swift
+++ b/Sample/Sample/Features/Actions/ActionsDemoView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import SwiftAutoGUI
 
 struct ActionsDemoView: View {
-    @StateObject private var viewModel = ActionsDemoViewModel()
+    @State private var viewModel = ActionsDemoViewModel()
     
     var body: some View {
         VStack(spacing: 20) {

--- a/Sample/Sample/Features/Actions/ActionsDemoViewModel.swift
+++ b/Sample/Sample/Features/Actions/ActionsDemoViewModel.swift
@@ -9,10 +9,11 @@ import SwiftUI
 import SwiftAutoGUI
 
 @MainActor
-class ActionsDemoViewModel: ObservableObject {
-    @Published var executionLog: [String] = []
-    @Published var isExecuting = false
-    @Published var selectedExample = ActionExample.mouseClick
+@Observable
+class ActionsDemoViewModel {
+    var executionLog: [String] = []
+    var isExecuting = false
+    var selectedExample = ActionExample.mouseClick
     
     enum ActionExample: String, CaseIterable {
         case mouseClick = "Mouse Click"

--- a/Sample/Sample/Features/AppleScript/AppleScriptView.swift
+++ b/Sample/Sample/Features/AppleScript/AppleScriptView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct AppleScriptView: View {
-    @StateObject private var viewModel = AppleScriptViewModel()
+    @State private var viewModel = AppleScriptViewModel()
     @Environment(\.colorScheme) var colorScheme
     
     var body: some View {

--- a/Sample/Sample/Features/AppleScript/AppleScriptViewModel.swift
+++ b/Sample/Sample/Features/AppleScript/AppleScriptViewModel.swift
@@ -9,11 +9,12 @@ import Foundation
 import SwiftAutoGUI
 
 @MainActor
-final class AppleScriptViewModel: ObservableObject {
-    @Published var scriptText: String
-    @Published var result: String = ""
-    @Published var isExecuting: Bool = false
-    @Published var errorMessage: String?
+@Observable
+final class AppleScriptViewModel {
+    var scriptText: String
+    var result: String = ""
+    var isExecuting: Bool = false
+    var errorMessage: String?
     
     init() {
         // Initial sample script

--- a/Sample/Sample/Features/Dialog/DialogDemoView.swift
+++ b/Sample/Sample/Features/Dialog/DialogDemoView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import SwiftAutoGUI
 
 struct DialogDemoView: View {
-    @StateObject private var viewModel = DialogDemoViewModel()
+    @State private var viewModel = DialogDemoViewModel()
     
     var body: some View {
         VStack(alignment: .leading, spacing: 24) {

--- a/Sample/Sample/Features/Dialog/DialogDemoViewModel.swift
+++ b/Sample/Sample/Features/Dialog/DialogDemoViewModel.swift
@@ -9,11 +9,12 @@ import Foundation
 import SwiftAutoGUI
 
 @MainActor
-class DialogDemoViewModel: ObservableObject {
-    @Published var alertResult: String?
-    @Published var confirmResult: String?
-    @Published var promptResult: String?
-    @Published var passwordResult: String?
+@Observable
+class DialogDemoViewModel {
+    var alertResult: String?
+    var confirmResult: String?
+    var promptResult: String?
+    var passwordResult: String?
     
     func showAlert() async {
         let result = await Action.alert(

--- a/Sample/Sample/Features/ImageRecognition/ImageRecognitionView.swift
+++ b/Sample/Sample/Features/ImageRecognition/ImageRecognitionView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ImageRecognitionView: View {
-    @StateObject private var viewModel = ImageRecognitionViewModel()
+    @State private var viewModel = ImageRecognitionViewModel()
     
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {

--- a/Sample/Sample/Features/ImageRecognition/ImageRecognitionViewModel.swift
+++ b/Sample/Sample/Features/ImageRecognition/ImageRecognitionViewModel.swift
@@ -9,9 +9,10 @@ import SwiftUI
 import SwiftAutoGUI
 
 @MainActor
-class ImageRecognitionViewModel: ObservableObject {
-    @Published var imageRecognitionResult: String = ""
-    @Published var testImagePath: String = ""
+@Observable
+class ImageRecognitionViewModel {
+    var imageRecognitionResult: String = ""
+    var testImagePath: String = ""
     
     func createTestImageForRecognition() {
         let size = NSSize(width: 100, height: 100)

--- a/Sample/Sample/Features/Keyboard/KeyboardDemoView.swift
+++ b/Sample/Sample/Features/Keyboard/KeyboardDemoView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct KeyboardDemoView: View {
-    @StateObject private var viewModel = KeyboardDemoViewModel()
+    @State private var viewModel = KeyboardDemoViewModel()
     
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {

--- a/Sample/Sample/Features/Keyboard/KeyboardDemoViewModel.swift
+++ b/Sample/Sample/Features/Keyboard/KeyboardDemoViewModel.swift
@@ -9,7 +9,8 @@ import SwiftUI
 import SwiftAutoGUI
 
 @MainActor
-class KeyboardDemoViewModel: ObservableObject {
+@Observable
+class KeyboardDemoViewModel {
     
     func sendKeyShortcut() {
         Task {

--- a/Sample/Sample/Features/Mouse/MouseControlView.swift
+++ b/Sample/Sample/Features/Mouse/MouseControlView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct MouseControlView: View {
-    @StateObject private var viewModel = MouseControlViewModel()
+    @State private var viewModel = MouseControlViewModel()
     
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {

--- a/Sample/Sample/Features/Mouse/MouseControlViewModel.swift
+++ b/Sample/Sample/Features/Mouse/MouseControlViewModel.swift
@@ -9,9 +9,10 @@ import SwiftUI
 import SwiftAutoGUI
 
 @MainActor
-class MouseControlViewModel: ObservableObject {
-    @Published var mousePosition: String = ""
-    @Published var isAnimating: Bool = false
+@Observable
+class MouseControlViewModel {
+    var mousePosition: String = ""
+    var isAnimating: Bool = false
     
     func moveMouse() {
         Task {

--- a/Sample/Sample/Features/PixelDetection/PixelDetectionView.swift
+++ b/Sample/Sample/Features/PixelDetection/PixelDetectionView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct PixelDetectionView: View {
-    @StateObject private var viewModel = PixelDetectionViewModel()
+    @State private var viewModel = PixelDetectionViewModel()
     
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {

--- a/Sample/Sample/Features/PixelDetection/PixelDetectionViewModel.swift
+++ b/Sample/Sample/Features/PixelDetection/PixelDetectionViewModel.swift
@@ -9,9 +9,10 @@ import SwiftUI
 import SwiftAutoGUI
 
 @MainActor
-class PixelDetectionViewModel: ObservableObject {
-    @Published var pixelColor: NSColor?
-    @Published var screenSize: String = ""
+@Observable
+class PixelDetectionViewModel {
+    var pixelColor: NSColor?
+    var screenSize: String = ""
     
     func getScreenSize() {
         Task {

--- a/Sample/Sample/Features/Screenshot/ScreenshotView.swift
+++ b/Sample/Sample/Features/Screenshot/ScreenshotView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ScreenshotView: View {
-    @StateObject private var viewModel = ScreenshotViewModel()
+    @State private var viewModel = ScreenshotViewModel()
     
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {

--- a/Sample/Sample/Features/Screenshot/ScreenshotViewModel.swift
+++ b/Sample/Sample/Features/Screenshot/ScreenshotViewModel.swift
@@ -9,8 +9,9 @@ import SwiftUI
 import SwiftAutoGUI
 
 @MainActor
-class ScreenshotViewModel: ObservableObject {
-    @Published var screenshotImage: NSImage?
+@Observable
+class ScreenshotViewModel {
+    var screenshotImage: NSImage?
     
     func takeScreenshot() {
         Task {

--- a/Sample/Sample/Features/Scrolling/ScrollingDemoView.swift
+++ b/Sample/Sample/Features/Scrolling/ScrollingDemoView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ScrollingDemoView: View {
-    @StateObject private var viewModel = ScrollingDemoViewModel()
+    @State private var viewModel = ScrollingDemoViewModel()
 
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {

--- a/Sample/Sample/Features/Scrolling/ScrollingDemoViewModel.swift
+++ b/Sample/Sample/Features/Scrolling/ScrollingDemoViewModel.swift
@@ -9,7 +9,8 @@ import SwiftUI
 import SwiftAutoGUI
 
 @MainActor
-class ScrollingDemoViewModel: ObservableObject {
+@Observable
+class ScrollingDemoViewModel {
     
     func verticalScrollDown() {
         Task {

--- a/Sample/Sample/Features/TextTyping/TextTypingView.swift
+++ b/Sample/Sample/Features/TextTyping/TextTypingView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct TextTypingView: View {
-    @StateObject private var viewModel = TextTypingViewModel()
+    @State private var viewModel = TextTypingViewModel()
     @FocusState private var isTargetFieldFocused: Bool
     @Environment(\.colorScheme) var colorScheme
     

--- a/Sample/Sample/Features/TextTyping/TextTypingViewModel.swift
+++ b/Sample/Sample/Features/TextTyping/TextTypingViewModel.swift
@@ -9,12 +9,13 @@ import SwiftUI
 import SwiftAutoGUI
 
 @MainActor
-class TextTypingViewModel: ObservableObject {
-    @Published var textToType: String = ""
-    @Published var typingSpeed: Double = 0.0
-    @Published var typingStatus: String = ""
-    @Published var targetTextField: String = ""
-    @Published var isTargetFieldFocused: Bool = false
+@Observable
+class TextTypingViewModel {
+    var textToType: String = ""
+    var typingSpeed: Double = 0.0
+    var typingStatus: String = ""
+    var targetTextField: String = ""
+    var isTargetFieldFocused: Bool = false
     
     func typeText(_ text: String) {
         guard !text.isEmpty else {


### PR DESCRIPTION
## Summary

- Replace `ObservableObject` + `@Published` with `@Observable` macro across all 11 Sample app ViewModels
- Update all 11 Views to use `@State` instead of `@StateObject`
- No changes to the main library (`Sources/SwiftAutoGUI/`)

## Motivation

The project targets macOS 26 / Swift 6.2, which fully supports the Observation framework. Migrating to `@Observable` eliminates the implicit Combine dependency, reduces boilerplate, and enables more efficient per-property change tracking.

## Changes

| Before | After |
|--------|-------|
| `class Foo: ObservableObject` | `@Observable class Foo` |
| `@Published var bar = ""` | `var bar = ""` |
| `@StateObject private var vm = Foo()` | `@State private var vm = Foo()` |

22 files changed across 11 ViewModel + 11 View pairs.

Closes #52

## Test plan

- [ ] `swift build` succeeds
- [ ] `xcodebuild build` for Sample app succeeds
- [ ] Sample app runs correctly with all features functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)