### PR TITLE
Add sagui CLI tool for command-line GUI automation

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3d18af739539d1ea3f897504ab0a6993a4ba9a5e1e24dc4e3b14585e1245dbac",
+  "originHash" : "b1bf03614c0b354ace1585bcf1e322743720e629f80221b3b78deee883dd0a7b",
   "pins" : [
     {
       "identity" : "openai",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "9b5943c3095350dedfb2bebd276f05643b7045d1",
         "version" : "4.11.0"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,10 +13,14 @@ let package = Package(
         .library(
             name: "SwiftAutoGUI",
             targets: ["SwiftAutoGUI"]),
+        .executable(
+            name: "sagui",
+            targets: ["sagui"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
         .package(url: "https://github.com/yeatse/opencv-spm.git", from: "4.9.0"),
         .package(url: "https://github.com/MacPaw/OpenAI.git", from: "0.4.7")
     ],
@@ -28,6 +32,12 @@ let package = Package(
             dependencies: [
                 .product(name: "OpenCV", package: "opencv-spm"),
                 .product(name: "OpenAI", package: "OpenAI")
+            ]),
+        .executableTarget(
+            name: "sagui",
+            dependencies: [
+                "SwiftAutoGUI",
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ]),
         .testTarget(
             name: "SwiftAutoGUITests",

--- a/Sample/Sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Sample/Sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "52438d581aa320088337604a89749f717f4aaf1c2e2a9dabd917925b87d0c35d",
+  "originHash" : "b1bf03614c0b354ace1585bcf1e322743720e629f80221b3b78deee883dd0a7b",
   "pins" : [
     {
       "identity" : "openai",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "9b5943c3095350dedfb2bebd276f05643b7045d1",
         "version" : "4.11.0"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
       }
     },
     {

--- a/Sources/sagui/KeyCommand.swift
+++ b/Sources/sagui/KeyCommand.swift
@@ -1,0 +1,81 @@
+import ArgumentParser
+import SwiftAutoGUI
+
+struct KeyCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "key",
+        abstract: "Keyboard control commands.",
+        subcommands: [Shortcut.self, Down.self, Up.self, TypeText.self]
+    )
+}
+
+extension KeyCommand {
+    struct Shortcut: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Send a keyboard shortcut (e.g., sagui key shortcut command c)."
+        )
+
+        @Argument(help: "Key names to press together (e.g., command shift a).")
+        var keys: [String]
+
+        func run() async throws {
+            let mapped = try keys.map { name -> Key in
+                guard let key = Key(rawValue: name) else {
+                    throw ValidationError("Unknown key: '\(name)'. Examples: a, command, shift, leftArrow, space, f1")
+                }
+                return key
+            }
+            await SwiftAutoGUI.sendKeyShortcut(mapped)
+        }
+    }
+
+    struct Down: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Press a key down without releasing."
+        )
+
+        @Argument(help: "Key name (e.g., command, shift, a).")
+        var key: String
+
+        func run() async throws {
+            guard let k = Key(rawValue: key) else {
+                throw ValidationError("Unknown key: '\(key)'. Examples: a, command, shift, leftArrow, space, f1")
+            }
+            await SwiftAutoGUI.keyDown(k)
+        }
+    }
+
+    struct Up: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Release a pressed key."
+        )
+
+        @Argument(help: "Key name (e.g., command, shift, a).")
+        var key: String
+
+        func run() async throws {
+            guard let k = Key(rawValue: key) else {
+                throw ValidationError("Unknown key: '\(key)'. Examples: a, command, shift, leftArrow, space, f1")
+            }
+            await SwiftAutoGUI.keyUp(k)
+        }
+    }
+
+    struct TypeText: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "type",
+            abstract: "Type a text string."
+        )
+
+        @Argument(help: "The text to type.")
+        var text: String
+
+        @Option(help: "Delay between keystrokes in seconds.")
+        var interval: Double = 0
+
+        @MainActor
+        func run() async throws {
+            await SwiftAutoGUI.write(text, interval: interval)
+        }
+    }
+}

