### PR TITLE
feat: add JIS keyboard layout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,28 @@ let loginActions = createLoginSequence(
 await loginActions.execute()
 ```
 
-Currently ***only US keyboards*** are supported. Otherwise, it may not work properly.
+## Keyboard Layout
+
+SwiftAutoGUI supports both **US** and **JIS** keyboard layouts. The physical keyboard type is auto-detected by default, so symbols like `@`, `[`, `:`, `_` are mapped to the correct keys regardless of the layout.
+
+```swift
+import SwiftAutoGUI
+
+// Auto-detected — just works on both US and JIS keyboards
+await SwiftAutoGUI.write("Hello @world [test]")
+
+// Check the current layout
+let layout = SwiftAutoGUI.currentLayout  // .us or .jis
+
+// Manually override the layout
+SwiftAutoGUI.currentLayout = .jis
+
+// Reset to auto-detection
+SwiftAutoGUI.resetLayoutToAutoDetect()
+
+// Use a specific layout without changing global state
+let key = Key.from(character: "@", layout: .jis)  // .leftBracket
+```
 
 ## Direct Method Calls (Alternative)
 

--- a/Sample/Sample/Common/DemoTab.swift
+++ b/Sample/Sample/Common/DemoTab.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 enum DemoTab: String, CaseIterable {
     case keyboard
+    case keyboardLayout
     case mouse
     case textTyping
     case screenshot
@@ -23,6 +24,7 @@ enum DemoTab: String, CaseIterable {
     var title: String {
         switch self {
         case .keyboard: return "Keyboard"
+        case .keyboardLayout: return "KB Layout"
         case .mouse: return "Mouse"
         case .textTyping: return "Text Typing"
         case .screenshot: return "Screenshot"
@@ -39,6 +41,7 @@ enum DemoTab: String, CaseIterable {
     var icon: String {
         switch self {
         case .keyboard: return "keyboard"
+        case .keyboardLayout: return "globe"
         case .mouse: return "cursorarrow"
         case .textTyping: return "text.cursor"
         case .screenshot: return "camera.viewfinder"

--- a/Sample/Sample/ContentView.swift
+++ b/Sample/Sample/ContentView.swift
@@ -84,6 +84,8 @@ struct ContentView: View {
                         switch selectedTab {
                         case .keyboard:
                             KeyboardDemoView()
+                        case .keyboardLayout:
+                            KeyboardLayoutView()
                         case .mouse:
                             MouseControlView()
                         case .textTyping:

--- a/Sample/Sample/Features/KeyboardLayout/KeyboardLayoutView.swift
+++ b/Sample/Sample/Features/KeyboardLayout/KeyboardLayoutView.swift
@@ -1,0 +1,230 @@
+//
+//  KeyboardLayoutView.swift
+//  Sample
+//
+//  Created by NakaokaRei on 2025/07/09.
+//
+
+import SwiftUI
+import SwiftAutoGUI
+
+struct KeyboardLayoutView: View {
+    @State private var viewModel = KeyboardLayoutViewModel()
+    @FocusState private var isTargetFieldFocused: Bool
+    @Environment(\.colorScheme) var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            // Header
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Keyboard Layout Demo")
+                    .font(.title2)
+                    .fontWeight(.bold)
+                Text("Switch between US and JIS keyboard layouts")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+
+            // Layout selection
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Label("Detected Layout", systemImage: "globe")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+
+                    Spacer()
+
+                    Text(viewModel.detectedLayout.rawValue.uppercased())
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(Color.green.opacity(0.2))
+                        )
+                }
+
+                HStack(spacing: 12) {
+                    Picker("Layout", selection: $viewModel.selectedLayout) {
+                        Text("US").tag(KeyboardLayout.us)
+                        Text("JIS").tag(KeyboardLayout.jis)
+                    }
+                    .pickerStyle(.segmented)
+
+                    Button("Apply") {
+                        viewModel.applyLayout()
+                    }
+                    .buttonStyle(.borderedProminent)
+
+                    Button("Auto Detect") {
+                        viewModel.resetToAutoDetect()
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+
+            Divider()
+
+            // Mapping comparison table
+            VStack(alignment: .leading, spacing: 8) {
+                Label("Symbol Key Mapping Comparison", systemImage: "tablecells")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+
+                ScrollView {
+                    VStack(spacing: 0) {
+                        // Header row
+                        HStack(spacing: 0) {
+                            Text("Char")
+                                .frame(width: 50, alignment: .center)
+                                .fontWeight(.semibold)
+                            Text("US Layout")
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .fontWeight(.semibold)
+                            Text("JIS Layout")
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .fontWeight(.semibold)
+                        }
+                        .font(.caption)
+                        .padding(.vertical, 6)
+                        .padding(.horizontal, 8)
+                        .background(colorScheme == .dark ? Color.white.opacity(0.1) : Color.gray.opacity(0.15))
+
+                        ForEach(Array(viewModel.comparisonCharacters.enumerated()), id: \.offset) { index, char in
+                            let usDesc = viewModel.mappingDescription(for: char, layout: .us)
+                            let jisDesc = viewModel.mappingDescription(for: char, layout: .jis)
+                            let isDifferent = usDesc != jisDesc
+
+                            HStack(spacing: 0) {
+                                Text(String(char))
+                                    .frame(width: 50, alignment: .center)
+                                    .fontWeight(.medium)
+                                    .font(.system(.caption, design: .monospaced))
+                                Text(usDesc)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .font(.system(.caption2, design: .monospaced))
+                                Text(jisDesc)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .font(.system(.caption2, design: .monospaced))
+                                    .foregroundColor(isDifferent ? .orange : .primary)
+                            }
+                            .padding(.vertical, 4)
+                            .padding(.horizontal, 8)
+                            .background(
+                                index % 2 == 0
+                                    ? Color.clear
+                                    : (colorScheme == .dark ? Color.white.opacity(0.05) : Color.gray.opacity(0.05))
+                            )
+                        }
+                    }
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color.gray.opacity(0.2), lineWidth: 1)
+                    )
+                }
+                .frame(maxHeight: 200)
+            }
+
+            Divider()
+
+            // Text typing with layout
+            VStack(alignment: .leading, spacing: 12) {
+                Label("Type with current layout:", systemImage: "keyboard")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+
+                TextField("Enter text with symbols...", text: $viewModel.textToType)
+                    .textFieldStyle(.plain)
+                    .padding(12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(colorScheme == .dark ? Color.white.opacity(0.1) : Color.gray.opacity(0.1))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color.blue.opacity(0.3), lineWidth: 1)
+                    )
+
+                VStack(alignment: .leading, spacing: 12) {
+                    Label("Target Text Field", systemImage: "text.cursor")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+
+                    TextField("Text will appear here...", text: $viewModel.targetTextField)
+                        .textFieldStyle(.plain)
+                        .padding(12)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(viewModel.isTargetFieldFocused
+                                    ? Color.blue.opacity(0.15)
+                                    : (colorScheme == .dark ? Color.white.opacity(0.1) : Color.gray.opacity(0.1)))
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(viewModel.isTargetFieldFocused
+                                    ? Color.blue
+                                    : Color.blue.opacity(0.3), lineWidth: viewModel.isTargetFieldFocused ? 2 : 1)
+                        )
+                        .focused($isTargetFieldFocused)
+                        .onChange(of: viewModel.isTargetFieldFocused) { newValue in
+                            isTargetFieldFocused = newValue
+                        }
+                }
+
+                HStack(spacing: 12) {
+                    Button("Type Custom Text") {
+                        viewModel.typeCustomText()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(viewModel.textToType.isEmpty)
+
+                    Button("Focus & Type") {
+                        viewModel.focusAndTypeInTargetField()
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(viewModel.textToType.isEmpty)
+                }
+
+                Text("Quick Actions")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+
+                HStack(spacing: 12) {
+                    Button("@[]:^~") {
+                        viewModel.typeText("@[]:^~")
+                    }
+                    .buttonStyle(.bordered)
+
+                    Button("{}|\"'`") {
+                        viewModel.typeText("{}|\"'`")
+                    }
+                    .buttonStyle(.bordered)
+
+                    Button("_=+*&\\") {
+                        viewModel.typeText("_=+*&\\")
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+
+            // Status
+            if !viewModel.statusMessage.isEmpty {
+                HStack {
+                    Image(systemName: "info.circle.fill")
+                        .foregroundColor(.blue)
+
+                    Text(viewModel.statusMessage)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .padding(12)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Color.blue.opacity(0.1))
+                )
+            }
+        }
+    }
+}

