### PR TITLE
Add screen context (accessibility tree + window info) to Agent

### DIFF
--- a/Sample/Sample/Common/DemoTab.swift
+++ b/Sample/Sample/Common/DemoTab.swift
@@ -20,6 +20,7 @@ enum DemoTab: String, CaseIterable {
     case appleScript
     case actions
     case aiGeneration
+    case screenContext
     case agent
 
     var title: String {
@@ -36,6 +37,7 @@ enum DemoTab: String, CaseIterable {
         case .appleScript: return "AppleScript"
         case .actions: return "Actions"
         case .aiGeneration: return "AI Generation"
+        case .screenContext: return "Screen Context"
         case .agent: return "AI Agent"
         }
     }
@@ -54,6 +56,7 @@ enum DemoTab: String, CaseIterable {
         case .appleScript: return "applescript"
         case .actions: return "play.circle"
         case .aiGeneration: return "sparkles"
+        case .screenContext: return "accessibility"
         case .agent: return "brain"
         }
     }

--- a/Sample/Sample/ContentView.swift
+++ b/Sample/Sample/ContentView.swift
@@ -106,6 +106,8 @@ struct ContentView: View {
                             ActionsDemoView()
                         case .aiGeneration:
                             AIGenerationDemoView()
+                        case .screenContext:
+                            ScreenContextDemoView()
                         case .agent:
                             AgentDemoView()
                         }

--- a/Sample/Sample/Features/Agent/AgentDemoView.swift
+++ b/Sample/Sample/Features/Agent/AgentDemoView.swift
@@ -124,6 +124,13 @@ struct AgentDemoView: View {
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
+                Toggle(isOn: $viewModel.useScreenContext) {
+                    Text("Screen context")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .toggleStyle(.checkbox)
+                .help("Send accessibility tree and window info alongside screenshots")
             }
         }
         .padding(10)

