### PR TITLE
feat: add Agent feature with vision-based autonomous loop

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "b1bf03614c0b354ace1585bcf1e322743720e629f80221b3b78deee883dd0a7b",
+  "originHash" : "f97fa09540c9bcffbfe5b9daf990cda230da86371b1b309a41dd77bddd1dac46",
   "pins" : [
-    {
-      "identity" : "openai",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MacPaw/OpenAI.git",
-      "state" : {
-        "revision" : "28884fcfb15946b119b6eb3498e5a900c1d8d595",
-        "version" : "0.4.7"
-      }
-    },
     {
       "identity" : "opencv-spm",
       "kind" : "remoteSourceControl",
@@ -44,24 +35,6 @@
       "state" : {
         "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
         "version" : "1.0.0"
-      }
-    },
-    {
-      "identity" : "swift-http-types",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-types",
-      "state" : {
-        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
-        "version" : "1.5.1"
-      }
-    },
-    {
-      "identity" : "swift-openapi-runtime",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-openapi-runtime",
-      "state" : {
-        "revision" : "7cdf33371bf89b23b9cf4fd3ce8d3c825c28fbe8",
-        "version" : "1.9.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -21,8 +21,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
-        .package(url: "https://github.com/yeatse/opencv-spm.git", from: "4.9.0"),
-        .package(url: "https://github.com/MacPaw/OpenAI.git", from: "0.4.7")
+        .package(url: "https://github.com/yeatse/opencv-spm.git", from: "4.9.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -30,8 +29,7 @@ let package = Package(
         .target(
             name: "SwiftAutoGUI",
             dependencies: [
-                .product(name: "OpenCV", package: "opencv-spm"),
-                .product(name: "OpenAI", package: "OpenAI")
+                .product(name: "OpenCV", package: "opencv-spm")
             ]),
         .executableTarget(
             name: "sagui",

--- a/README.md
+++ b/README.md
@@ -410,6 +410,66 @@ let actions = try await backend.generateActionSequence(from: "click at 100, 200"
 
 > **Important**: Never hard-code API keys in source code. Use environment variables or secure storage mechanisms.
 
+## AI Agent (Autonomous Loop)
+
+SwiftAutoGUI includes an Agent that can autonomously observe the screen, reason about what it sees, and execute actions in a loop until a goal is achieved. This follows the **ReAct** (Observe → Think → Act) pattern using a vision-capable LLM.
+
+### Basic Usage
+
+```swift
+import SwiftAutoGUI
+
+let backend = OpenAIVisionBackend(apiKey: "sk-...", model: "gpt-4o")
+let agent = Agent(backend: backend, maxIterations: 15)
+
+let result = try await agent.run(goal: "Open Safari and search for Swift")
+print("Completed: \(result.completed), Steps: \(result.iterationsUsed)")
+```
+
+### With Step Callback
+
+```swift
+let result = try await agent.run(goal: "Click the Settings icon") { step in
+    print("Reasoning: \(step.reasoning)")
+    print("Actions: \(step.actions)")
+}
+```
+
+### Custom Backend
+
+You can implement the `VisionActionGenerating` protocol to use any vision-capable LLM:
+
+```swift
+struct MyBackend: VisionActionGenerating {
+    var isAvailable: Bool { true }
+    var unavailableReason: String? { nil }
+    
+    func generateActions(
+        goal: String,
+        screenshot: Data,
+        screenSize: CGSize,
+        history: [AgentStep]
+    ) async throws -> AgentResponse {
+        // Send screenshot to your LLM and parse the response
+        ...
+    }
+}
+```
+
+### CLI
+
+```bash
+# Run the agent from the command line
+sagui agent "Open Safari and search for Swift" --api-key sk-...
+
+# With options
+sagui agent "Click the trash icon" --model gpt-4o --max-iterations 15 --delay 2.0
+
+# Using environment variable for the API key
+export OPENAI_API_KEY=sk-...
+sagui agent "Open Terminal"
+```
+
 ## AppleScript Execution
 SwiftAutoGUI can execute AppleScript code to control macOS applications and system features.
 

--- a/Sample/Sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Sample/Sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "b1bf03614c0b354ace1585bcf1e322743720e629f80221b3b78deee883dd0a7b",
+  "originHash" : "f97fa09540c9bcffbfe5b9daf990cda230da86371b1b309a41dd77bddd1dac46",
   "pins" : [
-    {
-      "identity" : "openai",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MacPaw/OpenAI.git",
-      "state" : {
-        "revision" : "28884fcfb15946b119b6eb3498e5a900c1d8d595",
-        "version" : "0.4.7"
-      }
-    },
     {
       "identity" : "opencv-spm",
       "kind" : "remoteSourceControl",
@@ -44,24 +35,6 @@
       "state" : {
         "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
         "version" : "1.0.0"
-      }
-    },
-    {
-      "identity" : "swift-http-types",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-http-types",
-      "state" : {
-        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
-        "version" : "1.5.1"
-      }
-    },
-    {
-      "identity" : "swift-openapi-runtime",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-openapi-runtime",
-      "state" : {
-        "revision" : "7cdf33371bf89b23b9cf4fd3ce8d3c825c28fbe8",
-        "version" : "1.9.0"
       }
     }
   ],

--- a/Sample/Sample/Common/DemoTab.swift
+++ b/Sample/Sample/Common/DemoTab.swift
@@ -20,6 +20,7 @@ enum DemoTab: String, CaseIterable {
     case appleScript
     case actions
     case aiGeneration
+    case agent
 
     var title: String {
         switch self {
@@ -35,6 +36,7 @@ enum DemoTab: String, CaseIterable {
         case .appleScript: return "AppleScript"
         case .actions: return "Actions"
         case .aiGeneration: return "AI Generation"
+        case .agent: return "AI Agent"
         }
     }
 
@@ -52,6 +54,7 @@ enum DemoTab: String, CaseIterable {
         case .appleScript: return "applescript"
         case .actions: return "play.circle"
         case .aiGeneration: return "sparkles"
+        case .agent: return "brain"
         }
     }
 }

--- a/Sample/Sample/ContentView.swift
+++ b/Sample/Sample/ContentView.swift
@@ -106,6 +106,8 @@ struct ContentView: View {
                             ActionsDemoView()
                         case .aiGeneration:
                             AIGenerationDemoView()
+                        case .agent:
+                            AgentDemoView()
                         }
                     }
                     .padding(24)

--- a/Sample/Sample/Features/Agent/AgentDemoView.swift
+++ b/Sample/Sample/Features/Agent/AgentDemoView.swift
@@ -1,0 +1,299 @@
+//
+//  AgentDemoView.swift
+//  Sample
+//
+
+import SwiftUI
+import SwiftAutoGUI
+
+struct AgentDemoView: View {
+    @State private var viewModel = AgentDemoViewModel()
+    @State private var showSettings = true
+    @Environment(\.colorScheme) var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // Header
+            HStack {
+                Image(systemName: "brain")
+                    .font(.title)
+                    .foregroundColor(.indigo)
+                Text("AI Agent")
+                    .font(.title2)
+                    .fontWeight(.bold)
+                Spacer()
+
+                if !viewModel.steps.isEmpty || viewModel.isRunning {
+                    statusBadge
+                }
+            }
+
+            // Settings (collapsible)
+            DisclosureGroup(isExpanded: $showSettings) {
+                settingsContent
+                    .padding(.top, 8)
+            } label: {
+                Text("Settings")
+                    .font(.headline)
+            }
+
+            // Goal + Controls
+            goalAndControls
+
+            // Error
+            if let error = viewModel.error {
+                HStack(alignment: .top) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(.orange)
+                    Text(error)
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                        .lineLimit(3)
+                }
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(RoundedRectangle(cornerRadius: 8).fill(Color.orange.opacity(0.1)))
+            }
+
+            // Steps table
+            if !viewModel.steps.isEmpty {
+                stepsTable
+            }
+        }
+    }
+
+    // MARK: - Status Badge
+
+    private var statusBadge: some View {
+        HStack(spacing: 6) {
+            if viewModel.isRunning {
+                ProgressView()
+                    .scaleEffect(0.6)
+                    .frame(width: 12, height: 12)
+                Text("Step \(viewModel.steps.count + 1)/\(viewModel.maxIterations)")
+                    .font(.caption2)
+                    .fontWeight(.medium)
+            } else if let completed = viewModel.completed {
+                Image(systemName: completed ? "checkmark.circle.fill" : "exclamationmark.circle.fill")
+                    .foregroundColor(completed ? .green : .orange)
+                    .font(.caption)
+                Text(completed ? "Done" : "Limit reached")
+                    .font(.caption2)
+                    .fontWeight(.medium)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+        .background(Capsule().fill(colorScheme == .dark ? Color.gray.opacity(0.3) : Color.gray.opacity(0.12)))
+    }
+
+    // MARK: - Settings
+
+    private var settingsContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 12) {
+                SecureField("OpenAI API Key", text: $viewModel.openAIKey)
+                    .textFieldStyle(.roundedBorder)
+
+                Picker("Model", selection: $viewModel.openAIModel) {
+                    ForEach(AgentDemoViewModel.availableModels, id: \.self) { model in
+                        Text(model).tag(model)
+                    }
+                }
+                .pickerStyle(.menu)
+                .frame(width: 180)
+            }
+
+            HStack(spacing: 24) {
+                HStack(spacing: 4) {
+                    Text("Max iterations:")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    TextField("", value: $viewModel.maxIterations, format: .number)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 50)
+                }
+                HStack(spacing: 4) {
+                    Text("Delay:")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    TextField("", value: $viewModel.delayBetweenSteps, format: .number)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 50)
+                    Text("s")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(colorScheme == .dark ? Color.gray.opacity(0.15) : Color.gray.opacity(0.06))
+        )
+    }
+
+    // MARK: - Goal + Controls
+
+    private var goalAndControls: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            // Goal input row
+            HStack(spacing: 8) {
+                TextEditor(text: $viewModel.goal)
+                    .frame(height: 44)
+                    .padding(6)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(colorScheme == .dark ? Color.gray.opacity(0.2) : Color.white)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+                    )
+
+                if viewModel.isRunning {
+                    Button(action: { viewModel.stopAgent() }) {
+                        Image(systemName: "stop.fill")
+                            .frame(width: 44, height: 44)
+                            .background(RoundedRectangle(cornerRadius: 8).fill(Color.red))
+                            .foregroundColor(.white)
+                    }
+                    .buttonStyle(.plain)
+                } else {
+                    Button(action: {
+                        showSettings = false
+                        viewModel.startAgent()
+                    }) {
+                        Image(systemName: "play.fill")
+                            .frame(width: 44, height: 44)
+                            .background(RoundedRectangle(cornerRadius: 8).fill(
+                                viewModel.goal.isEmpty || viewModel.openAIKey.isEmpty ? Color.gray : Color.indigo
+                            ))
+                            .foregroundColor(.white)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(viewModel.goal.isEmpty || viewModel.openAIKey.isEmpty)
+                }
+            }
+
+            // Sample goals
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    ForEach(viewModel.sampleGoals, id: \.self) { sample in
+                        Button(action: { viewModel.useSampleGoal(sample) }) {
+                            Text(sample)
+                                .font(.caption2)
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 4)
+                                .background(Capsule().fill(Color.indigo.opacity(0.1)))
+                                .foregroundColor(.indigo)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Steps Table
+
+    private var stepsTable: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Table header
+            HStack {
+                Text("Steps (\(viewModel.steps.count))")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                Spacer()
+                if !viewModel.isRunning {
+                    Button("Clear") { viewModel.clearResults() }
+                        .font(.caption)
+                        .buttonStyle(.plain)
+                        .foregroundColor(.red)
+                }
+            }
+            .padding(.bottom, 6)
+
+            // Column headers
+            HStack(spacing: 0) {
+                Text("#")
+                    .frame(width: 28, alignment: .center)
+                Text("Reasoning")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.leading, 6)
+                Text("Actions")
+                    .frame(width: 220, alignment: .leading)
+            }
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .foregroundColor(.secondary)
+            .padding(.vertical, 4)
+            .padding(.horizontal, 6)
+            .background(colorScheme == .dark ? Color.gray.opacity(0.2) : Color.gray.opacity(0.1))
+
+            // Rows in a fixed-height scrollable area
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(viewModel.steps) { step in
+                            stepRow(step)
+                                .id(step.id)
+                            Divider()
+                        }
+                    }
+                }
+                .frame(maxHeight: 240)
+                .onChange(of: viewModel.steps.count) {
+                    if let last = viewModel.steps.last {
+                        withAnimation {
+                            proxy.scrollTo(last.id, anchor: .bottom)
+                        }
+                    }
+                }
+            }
+            .background(
+                RoundedRectangle(cornerRadius: 0)
+                    .fill(colorScheme == .dark ? Color.gray.opacity(0.1) : Color.gray.opacity(0.03))
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(Color.gray.opacity(0.2), lineWidth: 1)
+            )
+        }
+    }
+
+    private func stepRow(_ step: AgentDemoViewModel.StepDisplay) -> some View {
+        HStack(spacing: 0) {
+            Text("\(step.number)")
+                .font(.caption2)
+                .fontWeight(.bold)
+                .foregroundColor(.white)
+                .frame(width: 20, height: 20)
+                .background(Circle().fill(Color.indigo))
+                .frame(width: 28)
+
+            Text(step.reasoning)
+                .font(.caption2)
+                .foregroundColor(.primary)
+                .lineLimit(2)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.leading, 6)
+
+            Text(step.actions)
+                .font(.system(.caption2, design: .monospaced))
+                .foregroundColor(.secondary)
+                .lineLimit(2)
+                .frame(width: 220, alignment: .leading)
+        }
+        .padding(.vertical, 6)
+        .padding(.horizontal, 6)
+    }
+}
+
+struct AgentDemoView_Previews: PreviewProvider {
+    static var previews: some View {
+        AgentDemoView()
+            .frame(width: 800, height: 600)
+    }
+}