--- a/Sample/Sample/Features/KeyboardLayout/KeyboardLayoutViewModel.swift
+++ b/Sample/Sample/Features/KeyboardLayout/KeyboardLayoutViewModel.swift
@@ -1,0 +1,103 @@
+//
+//  KeyboardLayoutViewModel.swift
+//  Sample
+//
+//  Created by NakaokaRei on 2025/07/09.
+//
+
+import SwiftUI
+import SwiftAutoGUI
+
+@MainActor
+@Observable
+class KeyboardLayoutViewModel {
+    var selectedLayout: KeyboardLayout = SwiftAutoGUI.currentLayout
+    var textToType: String = ""
+    var typingSpeed: Double = 0.0
+    var statusMessage: String = ""
+    var targetTextField: String = ""
+    var isTargetFieldFocused: Bool = false
+
+    var detectedLayout: KeyboardLayout {
+        KeyboardLayout.detect()
+    }
+
+    /// Character mapping comparison table data
+    var comparisonCharacters: [Character] {
+        let chars: [Character] = [
+            "@", "[", "]", ":", "^", "\"", "&", "'",
+            "(", ")", "=", "~", "`", "+", "*", "_",
+            "\\", "{", "}", "|"
+        ]
+        return chars
+    }
+
+    func mappingDescription(for character: Character, layout: KeyboardLayout) -> String {
+        guard let mapping = layout.mapping(for: character) else {
+            return "-"
+        }
+        let keyName = mapping.key.rawValue
+        if mapping.needsShift {
+            return "Shift + .\(keyName)"
+        }
+        return ".\(keyName)"
+    }
+
+    func applyLayout() {
+        SwiftAutoGUI.currentLayout = selectedLayout
+        statusMessage = "Layout set to \(selectedLayout.rawValue.uppercased())"
+    }
+
+    func resetToAutoDetect() {
+        SwiftAutoGUI.resetLayoutToAutoDetect()
+        selectedLayout = SwiftAutoGUI.currentLayout
+        statusMessage = "Reset to auto-detect (detected: \(detectedLayout.rawValue.uppercased()))"
+    }
+
+    func typeText(_ text: String) {
+        guard !text.isEmpty else {
+            statusMessage = "Please enter some text to type"
+            return
+        }
+
+        statusMessage = "Typing with \(SwiftAutoGUI.currentLayout.rawValue.uppercased()) layout..."
+
+        Task {
+            let actions: [Action] = [
+                .wait(1.0),
+                .write(text, interval: typingSpeed)
+            ]
+            await actions.execute()
+            statusMessage = "Typed: \"\(text)\" with \(SwiftAutoGUI.currentLayout.rawValue.uppercased()) layout"
+        }
+    }
+
+    func typeCustomText() {
+        typeText(textToType)
+    }
+
+    func focusAndTypeInTargetField() {
+        guard !textToType.isEmpty else {
+            statusMessage = "Please enter some text to type"
+            return
+        }
+
+        targetTextField = ""
+        isTargetFieldFocused = true
+        statusMessage = "Focusing target field and typing with \(SwiftAutoGUI.currentLayout.rawValue.uppercased()) layout..."
+
+        Task {
+            let actions: [Action] = [
+                .wait(0.5),
+                .selectAll(),
+                .wait(0.1),
+                .keyDown(.delete),
+                .keyUp(.delete),
+                .wait(0.1),
+                .write(textToType, interval: typingSpeed)
+            ]
+            await actions.execute()
+            statusMessage = "Typed in target field: \"\(textToType)\" with \(SwiftAutoGUI.currentLayout.rawValue.uppercased()) layout"
+        }
+    }
+}

