### PR TITLE
feat: add AXUIElement-based actions for semantic GUI automation

### DIFF
--- a/Sources/SwiftAutoGUI/AXAction.swift
+++ b/Sources/SwiftAutoGUI/AXAction.swift
@@ -1,0 +1,161 @@
+//
+//  AXAction.swift
+//  SwiftAutoGUI
+//
+
+import ApplicationServices
+import CoreGraphics
+import Foundation
+
+/// Low-level wrappers around `AXUIElementPerformAction` and
+/// `AXUIElementSetAttributeValue`.
+///
+/// Use these when you already hold an `AXUIElement` reference (for example,
+/// from ``AXSearch/findElement(role:options:scope:)``). For higher-level
+/// search-and-act convenience, see the AX methods on ``SwiftAutoGUI``.
+///
+/// All methods are `@MainActor` because `AXUIElement` is not thread-safe —
+/// even concurrent reads can corrupt internal state.
+public enum AXAction {
+
+    // MARK: - Perform-action wrappers
+
+    /// Performs `kAXPressAction` (the canonical "click" for a button or link).
+    @MainActor
+    @discardableResult
+    public static func press(_ element: AXUIElement) -> Bool {
+        perform(element, kAXPressAction)
+    }
+
+    /// Performs `kAXShowMenuAction` (right-click / contextual menu).
+    @MainActor
+    @discardableResult
+    public static func showMenu(_ element: AXUIElement) -> Bool {
+        perform(element, kAXShowMenuAction)
+    }
+
+    /// Performs `kAXConfirmAction` (e.g. enter/return on a default button).
+    @MainActor
+    @discardableResult
+    public static func confirm(_ element: AXUIElement) -> Bool {
+        perform(element, kAXConfirmAction)
+    }
+
+    /// Performs `kAXCancelAction` (e.g. escape on a cancel button).
+    @MainActor
+    @discardableResult
+    public static func cancel(_ element: AXUIElement) -> Bool {
+        perform(element, kAXCancelAction)
+    }
+
+    /// Performs `kAXIncrementAction` (sliders, steppers).
+    @MainActor
+    @discardableResult
+    public static func increment(_ element: AXUIElement) -> Bool {
+        perform(element, kAXIncrementAction)
+    }
+
+    /// Performs `kAXDecrementAction` (sliders, steppers).
+    @MainActor
+    @discardableResult
+    public static func decrement(_ element: AXUIElement) -> Bool {
+        perform(element, kAXDecrementAction)
+    }
+
+    /// Performs `kAXPickAction` (selects a menu item).
+    @MainActor
+    @discardableResult
+    public static func pick(_ element: AXUIElement) -> Bool {
+        perform(element, kAXPickAction)
+    }
+
+    /// Performs `kAXRaiseAction` (brings a window to the front).
+    @MainActor
+    @discardableResult
+    public static func raise(_ element: AXUIElement) -> Bool {
+        perform(element, kAXRaiseAction)
+    }
+
+    /// Performs an arbitrary AX action by name. Returns true on `.success`.
+    @MainActor
+    @discardableResult
+    public static func perform(_ element: AXUIElement, _ action: String) -> Bool {
+        AXUIElementPerformAction(element, action as CFString) == .success
+    }
+
+    // MARK: - Set-attribute wrappers
+
+    /// Sets `kAXValueAttribute` to the given string. Use for text fields and
+    /// text areas.
+    @MainActor
+    @discardableResult
+    public static func setValue(_ element: AXUIElement, value: String) -> Bool {
+        AXUIElementSetAttributeValue(element, kAXValueAttribute as CFString, value as CFString) == .success
+    }
+
+    /// Sets `kAXFocusedAttribute`. Useful before typing into a text field via
+    /// CGEvent-based ``SwiftAutoGUI/write(_:interval:)``.
+    @MainActor
+    @discardableResult
+    public static func setFocused(_ element: AXUIElement, _ focused: Bool = true) -> Bool {
+        AXUIElementSetAttributeValue(element, kAXFocusedAttribute as CFString, focused as CFBoolean) == .success
+    }
+
+    /// Sets `kAXPositionAttribute` to move a window.
+    @MainActor
+    @discardableResult
+    public static func setPosition(_ element: AXUIElement, _ point: CGPoint) -> Bool {
+        var p = point
+        guard let value = AXValueCreate(.cgPoint, &p) else { return false }
+        return AXUIElementSetAttributeValue(element, kAXPositionAttribute as CFString, value) == .success
+    }
+
+    /// Sets `kAXSizeAttribute` to resize a window.
+    @MainActor
+    @discardableResult
+    public static func setSize(_ element: AXUIElement, _ size: CGSize) -> Bool {
+        var s = size
+        guard let value = AXValueCreate(.cgSize, &s) else { return false }
+        return AXUIElementSetAttributeValue(element, kAXSizeAttribute as CFString, value) == .success
+    }
+
+    // MARK: - Introspection
+
+    /// Returns the action names this element advertises (e.g. `kAXPressAction`).
+    @MainActor
+    public static func availableActions(of element: AXUIElement) -> [String] {
+        axActionNames(element)
+    }
+
+    /// Returns the element's frame (position + size) in screen coordinates.
+    /// Origin is the top-left of the main display.
+    @MainActor
+    public static func frame(of element: AXUIElement) -> CGRect? {
+        axFrame(element)
+    }
+
+    /// Returns the element's role (e.g. "AXButton").
+    @MainActor
+    public static func role(of element: AXUIElement) -> String? {
+        axStringAttribute(element, kAXRoleAttribute)
+    }
+
+    /// Returns the element's label (`kAXTitleAttribute` or `kAXDescriptionAttribute`).
+    @MainActor
+    public static func label(of element: AXUIElement) -> String? {
+        axStringAttribute(element, kAXTitleAttribute)
+            ?? axStringAttribute(element, kAXDescriptionAttribute)
+    }
+
+    /// Returns the element's current value.
+    @MainActor
+    public static func value(of element: AXUIElement) -> String? {
+        axStringAttribute(element, kAXValueAttribute)
+    }
+
+    /// Returns whether the element is enabled.
+    @MainActor
+    public static func isEnabled(_ element: AXUIElement) -> Bool {
+        axBoolAttribute(element, kAXEnabledAttribute) ?? true
+    }
+}