--- a/Sources/sagui/MouseCommand.swift
+++ b/Sources/sagui/MouseCommand.swift
@@ -1,0 +1,140 @@
+import ArgumentParser
+import SwiftAutoGUI
+import CoreGraphics
+
+struct MouseCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "mouse",
+        abstract: "Mouse control commands.",
+        subcommands: [Position.self, Move.self, MoveRelative.self, Click.self, Drag.self, Scroll.self]
+    )
+}
+
+extension MouseCommand {
+    struct Position: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Print the current mouse cursor position."
+        )
+
+        func run() async throws {
+            let pos = SwiftAutoGUI.position()
+            print("\(pos.x) \(pos.y)")
+        }
+    }
+
+    struct Move: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Move the mouse to an absolute position."
+        )
+
+        @Option(help: "X coordinate.")
+        var x: Double
+
+        @Option(help: "Y coordinate.")
+        var y: Double
+
+        func run() async throws {
+            await SwiftAutoGUI.move(to: CGPoint(x: x, y: y), duration: 0)
+        }
+    }
+
+    struct MoveRelative: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "move-relative",
+            abstract: "Move the mouse relative to its current position."
+        )
+
+        @Option(help: "Horizontal distance (positive = right).")
+        var dx: Double
+
+        @Option(help: "Vertical distance (positive = down).")
+        var dy: Double
+
+        func run() async throws {
+            await SwiftAutoGUI.moveMouse(dx: dx, dy: dy)
+        }
+    }
+
+    struct Click: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Click the mouse at the current position."
+        )
+
+        @Flag(help: "Use right mouse button.")
+        var right = false
+
+        @Flag(name: .long, help: "Perform a double-click.")
+        var double = false
+
+        @Flag(name: .long, help: "Perform a triple-click.")
+        var triple = false
+
+        func run() async throws {
+            let button: SwiftAutoGUI.MouseButton = right ? .right : .left
+
+            if triple {
+                await SwiftAutoGUI.tripleClick(button: button)
+            } else if double {
+                await SwiftAutoGUI.doubleClick(button: button)
+            } else {
+                if right {
+                    SwiftAutoGUI.rightClick()
+                } else {
+                    SwiftAutoGUI.leftClick()
+                }
+            }
+        }
+    }
+
+    struct Drag: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Drag the mouse from one position to another."
+        )
+
+        @Option(name: .customLong("from-x"), help: "Start X coordinate.")
+        var fromX: Double
+
+        @Option(name: .customLong("from-y"), help: "Start Y coordinate.")
+        var fromY: Double
+
+        @Option(name: .customLong("to-x"), help: "End X coordinate.")
+        var toX: Double
+
+        @Option(name: .customLong("to-y"), help: "End Y coordinate.")
+        var toY: Double
+
+        func run() async throws {
+            SwiftAutoGUI.leftDragged(
+                to: CGPoint(x: toX, y: toY),
+                from: CGPoint(x: fromX, y: fromY)
+            )
+        }
+    }
+
+    struct Scroll: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Scroll the mouse wheel."
+        )
+
+        @Option(help: "Vertical scroll clicks (positive = up, negative = down).")
+        var vertical: Int?
+
+        @Option(help: "Horizontal scroll clicks (positive = left, negative = right).")
+        var horizontal: Int?
+
+        func validate() throws {
+            if vertical == nil && horizontal == nil {
+                throw ValidationError("Specify at least one of --vertical or --horizontal.")
+            }
+        }
+
+        func run() async throws {
+            if let v = vertical {
+                SwiftAutoGUI.vscroll(clicks: v)
+            }
+            if let h = horizontal {
+                SwiftAutoGUI.hscroll(clicks: h)
+            }
+        }
+    }
+}

--- a/Sources/sagui/SaguiCLI.swift
+++ b/Sources/sagui/SaguiCLI.swift
@@ -1,0 +1,11 @@
+import ArgumentParser
+
+@main
+struct SaguiCLI: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "sagui",
+        abstract: "Control mouse and keyboard on macOS from the command line.",
+        discussion: "Requires accessibility permissions in System Settings > Privacy & Security > Accessibility.",
+        subcommands: [KeyCommand.self, MouseCommand.self, ScreenCommand.self]
+    )
+}