--- a/Sources/SwiftAutoGUI/KeyboardLayout.swift
+++ b/Sources/SwiftAutoGUI/KeyboardLayout.swift
@@ -1,0 +1,188 @@
+import Carbon
+
+/// Represents the result of mapping a character to a physical key, including whether the Shift modifier is needed.
+public struct CharacterKeyMapping: Sendable {
+    public let key: Key
+    public let needsShift: Bool
+
+    public init(key: Key, needsShift: Bool) {
+        self.key = key
+        self.needsShift = needsShift
+    }
+}
+
+/// Represents a keyboard layout for character-to-keycode mapping.
+///
+/// Different keyboard layouts (e.g., US and JIS) map characters to different physical keys.
+/// This enum provides layout-specific character mappings and automatic layout detection.
+///
+/// ## Example
+///
+/// ```swift
+/// // Auto-detect the current keyboard layout
+/// let layout = KeyboardLayout.detect()
+///
+/// // Get the mapping for a character
+/// if let mapping = layout.mapping(for: "@") {
+///     print("Key: \(mapping.key), needsShift: \(mapping.needsShift)")
+/// }
+///
+/// // Manually set a layout
+/// SwiftAutoGUI.currentLayout = .jis
+/// ```
+public enum KeyboardLayout: String, Sendable, CaseIterable {
+    case us
+    case jis
+
+    /// Detects the physical keyboard layout using macOS hardware API.
+    ///
+    /// Uses `KBGetLayoutType(LMGetKbdType())` to determine the physical keyboard type,
+    /// independent of the current IME or input source setting.
+    ///
+    /// - Returns: The detected keyboard layout.
+    public static func detect() -> KeyboardLayout {
+        let layoutType = KBGetLayoutType(Int16(LMGetKbdType()))
+        if layoutType == kKeyboardJIS {
+            return .jis
+        }
+        return .us
+    }
+
+    /// Returns the character-to-key mapping for the given character in this layout.
+    ///
+    /// - Parameter character: The character to map.
+    /// - Returns: A `CharacterKeyMapping` containing the key and whether Shift is needed, or `nil` if unmapped.
+    public func mapping(for character: Character) -> CharacterKeyMapping? {
+        // Common mappings shared across layouts (letters, numbers, whitespace)
+        if let common = Self.commonMapping(for: character) {
+            return common
+        }
+        switch self {
+        case .us:
+            return Self.usMapping(for: character)
+        case .jis:
+            return Self.jisMapping(for: character)
+        }
+    }
+
+    // MARK: - Common mappings (shared across all layouts)
+
+    private static func commonMapping(for character: Character) -> CharacterKeyMapping? {
+        switch character.lowercased() {
+        case "a": return CharacterKeyMapping(key: .a, needsShift: character.isUppercase)
+        case "b": return CharacterKeyMapping(key: .b, needsShift: character.isUppercase)
+        case "c": return CharacterKeyMapping(key: .c, needsShift: character.isUppercase)
+        case "d": return CharacterKeyMapping(key: .d, needsShift: character.isUppercase)
+        case "e": return CharacterKeyMapping(key: .e, needsShift: character.isUppercase)
+        case "f": return CharacterKeyMapping(key: .f, needsShift: character.isUppercase)
+        case "g": return CharacterKeyMapping(key: .g, needsShift: character.isUppercase)
+        case "h": return CharacterKeyMapping(key: .h, needsShift: character.isUppercase)
+        case "i": return CharacterKeyMapping(key: .i, needsShift: character.isUppercase)
+        case "j": return CharacterKeyMapping(key: .j, needsShift: character.isUppercase)
+        case "k": return CharacterKeyMapping(key: .k, needsShift: character.isUppercase)
+        case "l": return CharacterKeyMapping(key: .l, needsShift: character.isUppercase)
+        case "m": return CharacterKeyMapping(key: .m, needsShift: character.isUppercase)
+        case "n": return CharacterKeyMapping(key: .n, needsShift: character.isUppercase)
+        case "o": return CharacterKeyMapping(key: .o, needsShift: character.isUppercase)
+        case "p": return CharacterKeyMapping(key: .p, needsShift: character.isUppercase)
+        case "q": return CharacterKeyMapping(key: .q, needsShift: character.isUppercase)
+        case "r": return CharacterKeyMapping(key: .r, needsShift: character.isUppercase)
+        case "s": return CharacterKeyMapping(key: .s, needsShift: character.isUppercase)
+        case "t": return CharacterKeyMapping(key: .t, needsShift: character.isUppercase)
+        case "u": return CharacterKeyMapping(key: .u, needsShift: character.isUppercase)
+        case "v": return CharacterKeyMapping(key: .v, needsShift: character.isUppercase)
+        case "w": return CharacterKeyMapping(key: .w, needsShift: character.isUppercase)
+        case "x": return CharacterKeyMapping(key: .x, needsShift: character.isUppercase)
+        case "y": return CharacterKeyMapping(key: .y, needsShift: character.isUppercase)
+        case "z": return CharacterKeyMapping(key: .z, needsShift: character.isUppercase)
+        default: break
+        }
+
+        switch character {
+        case "0": return CharacterKeyMapping(key: .zero, needsShift: false)
+        case "1": return CharacterKeyMapping(key: .one, needsShift: false)
+        case "2": return CharacterKeyMapping(key: .two, needsShift: false)
+        case "3": return CharacterKeyMapping(key: .three, needsShift: false)
+        case "4": return CharacterKeyMapping(key: .four, needsShift: false)
+        case "5": return CharacterKeyMapping(key: .five, needsShift: false)
+        case "6": return CharacterKeyMapping(key: .six, needsShift: false)
+        case "7": return CharacterKeyMapping(key: .seven, needsShift: false)
+        case "8": return CharacterKeyMapping(key: .eight, needsShift: false)
+        case "9": return CharacterKeyMapping(key: .nine, needsShift: false)
+        case " ": return CharacterKeyMapping(key: .space, needsShift: false)
+        case "\t": return CharacterKeyMapping(key: .tab, needsShift: false)
+        case "\n": return CharacterKeyMapping(key: .returnKey, needsShift: false)
+        case "\r": return CharacterKeyMapping(key: .returnKey, needsShift: false)
+        case ",": return CharacterKeyMapping(key: .comma, needsShift: false)
+        case ".": return CharacterKeyMapping(key: .period, needsShift: false)
+        case "/": return CharacterKeyMapping(key: .forwardSlash, needsShift: false)
+        case "-": return CharacterKeyMapping(key: .minus, needsShift: false)
+        case "!": return CharacterKeyMapping(key: .one, needsShift: true)
+        case "#": return CharacterKeyMapping(key: .three, needsShift: true)
+        case "$": return CharacterKeyMapping(key: .four, needsShift: true)
+        case "%": return CharacterKeyMapping(key: .five, needsShift: true)
+        case "<": return CharacterKeyMapping(key: .comma, needsShift: true)
+        case ">": return CharacterKeyMapping(key: .period, needsShift: true)
+        case "?": return CharacterKeyMapping(key: .forwardSlash, needsShift: true)
+        default: return nil
+        }
+    }
+
+    // MARK: - US layout mappings
+
+    private static func usMapping(for character: Character) -> CharacterKeyMapping? {
+        switch character {
+        case "=": return CharacterKeyMapping(key: .equals, needsShift: false)
+        case ";": return CharacterKeyMapping(key: .semicolon, needsShift: false)
+        case "'": return CharacterKeyMapping(key: .apostrophe, needsShift: false)
+        case "\\": return CharacterKeyMapping(key: .backslash, needsShift: false)
+        case "`": return CharacterKeyMapping(key: .grave, needsShift: false)
+        case "[": return CharacterKeyMapping(key: .leftBracket, needsShift: false)
+        case "]": return CharacterKeyMapping(key: .rightBracket, needsShift: false)
+        case "@": return CharacterKeyMapping(key: .two, needsShift: true)
+        case "^": return CharacterKeyMapping(key: .six, needsShift: true)
+        case "&": return CharacterKeyMapping(key: .seven, needsShift: true)
+        case "*": return CharacterKeyMapping(key: .eight, needsShift: true)
+        case "(": return CharacterKeyMapping(key: .nine, needsShift: true)
+        case ")": return CharacterKeyMapping(key: .zero, needsShift: true)
+        case "_": return CharacterKeyMapping(key: .minus, needsShift: true)
+        case "+": return CharacterKeyMapping(key: .equals, needsShift: true)
+        case "{": return CharacterKeyMapping(key: .leftBracket, needsShift: true)
+        case "}": return CharacterKeyMapping(key: .rightBracket, needsShift: true)
+        case "|": return CharacterKeyMapping(key: .backslash, needsShift: true)
+        case ":": return CharacterKeyMapping(key: .semicolon, needsShift: true)
+        case "\"": return CharacterKeyMapping(key: .apostrophe, needsShift: true)
+        case "~": return CharacterKeyMapping(key: .grave, needsShift: true)
+        default: return nil
+        }
+    }
+
+    // MARK: - JIS layout mappings
+
+    private static func jisMapping(for character: Character) -> CharacterKeyMapping? {
+        switch character {
+        case ";": return CharacterKeyMapping(key: .semicolon, needsShift: false)
+        case "@": return CharacterKeyMapping(key: .leftBracket, needsShift: false)
+        case "[": return CharacterKeyMapping(key: .rightBracket, needsShift: false)
+        case "]": return CharacterKeyMapping(key: .backslash, needsShift: false)
+        case ":": return CharacterKeyMapping(key: .apostrophe, needsShift: false)
+        case "^": return CharacterKeyMapping(key: .equals, needsShift: false)
+        case "_": return CharacterKeyMapping(key: .jisUnderscore, needsShift: false)
+        case "\\": return CharacterKeyMapping(key: .jisYen, needsShift: false)
+        case "\"": return CharacterKeyMapping(key: .two, needsShift: true)
+        case "&": return CharacterKeyMapping(key: .six, needsShift: true)
+        case "'": return CharacterKeyMapping(key: .seven, needsShift: true)
+        case "(": return CharacterKeyMapping(key: .eight, needsShift: true)
+        case ")": return CharacterKeyMapping(key: .nine, needsShift: true)
+        case "=": return CharacterKeyMapping(key: .minus, needsShift: true)
+        case "~": return CharacterKeyMapping(key: .equals, needsShift: true)
+        case "`": return CharacterKeyMapping(key: .leftBracket, needsShift: true)
+        case "+": return CharacterKeyMapping(key: .semicolon, needsShift: true)
+        case "*": return CharacterKeyMapping(key: .apostrophe, needsShift: true)
+        case "{": return CharacterKeyMapping(key: .rightBracket, needsShift: true)
+        case "}": return CharacterKeyMapping(key: .backslash, needsShift: true)
+        case "|": return CharacterKeyMapping(key: .jisYen, needsShift: true)
+        default: return nil
+        }
+    }
+}