--- a/Sources/SwiftAutoGUI/AXAttributes.swift
+++ b/Sources/SwiftAutoGUI/AXAttributes.swift
@@ -1,0 +1,81 @@
+//
+//  AXAttributes.swift
+//  SwiftAutoGUI
+//
+
+import ApplicationServices
+import CoreGraphics
+import Foundation
+
+// MARK: - Attribute Helpers
+
+/// Reads a string-valued AX attribute. Returns nil if missing or wrong type.
+@MainActor
+internal func axStringAttribute(_ element: AXUIElement, _ attribute: String) -> String? {
+    var value: CFTypeRef?
+    let result = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
+    guard result == .success else { return nil }
+    return value as? String
+}
+
+/// Reads a Bool-valued AX attribute. Returns nil if missing or wrong type.
+@MainActor
+internal func axBoolAttribute(_ element: AXUIElement, _ attribute: String) -> Bool? {
+    var value: CFTypeRef?
+    let result = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
+    guard result == .success else { return nil }
+    return (value as? NSNumber)?.boolValue
+}
+
+/// Reads the children of an AX element. Returns nil if missing or wrong type.
+@MainActor
+internal func axChildren(_ element: AXUIElement) -> [AXUIElement]? {
+    var value: CFTypeRef?
+    let result = AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &value)
+    guard result == .success else { return nil }
+    return value as? [AXUIElement]
+}
+
+/// Reads an arbitrary AX attribute and returns the raw `CFTypeRef`.
+@MainActor
+internal func axAttribute(_ element: AXUIElement, _ attribute: String) -> CFTypeRef? {
+    var value: CFTypeRef?
+    let result = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
+    guard result == .success else { return nil }
+    return value
+}
+
+/// Reads the position + size of an element as a `CGRect` in screen coordinates.
+/// Returns nil if either attribute is unavailable.
+@MainActor
+internal func axFrame(_ element: AXUIElement) -> CGRect? {
+    var positionRef: CFTypeRef?
+    var sizeRef: CFTypeRef?
+
+    AXUIElementCopyAttributeValue(element, kAXPositionAttribute as CFString, &positionRef)
+    AXUIElementCopyAttributeValue(element, kAXSizeAttribute as CFString, &sizeRef)
+
+    guard let positionRef, let sizeRef else { return nil }
+
+    var position = CGPoint.zero
+    var size = CGSize.zero
+
+    let positionValue = positionRef as! AXValue
+    let sizeValue = sizeRef as! AXValue
+
+    guard AXValueGetValue(positionValue, .cgPoint, &position),
+          AXValueGetValue(sizeValue, .cgSize, &size) else {
+        return nil
+    }
+
+    return CGRect(origin: position, size: size)
+}
+
+/// Returns the action names the element advertises (e.g. `kAXPressAction`).
+@MainActor
+internal func axActionNames(_ element: AXUIElement) -> [String] {
+    var namesRef: CFArray?
+    let result = AXUIElementCopyActionNames(element, &namesRef)
+    guard result == .success, let names = namesRef as? [String] else { return [] }
+    return names
+}

