### PR TITLE
feat: add keyboard input source context to AI agent

### DIFF
--- a/Sources/SwiftAutoGUI/OpenAIVisionBackend.swift
+++ b/Sources/SwiftAutoGUI/OpenAIVisionBackend.swift
@@ -249,6 +249,7 @@ extension OpenAIVisionBackend {
 
             You will also receive structured screen context alongside the screenshot. This includes:
             - The frontmost application name and bundle identifier
+            - The current keyboard input source / IME mode (e.g., "U.S.", "日本語ローマ字")
             - A list of visible windows with their titles, owning apps, and screen bounds
             - An accessibility tree of the focused window showing UI elements with their roles, labels, values, and positions
 
@@ -256,6 +257,10 @@ extension OpenAIVisionBackend {
             give exact coordinates you can use with move/click actions. Prefer using accessibility tree \
             coordinates over guessing positions from the screenshot when available. \
             The accessibility tree may be truncated ([...]) for deeply nested elements.
+
+            When the keyboard input source indicates a non-ASCII input mode (e.g., Japanese), \
+            consider switching to an ASCII-capable source before using the 'write' action for English text. \
+            Common shortcuts to toggle input source include Control+Space or Caps Lock, depending on user settings.
             """
         }
 

--- a/Sources/SwiftAutoGUI/ScreenContext.swift
+++ b/Sources/SwiftAutoGUI/ScreenContext.swift
@@ -5,6 +5,7 @@
 
 import AppKit
 import ApplicationServices
+import Carbon
 import Foundation
 
 // MARK: - Data Types
@@ -24,10 +25,14 @@ public struct ScreenContext: Sendable, Codable {
     /// The accessibility tree of the focused window (nil if unavailable).
     public let focusedWindowAXTree: AXNode?
 
-    public init(frontmostApp: AppInfo?, visibleWindows: [WindowInfo], focusedWindowAXTree: AXNode?) {
+    /// The current keyboard input source / IME mode (nil if unavailable).
+    public let keyboardInputSource: InputSourceInfo?
+
+    public init(frontmostApp: AppInfo?, visibleWindows: [WindowInfo], focusedWindowAXTree: AXNode?, keyboardInputSource: InputSourceInfo? = nil) {
         self.frontmostApp = frontmostApp
         self.visibleWindows = visibleWindows
         self.focusedWindowAXTree = focusedWindowAXTree
+        self.keyboardInputSource = keyboardInputSource
     }
 }
 
@@ -41,6 +46,20 @@ public struct AppInfo: Sendable, Codable {
         self.name = name
         self.bundleIdentifier = bundleIdentifier
         self.pid = pid
+    }
+}
+
+/// Information about the current keyboard input source (IME state).
+public struct InputSourceInfo: Sendable, Codable {
+    /// The input source identifier (e.g., "com.apple.inputmethod.Japanese.RomajiTyping").
+    public let id: String
+
+    /// The localized display name (e.g., "日本語ローマ字", "U.S.").
+    public let localizedName: String
+
+    public init(id: String, localizedName: String) {
+        self.id = id
+        self.localizedName = localizedName
     }
 }
 
@@ -157,6 +176,7 @@ public struct ScreenContextProvider: Sendable {
     public static func gather(options: Options = Options()) -> ScreenContext {
         let frontmostApp = gatherFrontmostApp()
         let visibleWindows = gatherVisibleWindows()
+        let inputSource = gatherKeyboardInputSource()
 
         var axTree: AXNode?
         if options.includeAXTree, let app = frontmostApp {
@@ -167,7 +187,8 @@ public struct ScreenContextProvider: Sendable {
         return ScreenContext(
             frontmostApp: frontmostApp,
             visibleWindows: visibleWindows,
-            focusedWindowAXTree: axTree
+            focusedWindowAXTree: axTree,
+            keyboardInputSource: inputSource
         )
     }
 }
@@ -182,6 +203,26 @@ extension ScreenContextProvider {
             bundleIdentifier: app.bundleIdentifier,
             pid: app.processIdentifier
         )
+    }
+}
+
+// MARK: - Gathering: Keyboard Input Source
+
+extension ScreenContextProvider {
+    private static func gatherKeyboardInputSource() -> InputSourceInfo? {
+        guard let source = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() else {
+            return nil
+        }
+
+        let idPtr = TISGetInputSourceProperty(source, kTISPropertyInputSourceID)
+        let namePtr = TISGetInputSourceProperty(source, kTISPropertyLocalizedName)
+
+        guard let idPtr, let namePtr else { return nil }
+
+        let id = Unmanaged<CFString>.fromOpaque(idPtr).takeUnretainedValue() as String
+        let localizedName = Unmanaged<CFString>.fromOpaque(namePtr).takeUnretainedValue() as String
+
+        return InputSourceInfo(id: id, localizedName: localizedName)
     }
 }
 
@@ -376,6 +417,11 @@ extension ScreenContext {
         if let app = frontmostApp {
             let bundle = app.bundleIdentifier.map { " (\($0))" } ?? ""
             lines.append("Frontmost app: \(app.name)\(bundle)")
+        }
+
+        // Keyboard input source
+        if let inputSource = keyboardInputSource {
+            lines.append("Keyboard input source: \(inputSource.localizedName) (\(inputSource.id))")
         }
 
         // Visible windows

--- a/Tests/SwiftAutoGUITests/ScreenContextTests.swift
+++ b/Tests/SwiftAutoGUITests/ScreenContextTests.swift
@@ -10,6 +10,21 @@ import Testing
 @Suite("ScreenContext Tests")
 struct ScreenContextTests {
 
+    // MARK: - InputSourceInfo Tests
+
+    @Suite("InputSourceInfo")
+    struct InputSourceInfoTests {
+
+        @Test("round-trip encoding/decoding")
+        func roundTrip() throws {
+            let info = InputSourceInfo(id: "com.apple.keylayout.US", localizedName: "U.S.")
+            let data = try JSONEncoder().encode(info)
+            let decoded = try JSONDecoder().decode(InputSourceInfo.self, from: data)
+            #expect(decoded.id == info.id)
+            #expect(decoded.localizedName == info.localizedName)
+        }
+    }
+
     // MARK: - CodableRect Tests
 
     @Suite("CodableRect")
@@ -194,6 +209,33 @@ struct ScreenContextTests {
             )
             let output = context.formatted()
             #expect(output.contains("[...]"))
+        }
+
+        @Test("formats keyboard input source")
+        func keyboardInputSource() {
+            let context = ScreenContext(
+                frontmostApp: nil,
+                visibleWindows: [],
+                focusedWindowAXTree: nil,
+                keyboardInputSource: InputSourceInfo(
+                    id: "com.apple.keylayout.US",
+                    localizedName: "U.S."
+                )
+            )
+            let output = context.formatted()
+            #expect(output.contains("Keyboard input source: U.S. (com.apple.keylayout.US)"))
+        }
+
+        @Test("omits keyboard input source when nil")
+        func noKeyboardInputSource() {
+            let context = ScreenContext(
+                frontmostApp: nil,
+                visibleWindows: [],
+                focusedWindowAXTree: nil,
+                keyboardInputSource: nil
+            )
+            let output = context.formatted()
+            #expect(!output.contains("Keyboard input source"))
         }
 
         @Test("full context output combines all sections")


### PR DESCRIPTION
## Summary
- Add `InputSourceInfo` struct and `keyboardInputSource` field to `ScreenContext` to expose the current keyboard input mode (e.g., "日本語ローマ字", "U.S.") to the AI agent
- Gather input source via `TISCopyCurrentKeyboardInputSource()` API in `ScreenContextProvider.gather()`
- Update the OpenAI Vision backend system prompt to describe the new context and guide the agent on input source switching
- Add tests for `InputSourceInfo` Codable round-trip and `formatted()` output

## Test plan
- [x] `swift build` passes
- [x] `swift test --filter ScreenContextTests` — all 14 tests pass (including 3 new tests)
- [ ] Run `sagui agent` and verify keyboard input source appears in Screen Context output

🤖 Generated with [Claude Code](https://claude.com/claude-code)