--- a/Sources/SwiftAutoGUI/Keycode.swift
+++ b/Sources/SwiftAutoGUI/Keycode.swift
@@ -133,6 +133,12 @@ public enum Key: String, Sendable {
     case keypad8
     case keypad9
 
+    // JIS-specific keys
+    case jisYen
+    case jisUnderscore
+    case jisEisu
+    case jisKana
+
     // special keycode
     // TODO: add other code
     case soundUp
@@ -262,6 +268,11 @@ public enum Key: String, Sendable {
         case .keypad7        : return 0x59
         case .keypad8        : return 0x5B
         case .keypad9        : return 0x5C
+
+        case .jisYen         : return 0x5D
+        case .jisUnderscore  : return 0x5E
+        case .jisEisu        : return 0x66
+        case .jisKana        : return 0x68
         default              : return nil
         }
     }
@@ -284,11 +295,11 @@ public enum Key: String, Sendable {
         }
     }
     
-    /// Maps a character to its corresponding Key enum case.
+    /// Maps a character to its corresponding Key enum case using the current keyboard layout.
     ///
-    /// This method provides a convenient way to convert characters to Key enum cases
-    /// for use with keyboard input methods. It supports ASCII characters, numbers,
-    /// and common punctuation marks.
+    /// This method uses `SwiftAutoGUI.currentLayout` to determine the correct key mapping.
+    /// Since `currentLayout` is `@MainActor`, this overload is also `@MainActor`.
+    /// For non-MainActor contexts, use ``from(character:layout:)`` instead.
     ///
     /// - Parameter character: The character to map to a Key enum case
     /// - Returns: The corresponding Key enum case, or `nil` if the character is not supported