--- a/Sources/SwiftAutoGUI/AXSearch.swift
+++ b/Sources/SwiftAutoGUI/AXSearch.swift
@@ -1,0 +1,269 @@
+//
+//  AXSearch.swift
+//  SwiftAutoGUI
+//
+
+import AppKit
+import ApplicationServices
+import CoreGraphics
+import Foundation
+
+/// Element resolution against the macOS accessibility tree.
+///
+/// Use these functions to obtain a live ``AXUIElement`` reference that you can
+/// pass to ``AXAction``. References become invalid when the UI changes, so try
+/// to find-and-act in close succession.
+public enum AXSearch {
+
+    // MARK: - App scope resolution
+
+    /// Resolves an ``AXAppScope`` to an application `AXUIElement`. Returns nil
+    /// if the app cannot be located.
+    @MainActor
+    public static func appElement(for scope: AXAppScope) -> AXUIElement? {
+        switch scope {
+        case .frontmost:
+            guard let pid = NSWorkspace.shared.frontmostApplication?.processIdentifier else {
+                return nil
+            }
+            return AXUIElementCreateApplication(pid)
+        case .bundleID(let id):
+            guard let app = NSWorkspace.shared.runningApplications.first(where: { $0.bundleIdentifier == id }) else {
+                return nil
+            }
+            return AXUIElementCreateApplication(app.processIdentifier)
+        case .pid(let pid):
+            return AXUIElementCreateApplication(pid)
+        }
+    }
+
+    // MARK: - Element search
+
+    /// Finds the first element matching the given role and options.
+    ///
+    /// - Parameters:
+    ///   - role: Required AX role (e.g. "AXButton"). Pass nil to match any role.
+    ///   - options: Label/value match strategy and traversal limits.
+    ///   - scope: Which application's tree to search.
+    @MainActor
+    public static func findElement(
+        role: String? = nil,
+        options: AXMatchOptions = AXMatchOptions(),
+        scope: AXAppScope = .frontmost
+    ) -> AXUIElement? {
+        guard let app = appElement(for: scope) else { return nil }
+        var nodeCount = 0
+        return findFirst(from: app, role: role, options: options, depth: 0, nodeCount: &nodeCount)
+    }
+
+    /// Convenience: find by role and label using the default
+    /// case-insensitive contains matcher (or exact equality if requested).
+    @MainActor
+    public static func findElement(
+        role: String? = nil,
+        label: String,
+        exact: Bool = false,
+        scope: AXAppScope = .frontmost
+    ) -> AXUIElement? {
+        findElement(
+            role: role,
+            options: .label(label, exact: exact),
+            scope: scope
+        )
+    }
+
+    /// Returns all elements matching the given role and options.
+    @MainActor
+    public static func findElements(
+        role: String? = nil,
+        options: AXMatchOptions = AXMatchOptions(),
+        scope: AXAppScope = .frontmost
+    ) -> [AXUIElement] {
+        guard let app = appElement(for: scope) else { return [] }
+        var results: [AXUIElement] = []
+        var nodeCount = 0
+        collectAll(from: app, role: role, options: options, depth: 0, into: &results, nodeCount: &nodeCount)
+        return results
+    }
+
+    /// Returns the deepest element at a screen point. Wraps
+    /// `AXUIElementCopyElementAtPosition`.
+    @MainActor
+    public static func findElement(at point: CGPoint) -> AXUIElement? {
+        let systemWide = AXUIElementCreateSystemWide()
+        var element: AXUIElement?
+        let result = AXUIElementCopyElementAtPosition(
+            systemWide,
+            Float(point.x),
+            Float(point.y),
+            &element
+        )
+        guard result == .success else { return nil }
+        return element
+    }
+
+    /// Finds a window in the given app whose title satisfies the matcher.
+    @MainActor
+    public static func findWindow(
+        title: String,
+        exact: Bool = false,
+        scope: AXAppScope = .frontmost
+    ) -> AXUIElement? {
+        guard let app = appElement(for: scope) else { return nil }
+        var windowsRef: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(
+            app,
+            kAXWindowsAttribute as CFString,
+            &windowsRef
+        )
+        guard result == .success, let windows = windowsRef as? [AXUIElement] else {
+            return nil
+        }
+        let match: AXStringMatch = exact ? .exact(title) : .containsCaseInsensitive(title)
+        return windows.first { window in
+            match.matches(axStringAttribute(window, kAXTitleAttribute))
+        }
+    }
+
+    /// Finds a menu item by hierarchical path, e.g. `["File", "Save As…"]`.
+    ///
+    /// Walks `kAXMenuBarAttribute` and recursively descends through
+    /// `kAXChildrenAttribute`. Each path component is matched
+    /// case-insensitively against the item's title (use `exact: true` for
+    /// strict equality).
+    @MainActor
+    public static func findMenuItem(
+        path: [String],
+        exact: Bool = false,
+        scope: AXAppScope = .frontmost
+    ) -> AXUIElement? {
+        guard !path.isEmpty,
+              let app = appElement(for: scope),
+              let menuBarRef = axAttribute(app, kAXMenuBarAttribute) else {
+            return nil
+        }
+        let menuBar = menuBarRef as! AXUIElement
+        return descendMenu(from: menuBar, path: path, exact: exact)
+    }
+
+    @MainActor
+    private static func descendMenu(
+        from element: AXUIElement,
+        path: [String],
+        exact: Bool
+    ) -> AXUIElement? {
+        guard let head = path.first else { return element }
+        let tail = Array(path.dropFirst())
+        let match: AXStringMatch = exact ? .exact(head) : .containsCaseInsensitive(head)
+
+        // The menu bar's direct children are AXMenuBarItem; inside, the visible
+        // children are AXMenu nodes whose own children are the AXMenuItems we
+        // want to match. Try both shapes so each path component can address
+        // either layer.
+        let directChildren = axChildren(element) ?? []
+        for child in directChildren {
+            let title = axStringAttribute(child, kAXTitleAttribute)
+            if match.matches(title) {
+                if tail.isEmpty { return child }
+                // Descend into the child's submenu wrapper if present.
+                if let submenuChildren = axChildren(child),
+                   let submenu = submenuChildren.first(where: {
+                       axStringAttribute($0, kAXRoleAttribute) == "AXMenu"
+                   }) ?? submenuChildren.first {
+                    if let found = descendMenu(from: submenu, path: tail, exact: exact) {
+                        return found
+                    }
+                }
+                if let found = descendMenu(from: child, path: tail, exact: exact) {
+                    return found
+                }
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Tree traversal
+
+    @MainActor
+    private static func findFirst(
+        from element: AXUIElement,
+        role: String?,
+        options: AXMatchOptions,
+        depth: Int,
+        nodeCount: inout Int
+    ) -> AXUIElement? {
+        guard nodeCount < options.maxNodes else { return nil }
+        nodeCount += 1
+
+        if matches(element, role: role, options: options) {
+            return element
+        }
+        guard depth < options.maxDepth, let children = axChildren(element) else {
+            return nil
+        }
+        for child in children {
+            if let found = findFirst(
+                from: child, role: role, options: options,
+                depth: depth + 1, nodeCount: &nodeCount
+            ) {
+                return found
+            }
+            if nodeCount >= options.maxNodes { break }
+        }
+        return nil
+    }
+
+    @MainActor
+    private static func collectAll(
+        from element: AXUIElement,
+        role: String?,
+        options: AXMatchOptions,
+        depth: Int,
+        into results: inout [AXUIElement],
+        nodeCount: inout Int
+    ) {
+        guard nodeCount < options.maxNodes else { return }
+        nodeCount += 1
+
+        if matches(element, role: role, options: options) {
+            results.append(element)
+        }
+        guard depth < options.maxDepth, let children = axChildren(element) else {
+            return
+        }
+        for child in children {
+            collectAll(
+                from: child, role: role, options: options,
+                depth: depth + 1, into: &results, nodeCount: &nodeCount
+            )
+            if nodeCount >= options.maxNodes { return }
+        }
+    }
+
+    @MainActor
+    private static func matches(
+        _ element: AXUIElement,
+        role: String?,
+        options: AXMatchOptions
+    ) -> Bool {
+        if let role {
+            guard axStringAttribute(element, kAXRoleAttribute) == role else {
+                return false
+            }
+        }
+        if options.requireEnabled {
+            let enabled = axBoolAttribute(element, kAXEnabledAttribute) ?? true
+            guard enabled else { return false }
+        }
+        if let labelMatch = options.labelMatch {
+            let label = axStringAttribute(element, kAXTitleAttribute)
+                ?? axStringAttribute(element, kAXDescriptionAttribute)
+            guard labelMatch.matches(label) else { return false }
+        }
+        if let valueMatch = options.valueMatch {
+            let value = axStringAttribute(element, kAXValueAttribute)
+            guard valueMatch.matches(value) else { return false }
+        }
+        return true
+    }
+}

--- a/Sources/SwiftAutoGUI/AXTypes.swift
+++ b/Sources/SwiftAutoGUI/AXTypes.swift
@@ -1,0 +1,101 @@
+//
+//  AXTypes.swift
+//  SwiftAutoGUI
+//
+
+import Darwin
+import Foundation
+
+// MARK: - AXStringMatch
+
+/// Strategies for matching an AX attribute string (label, title, value, etc.)
+/// against a query.
+public enum AXStringMatch: Sendable, Equatable {
+    /// Exact equality.
+    case exact(String)
+
+    /// Case-insensitive substring match. This is the default for label matching
+    /// because real-world buttons often look like "Save (⌘S)" or "Save…".
+    case containsCaseInsensitive(String)
+
+    /// Regular-expression match. The query is compiled with `NSRegularExpression`
+    /// using `.caseInsensitive`. A malformed pattern never matches.
+    case regex(String)
+
+    /// Returns true if `subject` satisfies this match strategy.
+    public func matches(_ subject: String?) -> Bool {
+        guard let subject else { return false }
+        switch self {
+        case .exact(let q):
+            return subject == q
+        case .containsCaseInsensitive(let q):
+            if q.isEmpty { return true }
+            return subject.range(of: q, options: .caseInsensitive) != nil
+        case .regex(let pattern):
+            guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
+                return false
+            }
+            let range = NSRange(subject.startIndex..., in: subject)
+            return regex.firstMatch(in: subject, options: [], range: range) != nil
+        }
+    }
+}
+
+// MARK: - AXMatchOptions
+
+/// Options that constrain an AX element search.
+public struct AXMatchOptions: Sendable {
+    /// How to match the element's label (title or description).
+    /// `nil` means do not constrain by label.
+    public var labelMatch: AXStringMatch?
+
+    /// How to match the element's current value.
+    /// `nil` means do not constrain by value.
+    public var valueMatch: AXStringMatch?
+
+    /// If true, only enabled elements match. Defaults to true so that disabled
+    /// buttons don't get picked when a similar enabled one exists elsewhere.
+    public var requireEnabled: Bool
+
+    /// Maximum tree depth to traverse before stopping a branch.
+    public var maxDepth: Int
+
+    /// Maximum total nodes to visit before giving up.
+    public var maxNodes: Int
+
+    public init(
+        labelMatch: AXStringMatch? = nil,
+        valueMatch: AXStringMatch? = nil,
+        requireEnabled: Bool = true,
+        maxDepth: Int = 20,
+        maxNodes: Int = 5000
+    ) {
+        self.labelMatch = labelMatch
+        self.valueMatch = valueMatch
+        self.requireEnabled = requireEnabled
+        self.maxDepth = maxDepth
+        self.maxNodes = maxNodes
+    }
+
+    /// Convenience: match by label using the default case-insensitive contains
+    /// strategy. Pass `exact: true` for strict equality.
+    public static func label(_ query: String, exact: Bool = false) -> AXMatchOptions {
+        AXMatchOptions(
+            labelMatch: exact ? .exact(query) : .containsCaseInsensitive(query)
+        )
+    }
+}
+
+// MARK: - AXAppScope
+
+/// Selects which application's accessibility tree to search.
+public enum AXAppScope: Sendable {
+    /// The currently frontmost application (`NSWorkspace.frontmostApplication`).
+    case frontmost
+
+    /// An application identified by bundle identifier (e.g. "com.apple.TextEdit").
+    case bundleID(String)
+
+    /// An application identified by process identifier.
+    case pid(pid_t)
+}

--- a/Sources/SwiftAutoGUI/ScreenContext.swift
+++ b/Sources/SwiftAutoGUI/ScreenContext.swift
@@ -270,6 +270,7 @@ extension ScreenContextProvider {
 
 extension ScreenContextProvider {
 
+    @MainActor
     private static func gatherAXTree(pid: Int32, options: Options, nodeCount: inout Int) -> AXNode? {
         let appElement = AXUIElementCreateApplication(pid)
 
@@ -290,6 +291,7 @@ extension ScreenContextProvider {
         return buildAXNode(from: axWindow, options: options, depth: 0, nodeCount: &nodeCount)
     }
 
+    @MainActor
     private static func buildAXNode(
         from element: AXUIElement,
         options: Options,
@@ -313,19 +315,13 @@ extension ScreenContextProvider {
             }
         }
 
-        let frame = axFrame(element)
+        let frame = CodableRect(axFrame(element) ?? .zero)
         let isEnabled = axBoolAttribute(element, kAXEnabledAttribute) ?? true
 
         // Get children if within depth limit
         let children: [AXNode]?
         if depth < options.maxDepth {
-            var childrenRef: CFTypeRef?
-            let result = AXUIElementCopyAttributeValue(
-                element,
-                kAXChildrenAttribute as CFString,
-                &childrenRef
-            )
-            if result == .success, let childArray = childrenRef as? [AXUIElement] {
+            if let childArray = axChildren(element) {
                 children = childArray.compactMap { child in
                     buildAXNode(from: child, options: options, depth: depth + 1, nodeCount: &nodeCount)
                 }
@@ -333,15 +329,9 @@ extension ScreenContextProvider {
                 children = []
             }
         } else {
-            // Check if there are children we're not traversing
-            var childCount: CFTypeRef?
-            let result = AXUIElementCopyAttributeValue(
-                element,
-                kAXChildrenAttribute as CFString,
-                &childCount
-            )
-            if result == .success, let arr = childCount as? [AnyObject], !arr.isEmpty {
-                children = nil // nil signals pruned subtree
+            // Pruned subtree: nil if children exist but were skipped, [] otherwise.
+            if let arr = axChildren(element), !arr.isEmpty {
+                children = nil
             } else {
                 children = []
             }
@@ -354,51 +344,6 @@ extension ScreenContextProvider {
             frame: frame,
             isEnabled: isEnabled,
             children: children
-        )
-    }
-
-    // MARK: AX Attribute Helpers
-
-    private static func axStringAttribute(_ element: AXUIElement, _ attribute: String) -> String? {
-        var value: CFTypeRef?
-        let result = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
-        guard result == .success else { return nil }
-        return value as? String
-    }
-
-    private static func axBoolAttribute(_ element: AXUIElement, _ attribute: String) -> Bool? {
-        var value: CFTypeRef?
-        let result = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
-        guard result == .success else { return nil }
-        return (value as? NSNumber)?.boolValue
-    }
-
-    private static func axFrame(_ element: AXUIElement) -> CodableRect {
-        var positionRef: CFTypeRef?
-        var sizeRef: CFTypeRef?
-
-        AXUIElementCopyAttributeValue(element, kAXPositionAttribute as CFString, &positionRef)
-        AXUIElementCopyAttributeValue(element, kAXSizeAttribute as CFString, &sizeRef)
-
-        var position = CGPoint.zero
-        var size = CGSize.zero
-
-        if let positionRef = positionRef {
-            // AXValue contains a CGPoint
-            let axValue = positionRef as! AXValue
-            AXValueGetValue(axValue, .cgPoint, &position)
-        }
-
-        if let sizeRef = sizeRef {
-            let axValue = sizeRef as! AXValue
-            AXValueGetValue(axValue, .cgSize, &size)
-        }
-
-        return CodableRect(
-            x: Double(position.x),
-            y: Double(position.y),
-            width: Double(size.width),
-            height: Double(size.height)
         )
     }
 }

--- a/Sources/SwiftAutoGUI/SwiftAutoGUI.swift
+++ b/Sources/SwiftAutoGUI/SwiftAutoGUI.swift
@@ -1306,4 +1306,146 @@ public class SwiftAutoGUI {
                             mouseCursorPosition: position, mouseButton: CGMouseButton.right)
         event?.post(tap: CGEventTapLocation.cghidEventTap)
     }
+
+    // MARK: - Accessibility (AX)
+
+    /// Presses a button by its label using the macOS accessibility API.
+    ///
+    /// Searches the AX tree of `app` (default: frontmost application) for a
+    /// button whose label matches `label`. Matching is case-insensitive
+    /// substring by default — pass `exact: true` for strict equality.
+    ///
+    /// If the AX press fails or is unsupported (common in Electron apps), this
+    /// falls back to a CGEvent click at the element's frame center. Pass
+    /// `axOnly: true` to skip the fallback and report failure instead.
+    ///
+    /// - Returns: `true` if the press (or fallback click) succeeded.
+    @MainActor
+    @discardableResult
+    public static func pressButton(
+        label: String,
+        app: AXAppScope = .frontmost,
+        exact: Bool = false,
+        axOnly: Bool = false
+    ) async -> Bool {
+        guard let element = AXSearch.findElement(
+            role: "AXButton", label: label, exact: exact, scope: app
+        ) else {
+            return false
+        }
+        return await invokePressOrFallback(element, axOnly: axOnly)
+    }
+
+    /// Sets the value of a text field or text area via the accessibility API.
+    ///
+    /// At least one of `label` or `role` must narrow the search. Defaults to
+    /// `role: "AXTextField"`; use `role: "AXTextArea"` for multi-line fields.
+    ///
+    /// - Returns: `true` if the value was set.
+    @MainActor
+    @discardableResult
+    public static func setTextField(
+        label: String? = nil,
+        role: String = "AXTextField",
+        value: String,
+        app: AXAppScope = .frontmost,
+        exact: Bool = false
+    ) -> Bool {
+        let options = AXMatchOptions(
+            labelMatch: label.map { exact ? .exact($0) : .containsCaseInsensitive($0) }
+        )
+        guard let element = AXSearch.findElement(role: role, options: options, scope: app) else {
+            return false
+        }
+        return AXAction.setValue(element, value: value)
+    }
+
+    /// Selects a menu item by hierarchical path, e.g. `["File", "Save As…"]`.
+    ///
+    /// - Returns: `true` if the menu item was found and the press succeeded.
+    @MainActor
+    @discardableResult
+    public static func selectMenuItem(
+        path: [String],
+        app: AXAppScope = .frontmost,
+        exact: Bool = false
+    ) -> Bool {
+        guard let item = AXSearch.findMenuItem(path: path, exact: exact, scope: app) else {
+            return false
+        }
+        // Try kAXPickAction first (correct for menu items); fall back to press.
+        if AXAction.availableActions(of: item).contains(kAXPickAction) {
+            if AXAction.pick(item) { return true }
+        }
+        return AXAction.press(item)
+    }
+
+    /// Brings a window to the front by title.
+    ///
+    /// - Returns: `true` if the raise succeeded.
+    @MainActor
+    @discardableResult
+    public static func raiseWindow(
+        title: String,
+        app: AXAppScope = .frontmost,
+        exact: Bool = false
+    ) -> Bool {
+        guard let window = AXSearch.findWindow(title: title, exact: exact, scope: app) else {
+            return false
+        }
+        return AXAction.raise(window)
+    }
+
+    /// Returns whether a matching element is enabled. `false` if no match was
+    /// found.
+    @MainActor
+    public static func isEnabled(
+        role: String,
+        label: String,
+        app: AXAppScope = .frontmost,
+        exact: Bool = false
+    ) -> Bool {
+        guard let element = AXSearch.findElement(
+            role: role, label: label, exact: exact, scope: app
+        ) else {
+            return false
+        }
+        return AXAction.isEnabled(element)
+    }
+
+    /// Returns the current value of a matching element, or nil if no match.
+    @MainActor
+    public static func getValue(
+        role: String,
+        label: String,
+        app: AXAppScope = .frontmost,
+        exact: Bool = false
+    ) -> String? {
+        guard let element = AXSearch.findElement(
+            role: role, label: label, exact: exact, scope: app
+        ) else {
+            return nil
+        }
+        return AXAction.value(of: element)
+    }
+
+    /// Tries `kAXPressAction`; on failure (or when the element doesn't
+    /// advertise press), falls back to a CGEvent click at the element's frame
+    /// center unless `axOnly` is true.
+    @MainActor
+    private static func invokePressOrFallback(
+        _ element: AXUIElement,
+        axOnly: Bool
+    ) async -> Bool {
+        let actions = AXAction.availableActions(of: element)
+        if actions.contains(kAXPressAction), AXAction.press(element) {
+            return true
+        }
+        if axOnly { return false }
+        guard let frame = AXAction.frame(of: element) else { return false }
+        let center = CGPoint(x: frame.midX, y: frame.midY)
+        await SwiftAutoGUI.move(to: center, duration: 0)
+        SwiftAutoGUI.leftClick()
+        return true
+    }
 }

--- a/Tests/SwiftAutoGUITests/AXMatchOptionsTests.swift
+++ b/Tests/SwiftAutoGUITests/AXMatchOptionsTests.swift
@@ -1,0 +1,93 @@
+import Testing
+@testable import SwiftAutoGUI
+
+@Suite("AX Matching")
+struct AXMatchOptionsTests {
+
+    // MARK: - AXStringMatch.exact
+
+    @Test("Exact match requires equality")
+    func exactRequiresEquality() {
+        let match: AXStringMatch = .exact("Save")
+        #expect(match.matches("Save"))
+        #expect(!match.matches("save"))
+        #expect(!match.matches("Save…"))
+        #expect(!match.matches("Save (⌘S)"))
+        #expect(!match.matches(nil))
+    }
+
+    // MARK: - AXStringMatch.containsCaseInsensitive
+
+    @Test("Contains is case-insensitive and tolerates real-world labels")
+    func containsHandlesRealLabels() {
+        let match: AXStringMatch = .containsCaseInsensitive("save")
+        #expect(match.matches("Save"))
+        #expect(match.matches("Save…"))
+        #expect(match.matches("Save (⌘S)"))
+        #expect(match.matches("Autosave Document"))
+        #expect(!match.matches("Open"))
+        #expect(!match.matches(nil))
+    }
+
+    @Test("Contains with empty query matches every non-nil string")
+    func containsEmptyQueryMatchesAll() {
+        let match: AXStringMatch = .containsCaseInsensitive("")
+        #expect(match.matches(""))
+        #expect(match.matches("anything"))
+        #expect(!match.matches(nil))
+    }
+
+    // MARK: - AXStringMatch.regex
+
+    @Test("Regex anchors and patterns work")
+    func regexPatterns() {
+        let saveOnly: AXStringMatch = .regex("^Save")
+        #expect(saveOnly.matches("Save"))
+        #expect(saveOnly.matches("Save…"))
+        #expect(!saveOnly.matches("Autosave"))
+
+        let digits: AXStringMatch = .regex("^[0-9]+$")
+        #expect(digits.matches("42"))
+        #expect(!digits.matches("4 + 2"))
+    }
+
+    @Test("Regex is case-insensitive")
+    func regexIsCaseInsensitive() {
+        let match: AXStringMatch = .regex("save")
+        #expect(match.matches("SAVE"))
+        #expect(match.matches("Saved Document"))
+    }
+
+    @Test("Malformed regex never matches")
+    func malformedRegexDoesNotMatch() {
+        let match: AXStringMatch = .regex("(unclosed")
+        #expect(!match.matches("anything"))
+        #expect(!match.matches("(unclosed"))
+    }
+
+    @Test("Regex against nil never matches")
+    func regexAgainstNil() {
+        let match: AXStringMatch = .regex(".*")
+        #expect(!match.matches(nil))
+    }
+
+    // MARK: - AXMatchOptions.label convenience
+
+    @Test("AXMatchOptions.label defaults to contains, exact: true upgrades to exact")
+    func labelConvenience() {
+        let lenient = AXMatchOptions.label("Save")
+        guard case .containsCaseInsensitive(let q1) = lenient.labelMatch else {
+            Issue.record("expected containsCaseInsensitive, got \(String(describing: lenient.labelMatch))")
+            return
+        }
+        #expect(q1 == "Save")
+        #expect(lenient.requireEnabled == true)
+
+        let strict = AXMatchOptions.label("Save", exact: true)
+        guard case .exact(let q2) = strict.labelMatch else {
+            Issue.record("expected exact, got \(String(describing: strict.labelMatch))")
+            return
+        }
+        #expect(q2 == "Save")
+    }
+}


### PR DESCRIPTION
## Summary

Implements **Phases 1–3** of #86 — AX action primitives, element search, and a high-level convenience API on `SwiftAutoGUI`. Phases 4 (AI `Action` enum integration) and 5 (sagui CLI) are deferred to a follow-up PR per the approved plan.

- **Phase 1 (`AXAction.swift`)** — `@MainActor` wrappers around `AXUIElementPerformAction` and `AXUIElementSetAttributeValue`: `press`, `showMenu`, `confirm`, `cancel`, `increment`, `decrement`, `pick`, `raise`, `setValue`, `setFocused`, `setPosition`, `setSize`, plus introspection (`availableActions`, `frame`, `role`, `label`, `value`, `isEnabled`).
- **Phase 2 (`AXSearch.swift`, `AXTypes.swift`)** — element resolution: `findElement(role:label:exact:scope:)`, `findElements`, `findElement(at:)`, `findWindow`, `findMenuItem(path:)`. `AXMatchOptions` defaults to **case-insensitive contains** so labels like `"Save (⌘S)"` and `"Save…"` work without special casing. `AXAppScope` selects `.frontmost`, `.bundleID(String)`, or `.pid(pid_t)`.
- **Phase 3 (`SwiftAutoGUI.swift`)** — convenience static methods composing search + action: `pressButton`, `setTextField`, `selectMenuItem`, `raiseWindow`, `isEnabled`, `getValue`. `pressButton` automatically falls back to a CGEvent click at the element's frame center when AX press is unsupported (e.g. Electron apps); opt out with `axOnly: true`.
- **Refactor** — moved the AX attribute helpers (`axStringAttribute`, `axBoolAttribute`, `axChildren`, `axFrame`, `axActionNames`) out of `ScreenContext.swift` into a shared `AXAttributes.swift` so the read-side and the new action/search side share one source of truth. `gatherAXTree` / `buildAXNode` are now `@MainActor` to match.

CGEvent-based automation is unchanged — this is purely additive.

## Design decisions

- **Label matching**: case-insensitive *contains* by default, with `exact: Bool = false` opt-in and `AXStringMatch.regex` available via `AXMatchOptions.labelMatch`. Real-world labels (`"Save (⌘S)"`, `"Save…"`) make exact matching brittle.
- **CGEvent fallback**: the high-level convenience API falls back to a CGEvent click on AX press failure. Opt out with `axOnly: true`. Driven by m13v's note on the issue that Electron apps need this.
- **Concurrency**: all AX entry points are `@MainActor`. `AXUIElement` isn't thread-safe even for reads; `@MainActor` provides the same single-threaded guarantee as a serial queue without extra plumbing, matching the existing `ScreenContextProvider.gather()` pattern.

## Test plan

- [x] `swift build` — clean
- [x] `swift build -c release` — clean
- [x] `swift test` — 104 tests pass (8 new in `AXMatchOptionsTests`, 96 prior, no regressions)
- [ ] Manual smoke against Calculator: `SwiftAutoGUI.pressButton(label: "5", app: .bundleID("com.apple.calculator"))`
- [ ] Manual smoke against TextEdit: `SwiftAutoGUI.selectMenuItem(path: ["File", "New"], app: .bundleID("com.apple.TextEdit"))` then `SwiftAutoGUI.setTextField(role: "AXTextArea", value: "hello", app: .bundleID("com.apple.TextEdit"))`
- [ ] Electron-app fallback: `pressButton` against a Slack/VS Code button with default `axOnly: false`

## Out of scope (follow-up PR)

- Phase 4 — `Action` / `BasicAction` enum cases, OpenAI system prompt + JSON schema updates
- Phase 5 — `sagui ax` CLI subcommands (`press`, `set`, `menu`, `tree`, `find`)

Closes part of #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)