--- a/Sample/Sample/Features/Agent/AgentDemoViewModel.swift
+++ b/Sample/Sample/Features/Agent/AgentDemoViewModel.swift
@@ -1,0 +1,135 @@
+//
+//  AgentDemoViewModel.swift
+//  Sample
+//
+
+import SwiftUI
+import SwiftAutoGUI
+
+@MainActor
+@Observable
+class AgentDemoViewModel {
+    var goal: String = ""
+    var isRunning = false
+    var error: String?
+
+    // MARK: - Backend Settings
+
+    var openAIKey: String = ""
+    var openAIModel: String = "gpt-5.4"
+    var maxIterations: Int = 20
+    var delayBetweenSteps: Double = 1.0
+
+    static let availableModels = [
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.4-nano",
+        "gpt-4o",
+        "gpt-4o-mini",
+        "gpt-4.1",
+        "gpt-4.1-mini",
+    ]
+
+    let sampleGoals: [String] = [
+        "Open Safari and search for Swift programming",
+        "Open System Settings",
+        "Open Finder and create a new folder on Desktop",
+        "Open TextEdit and type 'Hello, World!'",
+    ]
+
+    // MARK: - Step Tracking
+
+    struct StepDisplay: Identifiable {
+        let id = UUID()
+        let number: Int
+        let reasoning: String
+        let actions: String
+        let timestamp: Date
+    }
+
+    var steps: [StepDisplay] = []
+    var completed: Bool?
+
+    private var runTask: Task<Void, Never>?
+
+    // MARK: - Actions
+
+    func startAgent() {
+        guard !goal.isEmpty else {
+            error = "Please enter a goal"
+            return
+        }
+        guard !openAIKey.isEmpty else {
+            error = "Please enter your OpenAI API key"
+            return
+        }
+
+        isRunning = true
+        error = nil
+        steps = []
+        completed = nil
+
+        runTask = Task {
+            do {
+                let backend = OpenAIVisionBackend(apiKey: openAIKey, model: openAIModel)
+                let agent = Agent(
+                    backend: backend,
+                    maxIterations: maxIterations,
+                    delayBetweenSteps: delayBetweenSteps
+                )
+
+                let result = try await agent.run(goal: goal) { [weak self] step in
+                    guard let self else { return }
+                    Task { @MainActor in
+                        let actionSummary = step.actions.map { self.describeAction($0) }.joined(separator: ", ")
+                        self.steps.append(StepDisplay(
+                            number: self.steps.count + 1,
+                            reasoning: step.reasoning,
+                            actions: actionSummary,
+                            timestamp: step.timestamp
+                        ))
+                    }
+                }
+
+                completed = result.completed
+            } catch is CancellationError {
+                // Stopped by user
+            } catch {
+                self.error = String(describing: error)
+            }
+
+            isRunning = false
+        }
+    }
+
+    func stopAgent() {
+        runTask?.cancel()
+        runTask = nil
+    }
+
+    func useSampleGoal(_ sample: String) {
+        goal = sample
+    }
+
+    func clearResults() {
+        steps = []
+        completed = nil
+        error = nil
+    }
+
+    private func describeAction(_ action: BasicAction) -> String {
+        switch action {
+        case .write(let text): return "write(\"\(text)\")"
+        case .move(let x, let y): return "move(\(Int(x)), \(Int(y)))"
+        case .leftClick: return "leftClick"
+        case .rightClick: return "rightClick"
+        case .doubleClick: return "doubleClick"
+        case .vscroll(let clicks): return "vscroll(\(clicks))"
+        case .hscroll(let clicks): return "hscroll(\(clicks))"
+        case .wait(let duration): return "wait(\(duration)s)"
+        case .keyShortcut(let keys): return "keyShortcut(\(keys.joined(separator: "+")))"
+        case .drag(let fromX, let fromY, let toX, let toY):
+            return "drag(\(Int(fromX)),\(Int(fromY))->\(Int(toX)),\(Int(toY)))"
+        }
+    }
+}