@@ -296,93 +307,33 @@ public enum Key: String, Sendable {
     /// ## Example
     ///
     /// ```swift
-    /// // Map letter to key
+    /// // Map letter to key (uses current layout)
     /// let aKey = Key.from(character: "a")  // Returns .a
-    /// 
-    /// // Map number to key
-    /// let oneKey = Key.from(character: "1")  // Returns .one
-    /// 
-    /// // Map special character to key
-    /// let spaceKey = Key.from(character: " ")  // Returns .space
-    /// 
-    /// // Unsupported character
-    /// let emojiKey = Key.from(character: "😀")  // Returns nil
     /// ```
+    @MainActor
     public static func from(character: Character) -> Key? {
-        switch character.lowercased() {
-        case "a": return .a
-        case "b": return .b
-        case "c": return .c
-        case "d": return .d
-        case "e": return .e
-        case "f": return .f
-        case "g": return .g
-        case "h": return .h
-        case "i": return .i
-        case "j": return .j
-        case "k": return .k
-        case "l": return .l
-        case "m": return .m
-        case "n": return .n
-        case "o": return .o
-        case "p": return .p
-        case "q": return .q
-        case "r": return .r
-        case "s": return .s
-        case "t": return .t
-        case "u": return .u
-        case "v": return .v
-        case "w": return .w
-        case "x": return .x
-        case "y": return .y
-        case "z": return .z
-        case "0": return .zero
-        case "1": return .one
-        case "2": return .two
-        case "3": return .three
-        case "4": return .four
-        case "5": return .five
-        case "6": return .six
-        case "7": return .seven
-        case "8": return .eight
-        case "9": return .nine
-        case " ": return .space
-        case "\t": return .tab
-        case "\n": return .returnKey
-        case "\r": return .returnKey
-        case "=": return .equals
-        case "-": return .minus
-        case ";": return .semicolon
-        case "'": return .apostrophe
-        case ",": return .comma
-        case ".": return .period
-        case "/": return .forwardSlash
-        case "\\": return .backslash
-        case "`": return .grave
-        case "[": return .leftBracket
-        case "]": return .rightBracket
-        case "!": return .one      // Shift+1
-        case "@": return .two      // Shift+2
-        case "#": return .three    // Shift+3
-        case "$": return .four     // Shift+4
-        case "%": return .five     // Shift+5
-        case "^": return .six      // Shift+6
-        case "&": return .seven    // Shift+7
-        case "*": return .eight    // Shift+8
-        case "(": return .nine     // Shift+9
-        case ")": return .zero     // Shift+0
-        case "_": return .minus    // Shift+-
-        case "+": return .equals   // Shift+=
-        case "{": return .leftBracket  // Shift+[
-        case "}": return .rightBracket // Shift+]
-        case "|": return .backslash    // Shift+\
-        case ":": return .semicolon    // Shift+;
-        case "\"": return .apostrophe  // Shift+'
-        case "<": return .comma        // Shift+,
-        case ">": return .period       // Shift+.
-        case "?": return .forwardSlash // Shift+/
-        case "~": return .grave        // Shift+`
-        default: return nil
-        }
+        return from(character: character, layout: SwiftAutoGUI.currentLayout)
+    }
+
+    /// Maps a character to its corresponding Key enum case for the specified keyboard layout.
+    ///
+    /// This method provides a convenient way to convert characters to Key enum cases
+    /// for use with keyboard input methods. It supports ASCII characters, numbers,
+    /// and common punctuation marks. The mapping varies by keyboard layout.
+    ///
+    /// - Parameters:
+    ///   - character: The character to map to a Key enum case
+    ///   - layout: The keyboard layout to use for mapping
+    /// - Returns: The corresponding Key enum case, or `nil` if the character is not supported
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// // Map with explicit layout
+    /// let key = Key.from(character: "@", layout: .jis)  // Returns .leftBracket
+    /// let key2 = Key.from(character: "@", layout: .us)  // Returns .two
+    /// ```
+    public static func from(character: Character, layout: KeyboardLayout) -> Key? {
+        return layout.mapping(for: character)?.key
     }
 }