--- a/Sources/sagui/ScreenCommand.swift
+++ b/Sources/sagui/ScreenCommand.swift
@@ -1,0 +1,123 @@
+import ArgumentParser
+import SwiftAutoGUI
+import AppKit
+
+struct ScreenCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "screen",
+        abstract: "Screen information and capture commands.",
+        subcommands: [Size.self, Screenshot.self, Pixel.self, Locate.self, LocateCenter.self]
+    )
+}
+
+extension ScreenCommand {
+    struct Size: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Print the main screen dimensions."
+        )
+
+        func run() async throws {
+            let (width, height) = SwiftAutoGUI.size()
+            print("\(width) \(height)")
+        }
+    }
+
+    struct Screenshot: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Take a screenshot and save to file."
+        )
+
+        @Option(help: "Output file path (default: screenshot.png).")
+        var output: String = "screenshot.png"
+
+        @Option(help: "Capture region as x,y,width,height (e.g., 0,0,500,500).")
+        var region: String?
+
+        func run() async throws {
+            var rect: CGRect?
+            if let region {
+                let parts = region.split(separator: ",").compactMap { Double($0) }
+                guard parts.count == 4 else {
+                    throw ValidationError("Region must be x,y,width,height (e.g., 0,0,500,500).")
+                }
+                rect = CGRect(x: parts[0], y: parts[1], width: parts[2], height: parts[3])
+            }
+
+            let success = try await SwiftAutoGUI.screenshot(imageFilename: output, region: rect)
+            if success {
+                print(output)
+            } else {
+                throw RuntimeError("Failed to save screenshot.")
+            }
+        }
+    }
+
+    struct Pixel: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Get the color of a pixel at given coordinates."
+        )
+
+        @Option(help: "X coordinate.")
+        var x: Int
+
+        @Option(help: "Y coordinate.")
+        var y: Int
+
+        func run() async throws {
+            guard let color = try await SwiftAutoGUI.pixel(x: x, y: y) else {
+                throw RuntimeError("Failed to get pixel color.")
+            }
+            let r = Int(color.redComponent * 255)
+            let g = Int(color.greenComponent * 255)
+            let b = Int(color.blueComponent * 255)
+            let a = Int(color.alphaComponent * 255)
+            print("\(r) \(g) \(b) \(a)")
+        }
+    }
+
+    struct Locate: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Find an image on screen and print its position."
+        )
+
+        @Argument(help: "Path to the image file to search for.")
+        var imagePath: String
+
+        @Option(help: "Matching confidence threshold (0.0-1.0).")
+        var confidence: Double?
+
+        func run() async throws {
+            guard let rect = try await SwiftAutoGUI.locateOnScreen(imagePath, confidence: confidence) else {
+                throw RuntimeError("Image not found on screen.")
+            }
+            print("\(rect.origin.x) \(rect.origin.y) \(rect.width) \(rect.height)")
+        }
+    }
+
+    struct LocateCenter: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "locate-center",
+            abstract: "Find an image on screen and print its center point."
+        )
+
+        @Argument(help: "Path to the image file to search for.")
+        var imagePath: String
+
+        @Option(help: "Matching confidence threshold (0.0-1.0).")
+        var confidence: Double?
+
+        func run() async throws {
+            guard let point = try await SwiftAutoGUI.locateCenterOnScreen(imagePath, confidence: confidence) else {
+                throw RuntimeError("Image not found on screen.")
+            }
+            print("\(point.x) \(point.y)")
+        }
+    }
+}
+
+struct RuntimeError: Error, CustomStringConvertible {
+    let description: String
+    init(_ description: String) {
+        self.description = description
+    }
+}


### PR DESCRIPTION
## Summary
- Add new `sagui` CLI executable that exposes SwiftAutoGUI's core functionality from the command line
- Subcommands: `key` (shortcut/down/up/type), `mouse` (position/move/click/drag/scroll), `screen` (size/screenshot/pixel/locate/locate-center)
- Uses swift-argument-parser for CLI argument parsing

## Usage Examples
```bash
sagui key shortcut command c        # Send Cmd+C
sagui key type "Hello World"        # Type text
sagui mouse position                # Print cursor position
sagui mouse move --x 100 --y 200   # Move cursor
sagui mouse click --double          # Double-click
sagui screen size                   # Print screen dimensions
sagui screen screenshot --output out.png
```

## Test plan
- [x] `swift build` compiles without errors
- [x] `sagui --help` shows command tree
- [x] `sagui screen size` prints screen dimensions
- [x] `sagui mouse position` prints cursor position
- [x] All 82 existing tests pass

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)