--- a/Sources/SwiftAutoGUI/ActionGenerator.swift
+++ b/Sources/SwiftAutoGUI/ActionGenerator.swift
@@ -14,7 +14,7 @@ import FoundationModels
 /// context window. It covers common automation operations and converts to
 /// the full ``Action`` type via ``toAction()``.
 @Generable
-enum BasicAction: Sendable, Codable {
+public enum BasicAction: Sendable, Codable {
     /// Type text.
     case write(text: String)
 
@@ -46,7 +46,7 @@ enum BasicAction: Sendable, Codable {
     case drag(fromX: Double, fromY: Double, toX: Double, toY: Double)
 
     /// Convert to an executable ``Action``.
-    func toAction() -> Action {
+    public func toAction() -> Action {
         switch self {
         case .write(let text):
             return .write(text)
@@ -86,17 +86,17 @@ enum BasicAction: Sendable, Codable {
         case vscroll, hscroll, wait, keyShortcut, drag
     }
 
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let type = try container.decode(ActionType.self, forKey: .type)
 
         switch type {
         case .write:
-            let text = try container.decode(String.self, forKey: .text)
+            let text = try container.decodeIfPresent(String.self, forKey: .text) ?? ""
             self = .write(text: text)
         case .move:
-            let x = try container.decode(Double.self, forKey: .x)
-            let y = try container.decode(Double.self, forKey: .y)
+            let x = try container.decodeIfPresent(Double.self, forKey: .x) ?? 0
+            let y = try container.decodeIfPresent(Double.self, forKey: .y) ?? 0
             self = .move(x: x, y: y)
         case .leftClick:
             self = .leftClick
@@ -105,27 +105,27 @@ enum BasicAction: Sendable, Codable {
         case .doubleClick:
             self = .doubleClick
         case .vscroll:
-            let clicks = try container.decode(Int.self, forKey: .clicks)
+            let clicks = try container.decodeIfPresent(Int.self, forKey: .clicks) ?? 0
             self = .vscroll(clicks: clicks)
         case .hscroll:
-            let clicks = try container.decode(Int.self, forKey: .clicks)
+            let clicks = try container.decodeIfPresent(Int.self, forKey: .clicks) ?? 0
             self = .hscroll(clicks: clicks)
         case .wait:
-            let duration = try container.decode(Double.self, forKey: .duration)
+            let duration = try container.decodeIfPresent(Double.self, forKey: .duration) ?? 0
             self = .wait(duration: duration)
         case .keyShortcut:
-            let keys = try container.decode([String].self, forKey: .keys)
+            let keys = try container.decodeIfPresent([String].self, forKey: .keys) ?? []
             self = .keyShortcut(keys: keys)
         case .drag:
-            let fromX = try container.decode(Double.self, forKey: .fromX)
-            let fromY = try container.decode(Double.self, forKey: .fromY)
-            let toX = try container.decode(Double.self, forKey: .toX)
-            let toY = try container.decode(Double.self, forKey: .toY)
+            let fromX = try container.decodeIfPresent(Double.self, forKey: .fromX) ?? 0
+            let fromY = try container.decodeIfPresent(Double.self, forKey: .fromY) ?? 0
+            let toX = try container.decodeIfPresent(Double.self, forKey: .toX) ?? 0
+            let toY = try container.decodeIfPresent(Double.self, forKey: .toY) ?? 0
             self = .drag(fromX: fromX, fromY: fromY, toX: toX, toY: toY)
         }
     }
 
-    func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         switch self {

--- a/Sources/SwiftAutoGUI/Agent.swift
+++ b/Sources/SwiftAutoGUI/Agent.swift
@@ -1,0 +1,128 @@
+//
+//  Agent.swift
+//  SwiftAutoGUI
+//
+
+import AppKit
+import Foundation
+
+// MARK: - Agent
+
+/// An autonomous agent that observes the screen and executes actions to achieve a goal.
+///
+/// The agent runs a loop: take a screenshot, send it to a vision-capable LLM backend,
+/// execute the returned actions, and repeat until the goal is achieved or the iteration
+/// limit is reached.
+///
+/// ## Example
+///
+/// ```swift
+/// let backend = OpenAIVisionBackend(apiKey: "sk-...")
+/// let agent = Agent(backend: backend, maxIterations: 15)
+/// let result = try await agent.run(goal: "Open Safari and search for Swift")
+/// print("Completed: \(result.completed), Steps: \(result.iterationsUsed)")
+/// ```
+///
+/// ## Requirements
+///
+/// - macOS 26.0 or later
+/// - Accessibility permissions for mouse/keyboard control
+/// - A vision-capable backend (e.g., ``OpenAIVisionBackend``)
+public struct Agent: Sendable {
+
+    /// The vision backend used for action generation.
+    public let backend: any VisionActionGenerating
+
+    /// Maximum number of observe-think-act iterations.
+    public let maxIterations: Int
+
+    /// Delay between steps to allow the screen to update.
+    public let delayBetweenSteps: TimeInterval
+
+    /// Creates an agent with the specified configuration.
+    ///
+    /// - Parameters:
+    ///   - backend: The vision backend to use for action generation.
+    ///   - maxIterations: Maximum loop iterations (default: 20).
+    ///   - delayBetweenSteps: Seconds to wait between steps (default: 1.0).
+    public init(
+        backend: any VisionActionGenerating,
+        maxIterations: Int = 20,
+        delayBetweenSteps: TimeInterval = 1.0
+    ) {
+        self.backend = backend
+        self.maxIterations = maxIterations
+        self.delayBetweenSteps = delayBetweenSteps
+    }
+
+    /// Runs the agent loop to achieve the given goal.
+    ///
+    /// - Parameters:
+    ///   - goal: A natural language description of the goal.
+    ///   - onStep: Optional callback invoked after each step completes.
+    /// - Returns: An ``AgentResult`` describing the run outcome.
+    @MainActor
+    public func run(
+        goal: String,
+        onStep: (@Sendable (AgentStep) -> Void)? = nil
+    ) async throws -> AgentResult {
+        guard backend.isAvailable else {
+            throw ActionGeneratorError.backendUnavailable(
+                reason: backend.unavailableReason ?? "Backend is unavailable."
+            )
+        }
+
+        var steps: [AgentStep] = []
+        var completed = false
+
+        for _ in 0..<maxIterations {
+            try Task.checkCancellation()
+
+            // 1. Observe: take screenshot
+            guard let screenshot = try await SwiftAutoGUI.screenshot(),
+                  let jpegData = screenshot.jpegData(compressionFactor: 0.5) else {
+                throw ActionGeneratorError.invalidResponse(detail: "Failed to capture screenshot")
+            }
+
+            let screenSize = SwiftAutoGUI.size()
+            let screenCGSize = CGSize(width: screenSize.width, height: screenSize.height)
+
+            // 2. Think: send to backend
+            let response = try await backend.generateActions(
+                goal: goal,
+                screenshot: jpegData,
+                screenSize: screenCGSize,
+                history: steps
+            )
+
+            // 3. Act: execute actions
+            let actions = response.actions.map { $0.toAction() }
+            await actions.execute()
+
+            // 4. Record step
+            let step = AgentStep(
+                actions: response.actions,
+                reasoning: response.reasoning
+            )
+            steps.append(step)
+            onStep?(step)
+
+            // 5. Check completion
+            if response.isDone {
+                completed = true
+                break
+            }
+
+            // 6. Wait before next iteration
+            if delayBetweenSteps > 0 {
+                try await Task.sleep(for: .seconds(delayBetweenSteps))
+            }
+        }
+
+        return AgentResult(
+            steps: steps,
+            completed: completed,
+            iterationsUsed: steps.count
+        )
+    }
+}

--- a/Sources/SwiftAutoGUI/Documentation.docc/SwiftAutoGUI.md
+++ b/Sources/SwiftAutoGUI/Documentation.docc/SwiftAutoGUI.md
@@ -165,6 +165,23 @@ await action.execute()
 
 > Note: Requires macOS 26.0+ with Apple Intelligence enabled.
 
+### AI Agent (Autonomous Loop)
+
+The ``Agent`` observes the screen via screenshots, sends them to a vision-capable LLM, executes the returned actions, and repeats until the goal is achieved. This follows the **ReAct** (Observe → Think → Act) pattern.
+
+```swift
+let backend = OpenAIVisionBackend(apiKey: "sk-...", model: "gpt-4o")
+let agent = Agent(backend: backend, maxIterations: 15)
+
+let result = try await agent.run(goal: "Open Safari and search for Swift") { step in
+    print("Step: \(step.reasoning)")
+    print("Actions: \(step.actions)")
+}
+print("Completed: \(result.completed)")
+```
+
+You can implement ``VisionActionGenerating`` to use any vision-capable backend.
+
 ### Direct Method Calls (Alternative)
 
 While the Action pattern is recommended, you can also use SwiftAutoGUI methods directly for simple operations:
@@ -221,10 +238,25 @@ The sample app demonstrates all SwiftAutoGUI features with interactive examples.
 
 ## Topics
 
-### API Reference
+### Core
 
 - ``SwiftAutoGUI/SwiftAutoGUI``
 - ``Action``
-- ``ActionGenerator``
 - ``Key``
 - ``TweeningFunction``
+
+### AI Action Generation
+
+- ``ActionGenerator``
+- ``ActionGenerating``
+- ``OpenAIBackend``
+- ``BasicAction``
+
+### AI Agent
+
+- ``Agent``
+- ``VisionActionGenerating``
+- ``OpenAIVisionBackend``
+- ``AgentStep``
+- ``AgentResponse``
+- ``AgentResult``

--- a/Sources/SwiftAutoGUI/OpenAIBackend.swift
+++ b/Sources/SwiftAutoGUI/OpenAIBackend.swift
@@ -4,7 +4,6 @@
 //
 
 import Foundation
-@preconcurrency import OpenAI
 
 // MARK: - OpenAIBackend
 
@@ -29,26 +28,24 @@ import Foundation
 /// Never hard-code API keys in source code. Use environment variables or secure storage.
 public struct OpenAIBackend: ActionGenerating, Sendable {
 
-    private let client: OpenAI
-    private let model: Model
+    private let apiKey: String
+    private let model: String
+    private let baseURL: String
 
     /// Creates an OpenAI backend.
     ///
     /// - Parameters:
     ///   - apiKey: Your OpenAI API key.
     ///   - model: The model to use (default: `gpt-4.1-nano`).
-    public init(apiKey: String, model: String = "gpt-4.1-nano") {
-        self.client = OpenAI(apiToken: apiKey)
-        self.model = Model(model)
+    ///   - baseURL: The API base URL (default: OpenAI).
+    public init(apiKey: String, model: String = "gpt-4.1-nano", baseURL: String = "https://api.openai.com/v1") {
+        self.apiKey = apiKey
+        self.model = model
+        self.baseURL = baseURL
     }
 
-    public var isAvailable: Bool {
-        true
-    }
-
-    public var unavailableReason: String? {
-        nil
-    }
+    public var isAvailable: Bool { true }
+    public var unavailableReason: String? { nil }
 
     public func generateAction(from prompt: String) async throws -> Action {
         let actions = try await generateActionSequence(from: prompt)
@@ -59,28 +56,58 @@ public struct OpenAIBackend: ActionGenerating, Sendable {
     }
 
     public func generateActionSequence(from prompt: String) async throws -> [Action] {
-        let query = ChatQuery(
-            messages: [
-                .system(.init(content: .textContent(Self.systemPrompt))),
-                .user(.init(content: .string(prompt)))
-            ],
-            model: model,
-            responseFormat: .jsonSchema(.init(
-                name: "action_sequence",
-                schema: .jsonSchema(Self.actionsSchema),
-                strict: true
-            ))
-        )
+        let requestBody: [String: Any] = [
+            "model": model,
+            "stream": false,
+            "messages": [
+                ["role": "system", "content": Self.systemPrompt],
+                ["role": "user", "content": prompt]
+            ] as [[String: Any]],
+            "response_format": [
+                "type": "json_schema",
+                "json_schema": [
+                    "name": "action_sequence",
+                    "strict": true,
+                    "schema": Self.actionsSchemaDict
+                ] as [String: Any]
+            ] as [String: Any]
+        ]
 
-        let result = try await client.chats(query: query)
+        let requestData = try JSONSerialization.data(withJSONObject: requestBody)
 
-        guard let content = result.choices.first?.message.content,
-              let data = content.data(using: .utf8) else {
-            throw ActionGeneratorError.invalidResponse(detail: "No content in response")
+        var request = URLRequest(url: URL(string: "\(baseURL)/chat/completions")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.httpBody = requestData
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
+            let body = String(data: data, encoding: .utf8) ?? "(no body)"
+            throw ActionGeneratorError.invalidResponse(
+                detail: "API returned HTTP \(httpResponse.statusCode): \(String(body.prefix(500)))"
+            )
         }
 
-        let wrapper = try JSONDecoder().decode(ActionsWrapper.self, from: data)
-        let actions = wrapper.actions.map { $0.toAction() }
+        let json = try OpenAIVisionBackend.parseJSON(data)
+
+        guard let choices = json["choices"] as? [[String: Any]],
+              let firstChoice = choices.first,
+              let message = firstChoice["message"] as? [String: Any],
+              let content = message["content"] as? String else {
+            let preview = String(data: data, encoding: .utf8)?.prefix(500) ?? "(empty)"
+            throw ActionGeneratorError.invalidResponse(
+                detail: "Unexpected API response structure.\nRaw: \(preview)"
+            )
+        }
+
+        let parsed = try OpenAIVisionBackend.parseJSON(Data(content.utf8))
+
+        let actionsArray = parsed["actions"] as? [[String: Any]] ?? []
+        let actions: [Action] = actionsArray.compactMap { dict in
+            OpenAIVisionBackend.parseAction(dict)?.toAction()
+        }
 
         guard !actions.isEmpty else {
             throw ActionGeneratorError.noActionsGenerated
@@ -88,12 +115,6 @@ public struct OpenAIBackend: ActionGenerating, Sendable {
 
         return actions
     }
-}
-
-// MARK: - Response Wrapper
-
-private struct ActionsWrapper: Codable {
-    let actions: [BasicAction]
 }
 
 // MARK: - System Prompt
@@ -124,83 +145,20 @@ extension OpenAIBackend {
         """
 }
 
-// MARK: - JSON Schema for Structured Outputs
+// MARK: - JSON Schema (as Dictionary)
 
 extension OpenAIBackend {
-    /// JSON Schema for the actions wrapper object.
-    ///
-    /// Uses flat object format with all fields required (nullable for optional ones),
-    /// because OpenAI's strict mode does not fully support `oneOf`/`anyOf`.
-    static let actionsSchema: JSONSchema = .init(
-        .type(.object),
-        .description("A wrapper containing an array of automation actions."),
-        .properties([
-            "actions": JSONSchema(
-                .type(.array),
-                .description("The array of actions to execute."),
-                .items(actionItemSchema)
-            )
-        ]),
-        .required(["actions"]),
-        .additionalProperties(.boolean(false))
-    )
-
-    /// JSON Schema for a single action item (flat object, type-discriminated).
-    private static let actionItemSchema: JSONSchema = .init(
-        .type(.object),
-        .description("A single automation action."),
-        .properties([
-            "type": JSONSchema(
-                .type(.string),
-                .description("The action type."),
-                .enumValues([
-                    "write", "move", "leftClick", "rightClick", "doubleClick",
-                    "vscroll", "hscroll", "wait", "keyShortcut", "drag"
-                ] as [String])
-            ),
-            "text": JSONSchema(
-                .type(.types(["string", "null"])),
-                .description("Text to type. Used with 'write' action.")
-            ),
-            "x": JSONSchema(
-                .type(.types(["number", "null"])),
-                .description("X coordinate for mouse position. Used with 'move' action.")
-            ),
-            "y": JSONSchema(
-                .type(.types(["number", "null"])),
-                .description("Y coordinate for mouse position. Used with 'move' action.")
-            ),
-            "clicks": JSONSchema(
-                .type(.types(["integer", "null"])),
-                .description("Number of scroll clicks. Used with 'vscroll' and 'hscroll' actions.")
-            ),
-            "duration": JSONSchema(
-                .type(.types(["number", "null"])),
-                .description("Wait duration in seconds. Used with 'wait' action.")
-            ),
-            "keys": JSONSchema(
-                .type(.types(["array", "null"])),
-                .description("Key names for shortcut. Used with 'keyShortcut' action."),
-                .items(JSONSchema(.type(.string)))
-            ),
-            "fromX": JSONSchema(
-                .type(.types(["number", "null"])),
-                .description("Start X coordinate. Used with 'drag' action.")
-            ),
-            "fromY": JSONSchema(
-                .type(.types(["number", "null"])),
-                .description("Start Y coordinate. Used with 'drag' action.")
-            ),
-            "toX": JSONSchema(
-                .type(.types(["number", "null"])),
-                .description("End X coordinate. Used with 'drag' action.")
-            ),
-            "toY": JSONSchema(
-                .type(.types(["number", "null"])),
-                .description("End Y coordinate. Used with 'drag' action.")
-            )
-        ]),
-        .required(["type", "text", "x", "y", "clicks", "duration", "keys", "fromX", "fromY", "toX", "toY"]),
-        .additionalProperties(.boolean(false))
-    )
+    nonisolated(unsafe) static let actionsSchemaDict: [String: Any] = [
+        "type": "object",
+        "description": "A wrapper containing an array of automation actions.",
+        "properties": [
+            "actions": [
+                "type": "array",
+                "description": "The array of actions to execute.",
+                "items": OpenAIVisionBackend.actionItemSchemaDict
+            ] as [String: Any]
+        ] as [String: Any],
+        "required": ["actions"],
+        "additionalProperties": false
+    ] as [String: Any]
 }

--- a/Sources/SwiftAutoGUI/OpenAIVisionBackend.swift
+++ b/Sources/SwiftAutoGUI/OpenAIVisionBackend.swift
@@ -1,0 +1,394 @@
+//
+//  OpenAIVisionBackend.swift
+//  SwiftAutoGUI
+//
+
+import AppKit
+import Foundation
+
+// MARK: - OpenAIVisionBackend
+
+/// A ``VisionActionGenerating`` backend that uses the OpenAI API with vision capabilities.
+///
+/// This backend sends screenshots along with the goal and history to a vision-capable
+/// OpenAI model, enabling an observe-think-act agent loop.
+///
+/// Uses direct HTTP calls to the OpenAI Chat Completions API (no SDK dependency)
+/// for maximum compatibility with the latest models.
+///
+/// ## Example
+///
+/// ```swift
+/// let backend = OpenAIVisionBackend(apiKey: "sk-...")
+/// let response = try await backend.generateActions(
+///     goal: "Open Safari and search for Swift",
+///     screenshot: jpegData,
+///     screenSize: CGSize(width: 1920, height: 1080),
+///     history: []
+/// )
+/// ```
+public struct OpenAIVisionBackend: VisionActionGenerating, Sendable {
+
+    private let apiKey: String
+    private let model: String
+    private let baseURL: String
+
+    /// Creates an OpenAI vision backend.
+    ///
+    /// - Parameters:
+    ///   - apiKey: Your OpenAI API key.
+    ///   - model: The vision-capable model to use (default: `gpt-4o`).
+    ///   - baseURL: The API base URL (default: OpenAI).
+    public init(apiKey: String, model: String = "gpt-4o", baseURL: String = "https://api.openai.com/v1") {
+        self.apiKey = apiKey
+        self.model = model
+        self.baseURL = baseURL
+    }
+
+    public var isAvailable: Bool { true }
+    public var unavailableReason: String? { nil }
+
+    public func generateActions(
+        goal: String,
+        screenshot: Data,
+        screenSize: CGSize,
+        history: [AgentStep]
+    ) async throws -> AgentResponse {
+        let messages = buildMessages(
+            goal: goal,
+            screenshot: screenshot,
+            screenSize: screenSize,
+            history: history
+        )
+
+        let requestBody: [String: Any] = [
+            "model": model,
+            "stream": false,
+            "messages": messages,
+            "response_format": [
+                "type": "json_schema",
+                "json_schema": [
+                    "name": "agent_response",
+                    "strict": true,
+                    "schema": Self.agentResponseSchemaDict
+                ] as [String: Any]
+            ] as [String: Any]
+        ]
+
+        let requestData = try JSONSerialization.data(withJSONObject: requestBody)
+
+        var request = URLRequest(url: URL(string: "\(baseURL)/chat/completions")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.httpBody = requestData
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
+            let body = String(data: data, encoding: .utf8) ?? "(no body)"
+            throw ActionGeneratorError.invalidResponse(
+                detail: "API returned HTTP \(httpResponse.statusCode): \(String(body.prefix(500)))"
+            )
+        }
+
+        let json = try Self.parseJSON(data)
+
+        guard let choices = json["choices"] as? [[String: Any]],
+              let firstChoice = choices.first,
+              let message = firstChoice["message"] as? [String: Any],
+              let content = message["content"] as? String else {
+            let preview = String(data: data, encoding: .utf8)?.prefix(500) ?? "(empty)"
+            throw ActionGeneratorError.invalidResponse(
+                detail: "Unexpected API response structure.\nRaw: \(preview)"
+            )
+        }
+
+        let parsed = try Self.parseJSON(Data(content.utf8))
+
+        let reasoning = parsed["reasoning"] as? String ?? ""
+        let isDone = parsed["isDone"] as? Bool ?? false
+        let actionsArray = parsed["actions"] as? [[String: Any]] ?? []
+        let actions: [BasicAction] = actionsArray.compactMap { Self.parseAction($0) }
+
+        return AgentResponse(actions: actions, reasoning: reasoning, isDone: isDone)
+    }
+}
+
+// MARK: - Message Building
+
+extension OpenAIVisionBackend {
+    private func buildMessages(
+        goal: String,
+        screenshot: Data,
+        screenSize: CGSize,
+        history: [AgentStep]
+    ) -> [[String: Any]] {
+        var messages: [[String: Any]] = []
+
+        // System prompt
+        messages.append([
+            "role": "system",
+            "content": Self.buildSystemPrompt(screenSize: screenSize)
+        ])
+
+        // History steps
+        for (index, step) in history.enumerated() {
+            let actionSummary = step.actions.map { describeBasicAction($0) }.joined(separator: ", ")
+            messages.append([
+                "role": "assistant",
+                "content": "Step \(index + 1): \(step.reasoning)\nActions executed: \(actionSummary)"
+            ])
+        }
+
+        // Current screenshot + goal
+        let base64 = screenshot.base64EncodedString()
+        messages.append([
+            "role": "user",
+            "content": [
+                [
+                    "type": "image_url",
+                    "image_url": [
+                        "url": "data:image/jpeg;base64,\(base64)",
+                        "detail": "low"
+                    ] as [String: Any]
+                ] as [String: Any],
+                [
+                    "type": "text",
+                    "text": "Goal: \(goal)\n\nThis is the current screenshot. What actions should I take next?"
+                ] as [String: Any]
+            ] as [[String: Any]]
+        ] as [String: Any])
+
+        return messages
+    }
+
+    private func describeBasicAction(_ action: BasicAction) -> String {
+        switch action {
+        case .write(let text): return "write(\"\(text)\")"
+        case .move(let x, let y): return "move(\(Int(x)), \(Int(y)))"
+        case .leftClick: return "leftClick"
+        case .rightClick: return "rightClick"
+        case .doubleClick: return "doubleClick"
+        case .vscroll(let clicks): return "vscroll(\(clicks))"
+        case .hscroll(let clicks): return "hscroll(\(clicks))"
+        case .wait(let duration): return "wait(\(duration)s)"
+        case .keyShortcut(let keys): return "keyShortcut(\(keys.joined(separator: "+")))"
+        case .drag(let fromX, let fromY, let toX, let toY):
+            return "drag(\(Int(fromX)),\(Int(fromY)) -> \(Int(toX)),\(Int(toY)))"
+        }
+    }
+}
+
+// MARK: - System Prompt
+
+extension OpenAIVisionBackend {
+    static func buildSystemPrompt(screenSize: CGSize) -> String {
+        """
+        You are an AI agent controlling a macOS computer to achieve a user's goal. \
+        You will receive screenshots of the current screen state and must decide what actions to take.
+
+        Screen size: \(Int(screenSize.width)) x \(Int(screenSize.height)) pixels (origin at top-left).
+
+        Available action types and their parameters:
+        - write: Type text. Parameters: text (string)
+        - move: Move mouse to absolute position. Parameters: x (number), y (number)
+        - leftClick: Left click at current position. No additional parameters needed.
+        - rightClick: Right click at current position. No additional parameters needed.
+        - doubleClick: Double click at current position. No additional parameters needed.
+        - vscroll: Scroll vertically. Parameters: clicks (integer, positive=up, negative=down)
+        - hscroll: Scroll horizontally. Parameters: clicks (integer, positive=right, negative=left)
+        - wait: Wait for a duration. Parameters: duration (number, in seconds)
+        - keyShortcut: Press a keyboard shortcut. Parameters: keys (array of strings). \
+        Use key names: "command", "shift", "control", "option", "a"-"z", "0"-"9", \
+        "returnKey", "space", "delete", "tab", "escape", "upArrow", "downArrow", "leftArrow", "rightArrow", \
+        "f1"-"f20".
+        - drag: Drag mouse from one position to another. Parameters: fromX, fromY, toX, toY (numbers)
+
+        Instructions:
+        1. Analyze the screenshot to understand the current screen state.
+        2. Decide the next action(s) to move toward the goal.
+        3. Set isDone to true ONLY when the goal has been fully achieved.
+        4. Provide brief reasoning about what you see and why you chose these actions.
+        5. Use move + leftClick to click on UI elements. First move to the element, then click.
+        6. Keep action sequences short (1-3 actions per step) to allow re-observation.
+
+        Respond with a JSON object containing "reasoning", "isDone", and "actions" fields.
+        """
+    }
+}
+
+// MARK: - Action Parsing
+
+extension OpenAIVisionBackend {
+    /// Parse a single action from a JSON dictionary, tolerating null fields.
+    static func parseAction(_ dict: [String: Any]) -> BasicAction? {
+        guard let type = dict["type"] as? String else { return nil }
+
+        switch type {
+        case "write":
+            let text = dict["text"] as? String ?? ""
+            return .write(text: text)
+        case "move":
+            let x = (dict["x"] as? NSNumber)?.doubleValue ?? 0
+            let y = (dict["y"] as? NSNumber)?.doubleValue ?? 0
+            return .move(x: x, y: y)
+        case "leftClick":
+            return .leftClick
+        case "rightClick":
+            return .rightClick
+        case "doubleClick":
+            return .doubleClick
+        case "vscroll":
+            let clicks = (dict["clicks"] as? NSNumber)?.intValue ?? 0
+            return .vscroll(clicks: clicks)
+        case "hscroll":
+            let clicks = (dict["clicks"] as? NSNumber)?.intValue ?? 0
+            return .hscroll(clicks: clicks)
+        case "wait":
+            let duration = (dict["duration"] as? NSNumber)?.doubleValue ?? 0
+            return .wait(duration: duration)
+        case "keyShortcut":
+            let keys = dict["keys"] as? [String] ?? []
+            return .keyShortcut(keys: keys)
+        case "drag":
+            let fromX = (dict["fromX"] as? NSNumber)?.doubleValue ?? 0
+            let fromY = (dict["fromY"] as? NSNumber)?.doubleValue ?? 0
+            let toX = (dict["toX"] as? NSNumber)?.doubleValue ?? 0
+            let toY = (dict["toY"] as? NSNumber)?.doubleValue ?? 0
+            return .drag(fromX: fromX, fromY: fromY, toX: toX, toY: toY)
+        default:
+            return nil
+        }
+    }
+}
+
+// MARK: - JSON Parsing
+
+extension OpenAIVisionBackend {
+    /// Parse JSON data robustly, handling trailing whitespace/newlines that
+    /// some API responses include.
+    static func parseJSON(_ data: Data) throws -> [String: Any] {
+        guard let str = String(data: data, encoding: .utf8) else {
+            throw ActionGeneratorError.invalidResponse(detail: "Response is not valid UTF-8")
+        }
+
+        // Handle SSE streaming format: extract JSON from "data: {...}" lines
+        var jsonString = str.trimmingCharacters(in: .whitespacesAndNewlines)
+        if jsonString.hasPrefix("data: ") {
+            let lines = jsonString.components(separatedBy: "\n")
+            var lastJSON: String?
+            for line in lines {
+                let trimmedLine = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                if trimmedLine.hasPrefix("data: ") && trimmedLine != "data: [DONE]" {
+                    lastJSON = String(trimmedLine.dropFirst(6))
+                }
+            }
+            jsonString = lastJSON ?? jsonString
+        }
+
+        // Extract only the JSON object by finding balanced braces.
+        // Some API responses include trailing bytes (newlines, chunked encoding
+        // markers, etc.) that cause JSONSerialization to fail with
+        // "Garbage at end".
+        jsonString = Self.extractJSONObject(from: jsonString) ?? jsonString
+
+        guard let jsonData = jsonString.data(using: .utf8),
+              let json = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
+            throw ActionGeneratorError.invalidResponse(
+                detail: "Not a JSON object.\nRaw (\(data.count) bytes): \(String(str.prefix(800)))"
+            )
+        }
+        return json
+    }
+
+    /// Finds the first top-level `{ … }` in the string by counting balanced braces.
+    private static func extractJSONObject(from string: String) -> String? {
+        guard let startIdx = string.firstIndex(of: "{") else { return nil }
+        var depth = 0
+        var inString = false
+        var escaped = false
+        var endIdx: String.Index?
+
+        for i in string[startIdx...].indices {
+            let ch = string[i]
+            if escaped { escaped = false; continue }
+            if ch == "\\" && inString { escaped = true; continue }
+            if ch == "\"" { inString.toggle(); continue }
+            if inString { continue }
+            if ch == "{" { depth += 1 }
+            else if ch == "}" {
+                depth -= 1
+                if depth == 0 { endIdx = i; break }
+            }
+        }
+
+        guard let end = endIdx else { return nil }
+        return String(string[startIdx...end])
+    }
+}
+
+// MARK: - JSON Schema (as Dictionary for direct HTTP call)
+
+extension OpenAIVisionBackend {
+    nonisolated(unsafe) static let actionItemSchemaDict: [String: Any] = [
+        "type": "object",
+        "description": "A single automation action.",
+        "properties": [
+            "type": [
+                "type": "string",
+                "description": "The action type.",
+                "enum": ["write", "move", "leftClick", "rightClick", "doubleClick",
+                         "vscroll", "hscroll", "wait", "keyShortcut", "drag"]
+            ] as [String: Any],
+            "text": ["type": ["string", "null"], "description": "Text to type. Used with 'write' action."] as [String: Any],
+            "x": ["type": ["number", "null"], "description": "X coordinate. Used with 'move' action."] as [String: Any],
+            "y": ["type": ["number", "null"], "description": "Y coordinate. Used with 'move' action."] as [String: Any],
+            "clicks": ["type": ["integer", "null"], "description": "Scroll clicks. Used with 'vscroll'/'hscroll'."] as [String: Any],
+            "duration": ["type": ["number", "null"], "description": "Wait duration in seconds."] as [String: Any],
+            "keys": ["type": ["array", "null"], "description": "Key names for shortcut.", "items": ["type": "string"]] as [String: Any],
+            "fromX": ["type": ["number", "null"], "description": "Start X. Used with 'drag'."] as [String: Any],
+            "fromY": ["type": ["number", "null"], "description": "Start Y. Used with 'drag'."] as [String: Any],
+            "toX": ["type": ["number", "null"], "description": "End X. Used with 'drag'."] as [String: Any],
+            "toY": ["type": ["number", "null"], "description": "End Y. Used with 'drag'."] as [String: Any],
+        ] as [String: Any],
+        "required": ["type", "text", "x", "y", "clicks", "duration", "keys", "fromX", "fromY", "toX", "toY"],
+        "additionalProperties": false
+    ] as [String: Any]
+
+    nonisolated(unsafe) static let agentResponseSchemaDict: [String: Any] = [
+        "type": "object",
+        "description": "Agent response with reasoning, completion status, and actions.",
+        "properties": [
+            "reasoning": [
+                "type": "string",
+                "description": "Brief reasoning about the current screen state and chosen actions."
+            ] as [String: Any],
+            "isDone": [
+                "type": "boolean",
+                "description": "Whether the goal has been fully achieved."
+            ] as [String: Any],
+            "actions": [
+                "type": "array",
+                "description": "The array of actions to execute.",
+                "items": actionItemSchemaDict
+            ] as [String: Any]
+        ] as [String: Any],
+        "required": ["reasoning", "isDone", "actions"],
+        "additionalProperties": false
+    ] as [String: Any]
+}
+
+// MARK: - NSImage JPEG Conversion
+
+extension NSImage {
+    /// Converts the image to JPEG data.
+    ///
+    /// - Parameter compressionFactor: JPEG compression quality (0.0 to 1.0).
+    /// - Returns: JPEG data, or nil if conversion fails.
+    func jpegData(compressionFactor: CGFloat = 0.5) -> Data? {
+        guard let tiffData = tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiffData) else { return nil }
+        return bitmap.representation(using: .jpeg, properties: [.compressionFactor: compressionFactor])
+    }
+}

--- a/Sources/SwiftAutoGUI/VisionActionGenerating.swift
+++ b/Sources/SwiftAutoGUI/VisionActionGenerating.swift
@@ -1,0 +1,103 @@
+//
+//  VisionActionGenerating.swift
+//  SwiftAutoGUI
+//
+
+import Foundation
+
+// MARK: - VisionActionGenerating Protocol
+
+/// A protocol for backends that generate automation actions from screenshots and natural language goals.
+///
+/// Unlike ``ActionGenerating`` which only takes text prompts, this protocol accepts
+/// screenshots and conversation history, enabling an observe-think-act agent loop.
+///
+/// ## Example
+///
+/// ```swift
+/// let backend: any VisionActionGenerating = OpenAIVisionBackend(apiKey: "sk-...")
+/// let response = try await backend.generateActions(
+///     goal: "Open Safari",
+///     screenshot: screenshotData,
+///     screenSize: CGSize(width: 1920, height: 1080),
+///     history: []
+/// )
+/// ```
+public protocol VisionActionGenerating: Sendable {
+    /// Whether this backend is currently available.
+    var isAvailable: Bool { get }
+
+    /// A human-readable message describing why the backend is unavailable.
+    var unavailableReason: String? { get }
+
+    /// Generates actions based on a goal, current screenshot, and previous history.
+    ///
+    /// - Parameters:
+    ///   - goal: The natural language goal to accomplish.
+    ///   - screenshot: JPEG-compressed screenshot data of the current screen.
+    ///   - screenSize: The screen dimensions in points.
+    ///   - history: Previous agent steps for context.
+    /// - Returns: An ``AgentResponse`` containing actions, reasoning, and completion status.
+    func generateActions(
+        goal: String,
+        screenshot: Data,
+        screenSize: CGSize,
+        history: [AgentStep]
+    ) async throws -> AgentResponse
+}
+
+// MARK: - Agent Types
+
+/// A record of one step in the agent loop.
+public struct AgentStep: Sendable {
+    /// The actions that were executed in this step.
+    public let actions: [BasicAction]
+
+    /// The LLM's reasoning about what it observed and decided.
+    public let reasoning: String
+
+    /// When this step occurred.
+    public let timestamp: Date
+
+    public init(actions: [BasicAction], reasoning: String, timestamp: Date = Date()) {
+        self.actions = actions
+        self.reasoning = reasoning
+        self.timestamp = timestamp
+    }
+}
+
+/// The response from a vision backend for one agent iteration.
+public struct AgentResponse: Sendable {
+    /// The actions to execute.
+    public let actions: [BasicAction]
+
+    /// The LLM's reasoning about the current screen state and chosen actions.
+    public let reasoning: String
+
+    /// Whether the LLM believes the goal has been achieved.
+    public let isDone: Bool
+
+    public init(actions: [BasicAction], reasoning: String, isDone: Bool) {
+        self.actions = actions
+        self.reasoning = reasoning
+        self.isDone = isDone
+    }
+}
+
+/// The result of a completed agent run.
+public struct AgentResult: Sendable {
+    /// All steps executed during the agent run.
+    public let steps: [AgentStep]
+
+    /// Whether the agent believes it successfully completed the goal.
+    public let completed: Bool
+
+    /// The number of iterations used.
+    public let iterationsUsed: Int
+
+    public init(steps: [AgentStep], completed: Bool, iterationsUsed: Int) {
+        self.steps = steps
+        self.completed = completed
+        self.iterationsUsed = iterationsUsed
+    }
+}

--- a/Sources/sagui/AgentCommand.swift
+++ b/Sources/sagui/AgentCommand.swift
@@ -1,0 +1,69 @@
+import ArgumentParser
+import Foundation
+import SwiftAutoGUI
+
+/// Run an AI agent that observes the screen and executes actions to achieve a goal.
+///
+/// The agent takes screenshots, sends them to a vision-capable LLM, and executes
+/// the returned actions in a loop until the goal is achieved or the iteration limit is reached.
+///
+/// ## Usage
+///
+/// ```bash
+/// sagui agent "Open Safari and search for Swift" --api-key sk-...
+/// sagui agent "Click the trash icon" --model gpt-4o --max-iterations 15
+/// ```
+struct AgentCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "agent",
+        abstract: "Run an AI agent to accomplish a goal using screen observation."
+    )
+
+    @Argument(help: "The goal for the agent to accomplish.")
+    var goal: String
+
+    @Option(help: "OpenAI API key. Can also be set via OPENAI_API_KEY environment variable.")
+    var apiKey: String?
+
+    @Option(help: "Vision model to use.")
+    var model: String = "gpt-5.4"
+
+    @Option(help: "Maximum number of iterations.")
+    var maxIterations: Int = 20
+
+    @Option(help: "Delay between steps in seconds.")
+    var delay: Double = 1.0
+
+    @MainActor
+    func run() async throws {
+        let key = apiKey ?? ProcessInfo.processInfo.environment["OPENAI_API_KEY"]
+        guard let key else {
+            throw ValidationError("Provide --api-key or set OPENAI_API_KEY environment variable.")
+        }
+
+        let backend = OpenAIVisionBackend(apiKey: key, model: model)
+        let agent = Agent(
+            backend: backend,
+            maxIterations: maxIterations,
+            delayBetweenSteps: delay
+        )
+
+        print("Agent starting with goal: \"\(goal)\"")
+        print("Model: \(model), Max iterations: \(maxIterations), Delay: \(delay)s")
+        print("---")
+
+        let result = try await agent.run(goal: goal) { step in
+            let timestamp = DateFormatter.localizedString(
+                from: step.timestamp, dateStyle: .none, timeStyle: .medium
+            )
+            let actionSummary = step.actions.map { "\($0)" }.joined(separator: ", ")
+            print("[\(timestamp)] \(step.reasoning)")
+            print("  Actions: \(actionSummary)")
+            print("---")
+        }
+
+        print("Agent finished.")
+        print("Completed: \(result.completed)")
+        print("Iterations used: \(result.iterationsUsed)")
+    }
+}

--- a/Sources/sagui/SaguiCLI.swift
+++ b/Sources/sagui/SaguiCLI.swift
@@ -33,6 +33,6 @@ struct SaguiCLI: AsyncParsableCommand {
         commandName: "sagui",
         abstract: "Control mouse and keyboard on macOS from the command line.",
         discussion: "Requires accessibility permissions in System Settings > Privacy & Security > Accessibility.",
-        subcommands: [KeyCommand.self, MouseCommand.self, ScreenCommand.self]
+        subcommands: [KeyCommand.self, MouseCommand.self, ScreenCommand.self, AgentCommand.self]
     )
 }


### PR DESCRIPTION
## Summary
- Implement ReAct-pattern Agent that observes screen via screenshot, sends to vision LLM, generates actions, executes them, and loops until the goal is achieved
- Remove MacPaw/OpenAI SDK dependency entirely in favor of direct URLSession HTTP calls
- Add Agent demo tab in Sample app and `sagui agent` CLI subcommand

## Changes
- `VisionActionGenerating` protocol and `Agent` orchestrator for the observe→think→act loop
- `OpenAIVisionBackend` for vision+history-based action generation via URLSession
- Rewrite `OpenAIBackend` to use URLSession (no SDK dependency)
- Make `BasicAction` public with null-tolerant Codable decoding
- Add `sagui agent` CLI subcommand
- Add Agent demo tab in Sample app with collapsible settings, step history table, and stop support
- Fix JSON parsing for API responses with trailing bytes

## Test plan
- [ ] Build succeeds (`swift build`)
- [ ] Existing tests pass (`swift test`)
- [ ] Sample app Agent tab displays correctly
- [ ] Agent loop runs with valid OpenAI API key
- [ ] `sagui agent "goal" --api-key <key>` works from CLI
- [ ] Verify MacPaw/OpenAI dependency is fully removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)