--- a/Tests/SwiftAutoGUITests/KeyboardTests.swift
+++ b/Tests/SwiftAutoGUITests/KeyboardTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @Suite("Keyboard Tests")
 struct KeyboardTests {
-    
+
     @Test("Key enum normal keycodes mapping")
     func testNormalKeycodes() {
         // Test some common keys have correct keycodes
@@ -13,23 +13,23 @@ struct KeyboardTests {
         #expect(Key.returnKey.normalKeycode == 0x24)
         #expect(Key.escape.normalKeycode == 0x35)
         #expect(Key.tab.normalKeycode == 0x30)
-        
+
         // Test number keys
         #expect(Key.zero.normalKeycode == 0x1D)
         #expect(Key.one.normalKeycode == 0x12)
         #expect(Key.nine.normalKeycode == 0x19)
-        
+
         // Test function keys
         #expect(Key.f1.normalKeycode == 0x7A)
         #expect(Key.f12.normalKeycode == 0x6F)
-        
+
         // Test arrow keys
         #expect(Key.leftArrow.normalKeycode == 0x7B)
         #expect(Key.rightArrow.normalKeycode == 0x7C)
         #expect(Key.downArrow.normalKeycode == 0x7D)
         #expect(Key.upArrow.normalKeycode == 0x7E)
     }
-    
+
     @Test("Key enum special keycodes mapping")
     func testSpecialKeycodes() {
         // Test special keys return nil for normalKeycode
@@ -38,7 +38,7 @@ struct KeyboardTests {
         #expect(Key.brightnessUp.normalKeycode == nil)
         #expect(Key.brightnessDown.normalKeycode == nil)
         #expect(Key.numLock.normalKeycode == nil)
-        
+
         // Test special keys have special keycodes
         #expect(Key.soundUp.specialKeycode != nil)
         #expect(Key.soundDown.specialKeycode != nil)
@@ -46,7 +46,21 @@ struct KeyboardTests {
         #expect(Key.brightnessDown.specialKeycode != nil)
         #expect(Key.numLock.specialKeycode != nil)
     }
-    
+
+    @Test("JIS key keycodes")
+    func testJISKeycodes() {
+        #expect(Key.jisYen.normalKeycode == 0x5D)
+        #expect(Key.jisUnderscore.normalKeycode == 0x5E)
+        #expect(Key.jisEisu.normalKeycode == 0x66)
+        #expect(Key.jisKana.normalKeycode == 0x68)
+
+        // JIS keys are normal keys, not special keys
+        #expect(Key.jisYen.specialKeycode == nil)
+        #expect(Key.jisUnderscore.specialKeycode == nil)
+        #expect(Key.jisEisu.specialKeycode == nil)
+        #expect(Key.jisKana.specialKeycode == nil)
+    }
+
     @Test("Key enum comprehensive coverage")
     func testAllKeysHaveKeycode() {
         // Test that every key has either a normal or special keycode
@@ -68,80 +82,301 @@ struct KeyboardTests {
             .keypadDivide, .keypadEnter, .keypadMinus, .keypadEquals,
             .keypad0, .keypad1, .keypad2, .keypad3, .keypad4,
             .keypad5, .keypad6, .keypad7, .keypad8, .keypad9,
+            .jisYen, .jisUnderscore, .jisEisu, .jisKana,
             .soundUp, .soundDown, .brightnessUp, .brightnessDown, .numLock
         ]
-        
+
         for key in allKeys {
             let hasKeycode = (key.normalKeycode != nil) || (key.specialKeycode != nil)
             #expect(hasKeycode, "Key.\(key.rawValue) should have either normal or special keycode")
         }
     }
-    
+
+    @Test("US layout character mapping")
+    func testUSLayoutMapping() {
+        let layout = KeyboardLayout.us
+
+        // Letters
+        let aMapping = layout.mapping(for: "a")
+        #expect(aMapping?.key == .a)
+        #expect(aMapping?.needsShift == false)
+
+        let upperA = layout.mapping(for: "A")
+        #expect(upperA?.key == .a)
+        #expect(upperA?.needsShift == true)
+
+        // Numbers
+        #expect(layout.mapping(for: "0")?.key == .zero)
+        #expect(layout.mapping(for: "0")?.needsShift == false)
+
+        // US-specific symbol mappings
+        #expect(layout.mapping(for: "@")?.key == .two)
+        #expect(layout.mapping(for: "@")?.needsShift == true)
+
+        #expect(layout.mapping(for: "[")?.key == .leftBracket)
+        #expect(layout.mapping(for: "[")?.needsShift == false)
+
+        #expect(layout.mapping(for: "]")?.key == .rightBracket)
+        #expect(layout.mapping(for: "]")?.needsShift == false)
+
+        #expect(layout.mapping(for: ":")?.key == .semicolon)
+        #expect(layout.mapping(for: ":")?.needsShift == true)
+
+        #expect(layout.mapping(for: "^")?.key == .six)
+        #expect(layout.mapping(for: "^")?.needsShift == true)
+
+        #expect(layout.mapping(for: "\"")?.key == .apostrophe)
+        #expect(layout.mapping(for: "\"")?.needsShift == true)
+
+        #expect(layout.mapping(for: "&")?.key == .seven)
+        #expect(layout.mapping(for: "&")?.needsShift == true)
+
+        #expect(layout.mapping(for: "'")?.key == .apostrophe)
+        #expect(layout.mapping(for: "'")?.needsShift == false)
+
+        #expect(layout.mapping(for: "(")?.key == .nine)
+        #expect(layout.mapping(for: "(")?.needsShift == true)
+
+        #expect(layout.mapping(for: ")")?.key == .zero)
+        #expect(layout.mapping(for: ")")?.needsShift == true)
+
+        #expect(layout.mapping(for: "=")?.key == .equals)
+        #expect(layout.mapping(for: "=")?.needsShift == false)
+
+        #expect(layout.mapping(for: "~")?.key == .grave)
+        #expect(layout.mapping(for: "~")?.needsShift == true)
+
+        #expect(layout.mapping(for: "`")?.key == .grave)
+        #expect(layout.mapping(for: "`")?.needsShift == false)
+
+        #expect(layout.mapping(for: "+")?.key == .equals)
+        #expect(layout.mapping(for: "+")?.needsShift == true)
+
+        #expect(layout.mapping(for: "*")?.key == .eight)
+        #expect(layout.mapping(for: "*")?.needsShift == true)
+
+        #expect(layout.mapping(for: "_")?.key == .minus)
+        #expect(layout.mapping(for: "_")?.needsShift == true)
+
+        #expect(layout.mapping(for: "\\")?.key == .backslash)
+        #expect(layout.mapping(for: "\\")?.needsShift == false)
+
+        #expect(layout.mapping(for: "{")?.key == .leftBracket)
+        #expect(layout.mapping(for: "{")?.needsShift == true)
+
+        #expect(layout.mapping(for: "}")?.key == .rightBracket)
+        #expect(layout.mapping(for: "}")?.needsShift == true)
+
+        #expect(layout.mapping(for: "|")?.key == .backslash)
+        #expect(layout.mapping(for: "|")?.needsShift == true)
+
+        // Unsupported characters
+        #expect(layout.mapping(for: "😀") == nil)
+    }
+
+    @Test("JIS layout character mapping")
+    func testJISLayoutMapping() {
+        let layout = KeyboardLayout.jis
+
+        // Letters work the same way
+        let aMapping = layout.mapping(for: "a")
+        #expect(aMapping?.key == .a)
+        #expect(aMapping?.needsShift == false)
+
+        // JIS-specific mappings that differ from US
+        #expect(layout.mapping(for: "@")?.key == .leftBracket)
+        #expect(layout.mapping(for: "@")?.needsShift == false)
+
+        #expect(layout.mapping(for: "[")?.key == .rightBracket)
+        #expect(layout.mapping(for: "[")?.needsShift == false)
+
+        #expect(layout.mapping(for: "]")?.key == .backslash)
+        #expect(layout.mapping(for: "]")?.needsShift == false)
+
+        #expect(layout.mapping(for: ":")?.key == .apostrophe)
+        #expect(layout.mapping(for: ":")?.needsShift == false)
+
+        #expect(layout.mapping(for: "^")?.key == .equals)
+        #expect(layout.mapping(for: "^")?.needsShift == false)
+
+        #expect(layout.mapping(for: "\"")?.key == .two)
+        #expect(layout.mapping(for: "\"")?.needsShift == true)
+
+        #expect(layout.mapping(for: "&")?.key == .six)
+        #expect(layout.mapping(for: "&")?.needsShift == true)
+
+        #expect(layout.mapping(for: "'")?.key == .seven)
+        #expect(layout.mapping(for: "'")?.needsShift == true)
+
+        #expect(layout.mapping(for: "(")?.key == .eight)
+        #expect(layout.mapping(for: "(")?.needsShift == true)
+
+        #expect(layout.mapping(for: ")")?.key == .nine)
+        #expect(layout.mapping(for: ")")?.needsShift == true)
+
+        #expect(layout.mapping(for: "=")?.key == .minus)
+        #expect(layout.mapping(for: "=")?.needsShift == true)
+
+        #expect(layout.mapping(for: "~")?.key == .equals)
+        #expect(layout.mapping(for: "~")?.needsShift == true)
+
+        #expect(layout.mapping(for: "`")?.key == .leftBracket)
+        #expect(layout.mapping(for: "`")?.needsShift == true)
+
+        #expect(layout.mapping(for: "+")?.key == .semicolon)
+        #expect(layout.mapping(for: "+")?.needsShift == true)
+
+        #expect(layout.mapping(for: "*")?.key == .apostrophe)
+        #expect(layout.mapping(for: "*")?.needsShift == true)
+
+        #expect(layout.mapping(for: "_")?.key == .jisUnderscore)
+        #expect(layout.mapping(for: "_")?.needsShift == false)
+
+        #expect(layout.mapping(for: "\\")?.key == .jisYen)
+        #expect(layout.mapping(for: "\\")?.needsShift == false)
+
+        #expect(layout.mapping(for: "{")?.key == .rightBracket)
+        #expect(layout.mapping(for: "{")?.needsShift == true)
+
+        #expect(layout.mapping(for: "}")?.key == .backslash)
+        #expect(layout.mapping(for: "}")?.needsShift == true)
+
+        #expect(layout.mapping(for: "|")?.key == .jisYen)
+        #expect(layout.mapping(for: "|")?.needsShift == true)
+    }
+
+    @Test("Layout override")
+    @MainActor
+    func testLayoutOverride() {
+        // Set to JIS
+        SwiftAutoGUI.currentLayout = .jis
+        #expect(SwiftAutoGUI.currentLayout == .jis)
+
+        // Key.from(character:) should use JIS layout
+        #expect(Key.from(character: "@") == .leftBracket)
+        #expect(Key.from(character: "[") == .rightBracket)
+
+        // Set to US
+        SwiftAutoGUI.currentLayout = .us
+        #expect(SwiftAutoGUI.currentLayout == .us)
+
+        // Key.from(character:) should use US layout
+        #expect(Key.from(character: "@") == .two)
+        #expect(Key.from(character: "[") == .leftBracket)
+
+        // Reset to auto-detect
+        SwiftAutoGUI.resetLayoutToAutoDetect()
+    }
+
+    @Test("Key.from(character:layout:) backward compatibility")
+    func testFromCharacterWithLayout() {
+        // The layout-explicit version works from any context (not @MainActor)
+        #expect(Key.from(character: "a", layout: .us) == .a)
+        #expect(Key.from(character: "a", layout: .jis) == .a)
+
+        // Layout-specific differences
+        #expect(Key.from(character: "@", layout: .us) == .two)
+        #expect(Key.from(character: "@", layout: .jis) == .leftBracket)
+
+        #expect(Key.from(character: "_", layout: .us) == .minus)
+        #expect(Key.from(character: "_", layout: .jis) == .jisUnderscore)
+
+        #expect(Key.from(character: "\\", layout: .us) == .backslash)
+        #expect(Key.from(character: "\\", layout: .jis) == .jisYen)
+
+        // Unsupported character returns nil for both layouts
+        #expect(Key.from(character: "😀", layout: .us) == nil)
+        #expect(Key.from(character: "😀", layout: .jis) == nil)
+    }
+
+    @Test("KeyboardLayout.detect returns a valid layout")
+    func testLayoutDetection() {
+        let detected = KeyboardLayout.detect()
+        #expect(KeyboardLayout.allCases.contains(detected))
+    }
+
+    @Test("Common mappings are consistent across layouts")
+    func testCommonMappings() {
+        let commonChars: [Character] = [
+            "a", "z", "0", "9", " ", "\t", "\n",
+            ",", ".", "/", "-", "!", "#", "$", "%", "<", ">", "?"
+        ]
+
+        for char in commonChars {
+            let usMapping = KeyboardLayout.us.mapping(for: char)
+            let jisMapping = KeyboardLayout.jis.mapping(for: char)
+            #expect(usMapping?.key == jisMapping?.key,
+                    "Character '\(char)' should map to the same key on US and JIS")
+            #expect(usMapping?.needsShift == jisMapping?.needsShift,
+                    "Character '\(char)' should have the same shift requirement on US and JIS")
+        }
+    }
+
     @Test("Keyboard event functions basic test")
     func testKeyboardEventFunctions() async throws {
         // Note: These tests only verify that the functions can be called without crashing
         // Actual key event generation requires accessibility permissions and cannot be
         // fully tested in unit tests
-        
+
         // Test single key press
         await SwiftAutoGUI.keyDown(.a)
         await SwiftAutoGUI.keyUp(.a)
-        
+
         // Test special key
         await SwiftAutoGUI.keyDown(.soundUp)
         await SwiftAutoGUI.keyUp(.soundUp)
-        
+
         // Test key shortcut
         await SwiftAutoGUI.sendKeyShortcut([.command, .c])
-        
+
         // If we get here without crashing, the basic structure is working
         #expect(true)
     }
-    
+
     @Test("Write function basic test")
     func testWriteFunction() async {
         // Note: This test only verifies that the write function can be called without crashing
         // Actual text typing requires accessibility permissions and cannot be fully tested in unit tests
-        
+
         // Test basic text writing
         await SwiftAutoGUI.write("Hello")
-        
+
         // Test with special characters
         await SwiftAutoGUI.write("Hello, World!")
-        
+
         // Test with numbers
         await SwiftAutoGUI.write("123")
-        
+
         // Test with interval (should not crash)
         await SwiftAutoGUI.write("Test", interval: 0.01)
-        
+
         // Test empty string
         await SwiftAutoGUI.write("")
-        
+
         // Test with mixed case
         await SwiftAutoGUI.write("MixedCase")
-        
+
         // If we get here without crashing, the basic structure is working
         #expect(true)
     }
-    
+
     @Test("Character to key mapping")
     func testCharacterToKeyMapping() async {
         // Test that basic characters map correctly
         // Note: These are private functions, so we test indirectly through write
-        
+
         // Test that unsupported characters are handled gracefully
         await SwiftAutoGUI.write("🎉") // Should not crash on emoji
-        
+
         // Test common punctuation
         await SwiftAutoGUI.write("!@#$%^&*()")
         await SwiftAutoGUI.write("{}[]|:\"<>?~")
-        
+
         // Test basic ASCII characters
         await SwiftAutoGUI.write("abcdefghijklmnopqrstuvwxyz")
         await SwiftAutoGUI.write("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
         await SwiftAutoGUI.write("0123456789")
-        
+
         // If we get here without crashing, character mapping works
         #expect(true)
     }


### PR DESCRIPTION
## Summary

- Add JIS keyboard layout support with physical keyboard auto-detection via `KBGetLayoutType`
- US/JIS layouts map symbols (`@`, `[`, `:`, `_`, etc.) to the correct physical keys automatically
- Add `currentLayout` API for manual override and `KeyboardLayout.detect()` for programmatic detection
- Add JIS-specific keys (`.jisYen`, `.jisUnderscore`, `.jisEisu`, `.jisKana`) to `Key` enum
- Add keyboard layout demo tab to sample app with mapping comparison table
- Update README to document keyboard layout support

## Test plan

- [x] `swift build` passes
- [x] `swift test` passes (82 tests)
- [ ] Verify auto-detection returns `.jis` on JIS keyboard hardware
- [ ] Verify auto-detection returns `.us` on US keyboard hardware
- [ ] Verify `write()` types correct symbols on JIS keyboard
- [ ] Verify sample app keyboard layout demo tab works

🤖 Generated with [Claude Code](https://claude.com/claude-code)