--- a/Sample/Sample/Features/Agent/AgentDemoViewModel.swift
+++ b/Sample/Sample/Features/Agent/AgentDemoViewModel.swift
@@ -19,6 +19,7 @@ class AgentDemoViewModel {
     var openAIModel: String = "gpt-5.4"
     var maxIterations: Int = 20
     var delayBetweenSteps: Double = 1.0
+    var useScreenContext: Bool = true
 
     static let availableModels = [
         "gpt-5.4",
@@ -72,10 +73,12 @@ class AgentDemoViewModel {
         runTask = Task {
             do {
                 let backend = OpenAIVisionBackend(apiKey: openAIKey, model: openAIModel)
+                let contextOptions: ScreenContextProvider.Options? = useScreenContext ? ScreenContextProvider.Options() : nil
                 let agent = Agent(
                     backend: backend,
                     maxIterations: maxIterations,
-                    delayBetweenSteps: delayBetweenSteps
+                    delayBetweenSteps: delayBetweenSteps,
+                    screenContextOptions: contextOptions
                 )
 
                 let result = try await agent.run(goal: goal) { [weak self] step in

--- a/Sample/Sample/Features/ScreenContext/ScreenContextDemoView.swift
+++ b/Sample/Sample/Features/ScreenContext/ScreenContextDemoView.swift
@@ -1,0 +1,293 @@
+//
+//  ScreenContextDemoView.swift
+//  Sample
+//
+
+import SwiftUI
+import SwiftAutoGUI
+
+struct ScreenContextDemoView: View {
+    @State private var viewModel = ScreenContextViewModel()
+    @State private var showOptions = false
+    @Environment(\.colorScheme) var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // Header
+            HStack {
+                Image(systemName: "accessibility")
+                    .font(.title)
+                    .foregroundColor(.teal)
+                Text("Screen Context")
+                    .font(.title2)
+                    .fontWeight(.bold)
+                Spacer()
+
+                if let context = viewModel.context {
+                    HStack(spacing: 12) {
+                        badge("\(context.visibleWindows.count) windows", icon: "macwindow")
+                        badge("\(viewModel.nodeCount) nodes", icon: "list.bullet.indent")
+                    }
+                }
+            }
+
+            // Options (collapsible)
+            DisclosureGroup(isExpanded: $showOptions) {
+                optionsContent
+                    .padding(.top, 8)
+            } label: {
+                Text("Options")
+                    .font(.headline)
+            }
+
+            // Controls
+            HStack(spacing: 8) {
+                Button(action: { viewModel.gather() }) {
+                    Label("Capture", systemImage: "camera.viewfinder")
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.teal)
+                .disabled(viewModel.isLoading)
+
+                Toggle(isOn: Binding(
+                    get: { viewModel.autoRefresh },
+                    set: { newValue in
+                        if newValue {
+                            viewModel.startAutoRefresh()
+                        } else {
+                            viewModel.stopAutoRefresh()
+                        }
+                    }
+                )) {
+                    Label("Auto-refresh", systemImage: "arrow.clockwise")
+                        .font(.caption)
+                }
+                .toggleStyle(.checkbox)
+
+                if viewModel.autoRefresh {
+                    Text("every \(String(format: "%.1f", viewModel.refreshInterval))s")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+
+                if viewModel.isLoading {
+                    ProgressView()
+                        .scaleEffect(0.7)
+                }
+            }
+
+            if viewModel.formattedOutput.isEmpty {
+                emptyState
+            } else {
+                contextDisplay
+            }
+        }
+    }
+
+    // MARK: - Options
+
+    private var optionsContent: some View {
+        HStack(spacing: 24) {
+            HStack(spacing: 4) {
+                Text("Max depth:")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                TextField("", value: $viewModel.maxDepth, format: .number)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 50)
+            }
+            HStack(spacing: 4) {
+                Text("Max nodes:")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                TextField("", value: $viewModel.maxNodes, format: .number)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 60)
+            }
+            HStack(spacing: 4) {
+                Text("Max value length:")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                TextField("", value: $viewModel.maxValueLength, format: .number)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 50)
+            }
+            Toggle(isOn: $viewModel.includeAXTree) {
+                Text("AX Tree")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .toggleStyle(.checkbox)
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(colorScheme == .dark ? Color.gray.opacity(0.15) : Color.gray.opacity(0.06))
+        )
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "eye.slash")
+                .font(.largeTitle)
+                .foregroundColor(.secondary)
+            Text("Press Capture to gather screen context")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.vertical, 40)
+    }
+
+    // MARK: - Context Display
+
+    private var contextDisplay: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Summary cards
+            if let context = viewModel.context {
+                summaryCards(context)
+            }
+
+            // Formatted output
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Formatted Output (sent to LLM)")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.secondary)
+
+                ScrollView {
+                    Text(viewModel.formattedOutput)
+                        .font(.system(.caption, design: .monospaced))
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(10)
+                }
+                .frame(maxHeight: 300)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(colorScheme == .dark ? Color.black.opacity(0.3) : Color.gray.opacity(0.06))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color.gray.opacity(0.2), lineWidth: 1)
+                )
+            }
+        }
+    }
+
+    // MARK: - Summary Cards
+
+    private func summaryCards(_ context: ScreenContext) -> some View {
+        HStack(spacing: 12) {
+            // Frontmost app card
+            if let app = context.frontmostApp {
+                card(title: "Frontmost App") {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(app.name)
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                        if let bundle = app.bundleIdentifier {
+                            Text(bundle)
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                        }
+                        Text("PID: \(app.pid)")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+
+            // Windows card
+            card(title: "Visible Windows (\(context.visibleWindows.count))") {
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(Array(context.visibleWindows.prefix(5).enumerated()), id: \.offset) { _, window in
+                        HStack(spacing: 4) {
+                            Text(window.title ?? "(untitled)")
+                                .font(.caption2)
+                                .lineLimit(1)
+                            Text("- \(window.ownerApp)")
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                                .lineLimit(1)
+                        }
+                    }
+                    if context.visibleWindows.count > 5 {
+                        Text("... +\(context.visibleWindows.count - 5) more")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+
+            // AX Tree card
+            card(title: "AX Tree") {
+                if let tree = context.focusedWindowAXTree {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Root: \(tree.role)")
+                            .font(.caption2)
+                        if let label = tree.label {
+                            Text("\"\(label)\"")
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                        }
+                        Text("\(viewModel.nodeCount) nodes")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                } else {
+                    Text("Not available")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func card<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption2)
+                .fontWeight(.bold)
+                .foregroundColor(.secondary)
+            content()
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(colorScheme == .dark ? Color.gray.opacity(0.15) : Color.gray.opacity(0.06))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.gray.opacity(0.15), lineWidth: 1)
+        )
+    }
+
+    private func badge(_ text: String, icon: String) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.caption2)
+            Text(text)
+                .font(.caption2)
+                .fontWeight(.medium)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .background(Capsule().fill(Color.teal.opacity(0.15)))
+        .foregroundColor(.teal)
+    }
+}
+
+struct ScreenContextDemoView_Previews: PreviewProvider {
+    static var previews: some View {
+        ScreenContextDemoView()
+            .frame(width: 800, height: 600)
+    }
+}

--- a/Sample/Sample/Features/ScreenContext/ScreenContextViewModel.swift
+++ b/Sample/Sample/Features/ScreenContext/ScreenContextViewModel.swift
@@ -1,0 +1,71 @@
+//
+//  ScreenContextViewModel.swift
+//  Sample
+//
+
+import SwiftUI
+import SwiftAutoGUI
+
+@MainActor
+@Observable
+class ScreenContextViewModel {
+    var context: ScreenContext?
+    var formattedOutput: String = ""
+    var isLoading = false
+    var autoRefresh = false
+    var refreshInterval: Double = 2.0
+
+    // Options
+    var maxDepth: Int = 5
+    var maxNodes: Int = 200
+    var maxValueLength: Int = 100
+    var includeAXTree: Bool = true
+
+    private var refreshTask: Task<Void, Never>?
+
+    func gather() {
+        isLoading = true
+        let options = ScreenContextProvider.Options(
+            maxDepth: maxDepth,
+            maxNodes: maxNodes,
+            maxValueLength: maxValueLength,
+            includeAXTree: includeAXTree
+        )
+        let result = ScreenContextProvider.gather(options: options)
+        context = result
+        formattedOutput = result.formatted()
+        isLoading = false
+    }
+
+    func startAutoRefresh() {
+        stopAutoRefresh()
+        autoRefresh = true
+        refreshTask = Task {
+            while !Task.isCancelled {
+                gather()
+                try? await Task.sleep(for: .seconds(refreshInterval))
+            }
+        }
+    }
+
+    func stopAutoRefresh() {
+        autoRefresh = false
+        refreshTask?.cancel()
+        refreshTask = nil
+    }
+
+    var nodeCount: Int {
+        guard let tree = context?.focusedWindowAXTree else { return 0 }
+        return countNodes(tree)
+    }
+
+    private func countNodes(_ node: AXNode) -> Int {
+        var count = 1
+        if let children = node.children {
+            for child in children {
+                count += countNodes(child)
+            }
+        }
+        return count
+    }
+}

--- a/Sources/SwiftAutoGUI/Agent.swift
+++ b/Sources/SwiftAutoGUI/Agent.swift
@@ -39,20 +39,28 @@ public struct Agent: Sendable {
     /// Delay between steps to allow the screen to update.
     public let delayBetweenSteps: TimeInterval
 
+    /// Options for gathering screen context (accessibility tree, window info).
+    /// Set to `nil` to disable screen context gathering entirely.
+    public let screenContextOptions: ScreenContextProvider.Options?
+
     /// Creates an agent with the specified configuration.
     ///
     /// - Parameters:
     ///   - backend: The vision backend to use for action generation.
     ///   - maxIterations: Maximum loop iterations (default: 20).
     ///   - delayBetweenSteps: Seconds to wait between steps (default: 1.0).
+    ///   - screenContextOptions: Options for screen context gathering (default: enabled with defaults).
+    ///     Pass `nil` to disable.
     public init(
         backend: any VisionActionGenerating,
         maxIterations: Int = 20,
-        delayBetweenSteps: TimeInterval = 1.0
+        delayBetweenSteps: TimeInterval = 1.0,
+        screenContextOptions: ScreenContextProvider.Options? = ScreenContextProvider.Options()
     ) {
         self.backend = backend
         self.maxIterations = maxIterations
         self.delayBetweenSteps = delayBetweenSteps
+        self.screenContextOptions = screenContextOptions
     }
 
     /// Runs the agent loop to achieve the given goal.
@@ -87,12 +95,18 @@ public struct Agent: Sendable {
             let screenSize = SwiftAutoGUI.size()
             let screenCGSize = CGSize(width: screenSize.width, height: screenSize.height)
 
+            // 1b. Gather screen context (if enabled)
+            let screenContext: ScreenContext? = screenContextOptions.map { options in
+                ScreenContextProvider.gather(options: options)
+            }
+
             // 2. Think: send to backend
             let response = try await backend.generateActions(
                 goal: goal,
                 screenshot: jpegData,
                 screenSize: screenCGSize,
-                history: steps
+                history: steps,
+                screenContext: screenContext
             )
 
             // 3. Act: execute actions

--- a/Sources/SwiftAutoGUI/OpenAIVisionBackend.swift
+++ b/Sources/SwiftAutoGUI/OpenAIVisionBackend.swift
@@ -54,11 +54,28 @@ public struct OpenAIVisionBackend: VisionActionGenerating, Sendable {
         screenSize: CGSize,
         history: [AgentStep]
     ) async throws -> AgentResponse {
+        try await generateActions(
+            goal: goal,
+            screenshot: screenshot,
+            screenSize: screenSize,
+            history: history,
+            screenContext: nil
+        )
+    }
+
+    public func generateActions(
+        goal: String,
+        screenshot: Data,
+        screenSize: CGSize,
+        history: [AgentStep],
+        screenContext: ScreenContext?
+    ) async throws -> AgentResponse {
         let messages = buildMessages(
             goal: goal,
             screenshot: screenshot,
             screenSize: screenSize,
-            history: history
+            history: history,
+            screenContext: screenContext
         )
 
         let requestBody: [String: Any] = [
@@ -122,14 +139,15 @@ extension OpenAIVisionBackend {
         goal: String,
         screenshot: Data,
         screenSize: CGSize,
-        history: [AgentStep]
+        history: [AgentStep],
+        screenContext: ScreenContext? = nil
     ) -> [[String: Any]] {
         var messages: [[String: Any]] = []
 
         // System prompt
         messages.append([
             "role": "system",
-            "content": Self.buildSystemPrompt(screenSize: screenSize)
+            "content": Self.buildSystemPrompt(screenSize: screenSize, hasScreenContext: screenContext != nil)
         ])
 
         // History steps
@@ -141,8 +159,17 @@ extension OpenAIVisionBackend {
             ])
         }
 
-        // Current screenshot + goal
+        // Current screenshot + goal + screen context
         let base64 = screenshot.base64EncodedString()
+
+        var userText = "Goal: \(goal)\n"
+        if let context = screenContext {
+            userText += "\n--- Screen Context ---\n"
+            userText += context.formatted()
+            userText += "\n--- End Screen Context ---\n"
+        }
+        userText += "\nThis is the current screenshot. What actions should I take next?"
+
         messages.append([
             "role": "user",
             "content": [
@@ -155,7 +182,7 @@ extension OpenAIVisionBackend {
                 ] as [String: Any],
                 [
                     "type": "text",
-                    "text": "Goal: \(goal)\n\nThis is the current screenshot. What actions should I take next?"
+                    "text": userText
                 ] as [String: Any]
             ] as [[String: Any]]
         ] as [String: Any])
@@ -183,8 +210,8 @@ extension OpenAIVisionBackend {
 // MARK: - System Prompt
 
 extension OpenAIVisionBackend {
-    static func buildSystemPrompt(screenSize: CGSize) -> String {
-        """
+    static func buildSystemPrompt(screenSize: CGSize, hasScreenContext: Bool = false) -> String {
+        var prompt = """
         You are an AI agent controlling a macOS computer to achieve a user's goal. \
         You will receive screenshots of the current screen state and must decide what actions to take.
 
@@ -215,6 +242,24 @@ extension OpenAIVisionBackend {
 
         Respond with a JSON object containing "reasoning", "isDone", and "actions" fields.
         """
+
+        if hasScreenContext {
+            prompt += """
+
+
+            You will also receive structured screen context alongside the screenshot. This includes:
+            - The frontmost application name and bundle identifier
+            - A list of visible windows with their titles, owning apps, and screen bounds
+            - An accessibility tree of the focused window showing UI elements with their roles, labels, values, and positions
+
+            Use this context to precisely locate UI elements. The bounding boxes in the accessibility tree \
+            give exact coordinates you can use with move/click actions. Prefer using accessibility tree \
+            coordinates over guessing positions from the screenshot when available. \
+            The accessibility tree may be truncated ([...]) for deeply nested elements.
+            """
+        }
+
+        return prompt
     }
 }
 

--- a/Sources/SwiftAutoGUI/ScreenContext.swift
+++ b/Sources/SwiftAutoGUI/ScreenContext.swift
@@ -1,0 +1,434 @@
+//
+//  ScreenContext.swift
+//  SwiftAutoGUI
+//
+
+import AppKit
+import ApplicationServices
+import Foundation
+
+// MARK: - Data Types
+
+/// Rich context about the current macOS screen state, including the frontmost app,
+/// visible windows, and an accessibility tree of the focused window.
+///
+/// This information supplements screenshots to give AI agents precise knowledge
+/// of UI element positions, labels, roles, and states.
+public struct ScreenContext: Sendable, Codable {
+    /// The currently active (frontmost) application.
+    public let frontmostApp: AppInfo?
+
+    /// All visible on-screen windows, ordered by layer.
+    public let visibleWindows: [WindowInfo]
+
+    /// The accessibility tree of the focused window (nil if unavailable).
+    public let focusedWindowAXTree: AXNode?
+
+    public init(frontmostApp: AppInfo?, visibleWindows: [WindowInfo], focusedWindowAXTree: AXNode?) {
+        self.frontmostApp = frontmostApp
+        self.visibleWindows = visibleWindows
+        self.focusedWindowAXTree = focusedWindowAXTree
+    }
+}
+
+/// Information about a running application.
+public struct AppInfo: Sendable, Codable {
+    public let name: String
+    public let bundleIdentifier: String?
+    public let pid: Int32
+
+    public init(name: String, bundleIdentifier: String?, pid: Int32) {
+        self.name = name
+        self.bundleIdentifier = bundleIdentifier
+        self.pid = pid
+    }
+}
+
+/// Information about a visible window on screen.
+public struct WindowInfo: Sendable, Codable {
+    public let title: String?
+    public let ownerApp: String
+    public let bounds: CodableRect
+    public let layer: Int
+    public let isOnScreen: Bool
+
+    public init(title: String?, ownerApp: String, bounds: CodableRect, layer: Int, isOnScreen: Bool) {
+        self.title = title
+        self.ownerApp = ownerApp
+        self.bounds = bounds
+        self.layer = layer
+        self.isOnScreen = isOnScreen
+    }
+}
+
+/// A node in the macOS accessibility tree.
+///
+/// Represents a single UI element with its role, label, value, position, and children.
+/// The tree is depth- and node-limited to control token usage when sent to an LLM.
+public struct AXNode: Sendable, Codable {
+    /// The accessibility role (e.g. "AXButton", "AXTextField", "AXWindow").
+    public let role: String
+
+    /// The element's title or description label.
+    public let label: String?
+
+    /// The element's value (e.g. text field content), truncated for long values.
+    public let value: String?
+
+    /// The element's position and size in screen coordinates (top-left origin).
+    public let frame: CodableRect
+
+    /// Whether the element is currently enabled.
+    public let isEnabled: Bool
+
+    /// Child elements. `nil` means the subtree was pruned due to depth/node limits.
+    /// An empty array means the element genuinely has no children.
+    public let children: [AXNode]?
+
+    public init(role: String, label: String?, value: String?, frame: CodableRect, isEnabled: Bool, children: [AXNode]?) {
+        self.role = role
+        self.label = label
+        self.value = value
+        self.frame = frame
+        self.isEnabled = isEnabled
+        self.children = children
+    }
+}
+
+/// A `Codable`-conforming wrapper for `CGRect`, since `CGRect` does not conform to `Codable`.
+public struct CodableRect: Sendable, Codable, Equatable {
+    public let x: Double
+    public let y: Double
+    public let width: Double
+    public let height: Double
+
+    public init(x: Double, y: Double, width: Double, height: Double) {
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+    }
+
+    public init(_ rect: CGRect) {
+        self.x = Double(rect.origin.x)
+        self.y = Double(rect.origin.y)
+        self.width = Double(rect.size.width)
+        self.height = Double(rect.size.height)
+    }
+
+    public var cgRect: CGRect {
+        CGRect(x: x, y: y, width: width, height: height)
+    }
+}
+
+// MARK: - ScreenContextProvider
+
+/// Gathers rich context about the current macOS screen state.
+public struct ScreenContextProvider: Sendable {
+
+    /// Options controlling what information is gathered and how much of the
+    /// accessibility tree is traversed.
+    public struct Options: Sendable {
+        /// Maximum depth of the accessibility tree traversal.
+        public var maxDepth: Int
+
+        /// Maximum total number of AX nodes to collect.
+        public var maxNodes: Int
+
+        /// Maximum length for element values (longer values are truncated).
+        public var maxValueLength: Int
+
+        /// Whether to include the accessibility tree at all.
+        public var includeAXTree: Bool
+
+        public init(maxDepth: Int = 5, maxNodes: Int = 200, maxValueLength: Int = 100, includeAXTree: Bool = true) {
+            self.maxDepth = maxDepth
+            self.maxNodes = maxNodes
+            self.maxValueLength = maxValueLength
+            self.includeAXTree = includeAXTree
+        }
+    }
+
+    /// Gathers the current screen context.
+    ///
+    /// - Parameter options: Controls tree depth, node limits, and whether to include the AX tree.
+    /// - Returns: A ``ScreenContext`` with the current screen state.
+    @MainActor
+    public static func gather(options: Options = Options()) -> ScreenContext {
+        let frontmostApp = gatherFrontmostApp()
+        let visibleWindows = gatherVisibleWindows()
+
+        var axTree: AXNode?
+        if options.includeAXTree, let app = frontmostApp {
+            var nodeCount = 0
+            axTree = gatherAXTree(pid: app.pid, options: options, nodeCount: &nodeCount)
+        }
+
+        return ScreenContext(
+            frontmostApp: frontmostApp,
+            visibleWindows: visibleWindows,
+            focusedWindowAXTree: axTree
+        )
+    }
+}
+
+// MARK: - Gathering: Frontmost App
+
+extension ScreenContextProvider {
+    private static func gatherFrontmostApp() -> AppInfo? {
+        guard let app = NSWorkspace.shared.frontmostApplication else { return nil }
+        return AppInfo(
+            name: app.localizedName ?? "Unknown",
+            bundleIdentifier: app.bundleIdentifier,
+            pid: app.processIdentifier
+        )
+    }
+}
+
+// MARK: - Gathering: Visible Windows
+
+extension ScreenContextProvider {
+    private static func gatherVisibleWindows() -> [WindowInfo] {
+        guard let windowList = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements],
+            kCGNullWindowID
+        ) as? [[String: Any]] else {
+            return []
+        }
+
+        return windowList.compactMap { dict -> WindowInfo? in
+            guard let ownerName = dict[kCGWindowOwnerName as String] as? String else { return nil }
+
+            let layer = dict[kCGWindowLayer as String] as? Int ?? 0
+            // Only include normal windows (layer 0)
+            guard layer == 0 else { return nil }
+
+            let title = dict[kCGWindowName as String] as? String
+            let isOnScreen = dict[kCGWindowIsOnscreen as String] as? Bool ?? false
+
+            let bounds: CodableRect
+            if let boundsDict = dict[kCGWindowBounds as String] as? [String: Any],
+               let boundsRef = CGRect(dictionaryRepresentation: boundsDict as CFDictionary) {
+                bounds = CodableRect(boundsRef)
+            } else {
+                bounds = CodableRect(x: 0, y: 0, width: 0, height: 0)
+            }
+
+            return WindowInfo(
+                title: title,
+                ownerApp: ownerName,
+                bounds: bounds,
+                layer: layer,
+                isOnScreen: isOnScreen
+            )
+        }
+    }
+}
+
+// MARK: - Gathering: Accessibility Tree
+
+extension ScreenContextProvider {
+
+    private static func gatherAXTree(pid: Int32, options: Options, nodeCount: inout Int) -> AXNode? {
+        let appElement = AXUIElementCreateApplication(pid)
+
+        // Get the focused window
+        var focusedWindow: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(
+            appElement,
+            kAXFocusedWindowAttribute as CFString,
+            &focusedWindow
+        )
+
+        guard result == .success, let windowElement = focusedWindow else {
+            return nil
+        }
+
+        // The CFTypeRef is actually an AXUIElement
+        let axWindow = windowElement as! AXUIElement
+        return buildAXNode(from: axWindow, options: options, depth: 0, nodeCount: &nodeCount)
+    }
+
+    private static func buildAXNode(
+        from element: AXUIElement,
+        options: Options,
+        depth: Int,
+        nodeCount: inout Int
+    ) -> AXNode? {
+        guard nodeCount < options.maxNodes else { return nil }
+        nodeCount += 1
+
+        let role = axStringAttribute(element, kAXRoleAttribute) ?? "AXUnknown"
+        let title = axStringAttribute(element, kAXTitleAttribute)
+        let description = axStringAttribute(element, kAXDescriptionAttribute)
+        let label = title ?? description
+
+        var value: String? = nil
+        if let rawValue = axStringAttribute(element, kAXValueAttribute) {
+            if rawValue.count > options.maxValueLength {
+                value = String(rawValue.prefix(options.maxValueLength)) + "..."
+            } else {
+                value = rawValue
+            }
+        }
+
+        let frame = axFrame(element)
+        let isEnabled = axBoolAttribute(element, kAXEnabledAttribute) ?? true
+
+        // Get children if within depth limit
+        let children: [AXNode]?
+        if depth < options.maxDepth {
+            var childrenRef: CFTypeRef?
+            let result = AXUIElementCopyAttributeValue(
+                element,
+                kAXChildrenAttribute as CFString,
+                &childrenRef
+            )
+            if result == .success, let childArray = childrenRef as? [AXUIElement] {
+                children = childArray.compactMap { child in
+                    buildAXNode(from: child, options: options, depth: depth + 1, nodeCount: &nodeCount)
+                }
+            } else {
+                children = []
+            }
+        } else {
+            // Check if there are children we're not traversing
+            var childCount: CFTypeRef?
+            let result = AXUIElementCopyAttributeValue(
+                element,
+                kAXChildrenAttribute as CFString,
+                &childCount
+            )
+            if result == .success, let arr = childCount as? [AnyObject], !arr.isEmpty {
+                children = nil // nil signals pruned subtree
+            } else {
+                children = []
+            }
+        }
+
+        return AXNode(
+            role: role,
+            label: label,
+            value: value,
+            frame: frame,
+            isEnabled: isEnabled,
+            children: children
+        )
+    }
+
+    // MARK: AX Attribute Helpers
+
+    private static func axStringAttribute(_ element: AXUIElement, _ attribute: String) -> String? {
+        var value: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
+        guard result == .success else { return nil }
+        return value as? String
+    }
+
+    private static func axBoolAttribute(_ element: AXUIElement, _ attribute: String) -> Bool? {
+        var value: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
+        guard result == .success else { return nil }
+        return (value as? NSNumber)?.boolValue
+    }
+
+    private static func axFrame(_ element: AXUIElement) -> CodableRect {
+        var positionRef: CFTypeRef?
+        var sizeRef: CFTypeRef?
+
+        AXUIElementCopyAttributeValue(element, kAXPositionAttribute as CFString, &positionRef)
+        AXUIElementCopyAttributeValue(element, kAXSizeAttribute as CFString, &sizeRef)
+
+        var position = CGPoint.zero
+        var size = CGSize.zero
+
+        if let positionRef = positionRef {
+            // AXValue contains a CGPoint
+            let axValue = positionRef as! AXValue
+            AXValueGetValue(axValue, .cgPoint, &position)
+        }
+
+        if let sizeRef = sizeRef {
+            let axValue = sizeRef as! AXValue
+            AXValueGetValue(axValue, .cgSize, &size)
+        }
+
+        return CodableRect(
+            x: Double(position.x),
+            y: Double(position.y),
+            width: Double(size.width),
+            height: Double(size.height)
+        )
+    }
+}
+
+// MARK: - Formatting
+
+extension ScreenContext {
+    /// Formats the screen context as compact, LLM-friendly text.
+    ///
+    /// The output uses indented tree structure which is token-efficient
+    /// and easy for LLMs to parse.
+    public func formatted() -> String {
+        var lines: [String] = []
+
+        // Frontmost app
+        if let app = frontmostApp {
+            let bundle = app.bundleIdentifier.map { " (\($0))" } ?? ""
+            lines.append("Frontmost app: \(app.name)\(bundle)")
+        }
+
+        // Visible windows
+        if !visibleWindows.isEmpty {
+            lines.append("Visible windows:")
+            for (index, window) in visibleWindows.enumerated() {
+                let title = window.title.map { "\"\($0)\"" } ?? "(untitled)"
+                let b = window.bounds
+                lines.append("  [\(index)] \(title) - \(window.ownerApp) @ {\(Int(b.x)),\(Int(b.y)) \(Int(b.width))x\(Int(b.height))}")
+            }
+        }
+
+        // AX tree
+        if let tree = focusedWindowAXTree {
+            lines.append("Focused window AX tree:")
+            tree.appendFormatted(to: &lines, indent: 1)
+        }
+
+        return lines.joined(separator: "\n")
+    }
+}
+
+extension AXNode {
+    func appendFormatted(to lines: inout [String], indent: Int) {
+        let prefix = String(repeating: "  ", count: indent)
+        var parts: [String] = [role]
+
+        if let label = label, !label.isEmpty {
+            parts.append("\"\(label)\"")
+        }
+
+        if let value = value, !value.isEmpty {
+            parts.append("value=\"\(value)\"")
+        }
+
+        let f = frame
+        if f.width > 0 || f.height > 0 {
+            parts.append("{\(Int(f.x)),\(Int(f.y)) \(Int(f.width))x\(Int(f.height))}")
+        }
+
+        if !isEnabled {
+            parts.append("disabled")
+        }
+
+        lines.append(prefix + parts.joined(separator: " "))
+
+        if let children = children {
+            for child in children {
+                child.appendFormatted(to: &lines, indent: indent + 1)
+            }
+        } else {
+            // nil children means pruned
+            lines.append(prefix + "  [...]")
+        }
+    }
+}

--- a/Sources/SwiftAutoGUI/VisionActionGenerating.swift
+++ b/Sources/SwiftAutoGUI/VisionActionGenerating.swift
@@ -46,6 +46,38 @@ public protocol VisionActionGenerating: Sendable {
     ) async throws -> AgentResponse
 }
 
+// MARK: - Default Implementation with Screen Context
+
+extension VisionActionGenerating {
+    /// Generates actions with additional screen context alongside the screenshot.
+    ///
+    /// The default implementation ignores the screen context and delegates to the
+    /// base ``generateActions(goal:screenshot:screenSize:history:)`` method.
+    /// Backends that support screen context can override this method.
+    ///
+    /// - Parameters:
+    ///   - goal: The natural language goal to accomplish.
+    ///   - screenshot: JPEG-compressed screenshot data of the current screen.
+    ///   - screenSize: The screen dimensions in points.
+    ///   - history: Previous agent steps for context.
+    ///   - screenContext: Structured information about the current screen state.
+    /// - Returns: An ``AgentResponse`` containing actions, reasoning, and completion status.
+    public func generateActions(
+        goal: String,
+        screenshot: Data,
+        screenSize: CGSize,
+        history: [AgentStep],
+        screenContext: ScreenContext?
+    ) async throws -> AgentResponse {
+        try await generateActions(
+            goal: goal,
+            screenshot: screenshot,
+            screenSize: screenSize,
+            history: history
+        )
+    }
+}
+
 // MARK: - Agent Types
 
 /// A record of one step in the agent loop.

--- a/Sources/sagui/AgentCommand.swift
+++ b/Sources/sagui/AgentCommand.swift
@@ -34,6 +34,9 @@ struct AgentCommand: AsyncParsableCommand {
     @Option(help: "Delay between steps in seconds.")
     var delay: Double = 1.0
 
+    @Flag(help: "Disable screen context (accessibility tree and window info).")
+    var noScreenContext: Bool = false
+
     @MainActor
     func run() async throws {
         let key = apiKey ?? ProcessInfo.processInfo.environment["OPENAI_API_KEY"]
@@ -42,14 +45,16 @@ struct AgentCommand: AsyncParsableCommand {
         }
 
         let backend = OpenAIVisionBackend(apiKey: key, model: model)
+        let contextOptions: ScreenContextProvider.Options? = noScreenContext ? nil : ScreenContextProvider.Options()
         let agent = Agent(
             backend: backend,
             maxIterations: maxIterations,
-            delayBetweenSteps: delay
+            delayBetweenSteps: delay,
+            screenContextOptions: contextOptions
         )
 
         print("Agent starting with goal: \"\(goal)\"")
-        print("Model: \(model), Max iterations: \(maxIterations), Delay: \(delay)s")
+        print("Model: \(model), Max iterations: \(maxIterations), Delay: \(delay)s, Screen context: \(!noScreenContext)")
         print("---")
 
         let result = try await agent.run(goal: goal) { step in

--- a/Tests/SwiftAutoGUITests/ScreenContextTests.swift
+++ b/Tests/SwiftAutoGUITests/ScreenContextTests.swift
@@ -1,0 +1,228 @@
+//
+//  ScreenContextTests.swift
+//  SwiftAutoGUITests
+//
+
+import Foundation
+import Testing
+@testable import SwiftAutoGUI
+
+@Suite("ScreenContext Tests")
+struct ScreenContextTests {
+
+    // MARK: - CodableRect Tests
+
+    @Suite("CodableRect")
+    struct CodableRectTests {
+
+        @Test("round-trip encoding/decoding")
+        func roundTrip() throws {
+            let rect = CodableRect(x: 10, y: 20, width: 300, height: 400)
+            let data = try JSONEncoder().encode(rect)
+            let decoded = try JSONDecoder().decode(CodableRect.self, from: data)
+            #expect(decoded == rect)
+        }
+
+        @Test("init from CGRect")
+        func initFromCGRect() {
+            let cgRect = CGRect(x: 1.5, y: 2.5, width: 100.0, height: 200.0)
+            let rect = CodableRect(cgRect)
+            #expect(rect.x == 1.5)
+            #expect(rect.y == 2.5)
+            #expect(rect.width == 100.0)
+            #expect(rect.height == 200.0)
+        }
+
+        @Test("cgRect conversion")
+        func cgRectConversion() {
+            let rect = CodableRect(x: 5, y: 10, width: 50, height: 60)
+            let cgRect = rect.cgRect
+            #expect(cgRect.origin.x == 5)
+            #expect(cgRect.origin.y == 10)
+            #expect(cgRect.size.width == 50)
+            #expect(cgRect.size.height == 60)
+        }
+    }
+
+    // MARK: - Formatting Tests
+
+    @Suite("ScreenContext Formatting")
+    struct FormattingTests {
+
+        @Test("formats frontmost app")
+        func frontmostApp() {
+            let context = ScreenContext(
+                frontmostApp: AppInfo(name: "Safari", bundleIdentifier: "com.apple.Safari", pid: 123),
+                visibleWindows: [],
+                focusedWindowAXTree: nil
+            )
+            let output = context.formatted()
+            #expect(output.contains("Frontmost app: Safari (com.apple.Safari)"))
+        }
+
+        @Test("formats frontmost app without bundle identifier")
+        func frontmostAppNoBundleId() {
+            let context = ScreenContext(
+                frontmostApp: AppInfo(name: "MyApp", bundleIdentifier: nil, pid: 456),
+                visibleWindows: [],
+                focusedWindowAXTree: nil
+            )
+            let output = context.formatted()
+            #expect(output.contains("Frontmost app: MyApp"))
+            #expect(!output.contains("("))
+        }
+
+        @Test("formats visible windows")
+        func visibleWindows() {
+            let context = ScreenContext(
+                frontmostApp: nil,
+                visibleWindows: [
+                    WindowInfo(
+                        title: "Documents",
+                        ownerApp: "Finder",
+                        bounds: CodableRect(x: 0, y: 25, width: 1200, height: 775),
+                        layer: 0,
+                        isOnScreen: true
+                    ),
+                    WindowInfo(
+                        title: "Terminal",
+                        ownerApp: "Terminal",
+                        bounds: CodableRect(x: 200, y: 100, width: 800, height: 600),
+                        layer: 0,
+                        isOnScreen: true
+                    ),
+                ],
+                focusedWindowAXTree: nil
+            )
+            let output = context.formatted()
+            #expect(output.contains("Visible windows:"))
+            #expect(output.contains("[0] \"Documents\" - Finder @ {0,25 1200x775}"))
+            #expect(output.contains("[1] \"Terminal\" - Terminal @ {200,100 800x600}"))
+        }
+
+        @Test("formats untitled window")
+        func untitledWindow() {
+            let context = ScreenContext(
+                frontmostApp: nil,
+                visibleWindows: [
+                    WindowInfo(
+                        title: nil,
+                        ownerApp: "Finder",
+                        bounds: CodableRect(x: 0, y: 0, width: 100, height: 100),
+                        layer: 0,
+                        isOnScreen: true
+                    ),
+                ],
+                focusedWindowAXTree: nil
+            )
+            let output = context.formatted()
+            #expect(output.contains("(untitled)"))
+        }
+
+        @Test("formats AX tree with children")
+        func axTreeWithChildren() {
+            let tree = AXNode(
+                role: "AXWindow",
+                label: "Documents",
+                value: nil,
+                frame: CodableRect(x: 0, y: 25, width: 1200, height: 775),
+                isEnabled: true,
+                children: [
+                    AXNode(
+                        role: "AXButton",
+                        label: "Back",
+                        value: nil,
+                        frame: CodableRect(x: 10, y: 30, width: 28, height: 28),
+                        isEnabled: true,
+                        children: []
+                    ),
+                    AXNode(
+                        role: "AXButton",
+                        label: "Forward",
+                        value: nil,
+                        frame: CodableRect(x: 42, y: 30, width: 28, height: 28),
+                        isEnabled: false,
+                        children: []
+                    ),
+                ]
+            )
+            let context = ScreenContext(
+                frontmostApp: nil,
+                visibleWindows: [],
+                focusedWindowAXTree: tree
+            )
+            let output = context.formatted()
+            #expect(output.contains("Focused window AX tree:"))
+            #expect(output.contains("AXWindow \"Documents\" {0,25 1200x775}"))
+            #expect(output.contains("AXButton \"Back\" {10,30 28x28}"))
+            #expect(output.contains("AXButton \"Forward\" {42,30 28x28} disabled"))
+        }
+
+        @Test("formats AX node with value")
+        func axNodeWithValue() {
+            let node = AXNode(
+                role: "AXTextField",
+                label: "Search",
+                value: "hello world",
+                frame: CodableRect(x: 100, y: 50, width: 200, height: 22),
+                isEnabled: true,
+                children: []
+            )
+            let context = ScreenContext(
+                frontmostApp: nil,
+                visibleWindows: [],
+                focusedWindowAXTree: node
+            )
+            let output = context.formatted()
+            #expect(output.contains("AXTextField \"Search\" value=\"hello world\" {100,50 200x22}"))
+        }
+
+        @Test("formats pruned subtree with [...]")
+        func prunedSubtree() {
+            let node = AXNode(
+                role: "AXGroup",
+                label: nil,
+                value: nil,
+                frame: CodableRect(x: 0, y: 0, width: 500, height: 500),
+                isEnabled: true,
+                children: nil // nil = pruned
+            )
+            let context = ScreenContext(
+                frontmostApp: nil,
+                visibleWindows: [],
+                focusedWindowAXTree: node
+            )
+            let output = context.formatted()
+            #expect(output.contains("[...]"))
+        }
+
+        @Test("full context output combines all sections")
+        func fullContext() {
+            let context = ScreenContext(
+                frontmostApp: AppInfo(name: "Finder", bundleIdentifier: "com.apple.finder", pid: 312),
+                visibleWindows: [
+                    WindowInfo(
+                        title: "Documents",
+                        ownerApp: "Finder",
+                        bounds: CodableRect(x: 0, y: 25, width: 1200, height: 775),
+                        layer: 0,
+                        isOnScreen: true
+                    ),
+                ],
+                focusedWindowAXTree: AXNode(
+                    role: "AXWindow",
+                    label: "Documents",
+                    value: nil,
+                    frame: CodableRect(x: 0, y: 25, width: 1200, height: 775),
+                    isEnabled: true,
+                    children: []
+                )
+            )
+            let output = context.formatted()
+            // All three sections present
+            #expect(output.contains("Frontmost app:"))
+            #expect(output.contains("Visible windows:"))
+            #expect(output.contains("Focused window AX tree:"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ScreenContext` module that gathers rich macOS screen state (frontmost app, visible windows, accessibility tree of focused window) using `AXUIElement`, `CGWindowListCopyWindowInfo`, and `NSWorkspace` APIs
- Send structured context as text alongside screenshots in the Agent loop, improving AI accuracy for UI element targeting
- Backward compatible: protocol extension with default implementation that ignores context
- Add `--no-screen-context` flag to `sagui agent` CLI command
- Add Screen Context demo tab to Sample app for inspecting gathered context with auto-refresh
- Add screen context toggle to Agent demo settings in Sample app

Closes #77

## Test plan
- [x] `swift build` passes
- [x] `swift test --filter ScreenContextTests` — 11 tests pass (formatting, CodableRect, AX tree rendering)
- [ ] Run Sample app → Screen Context tab → Capture button shows correct context
- [ ] Run Sample app → AI Agent tab → verify screen context toggle works
- [ ] Run `sagui agent` with and without `--no-screen-context` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)