### PR TITLE
feat: wire AX actions into AI backends and sagui CLI

### DIFF
--- a/Sample/Sample/Features/AIGeneration/AIGenerationDemoViewModel.swift
+++ b/Sample/Sample/Features/AIGeneration/AIGenerationDemoViewModel.swift
@@ -197,6 +197,14 @@ class AIGenerationDemoViewModel {
             return "Execute AppleScript: \(script.prefix(30))..."
         case .executeAppleScriptFile(let path):
             return "Execute AppleScript file: \(path)"
+        case .pressButton(let label, _, _, _):
+            return "Press button: \"\(label)\""
+        case .setTextField(let label, _, let value, _, _):
+            return "Set text field \(label.map { "\"\($0)\"" } ?? "(role)") = \"\(value)\""
+        case .selectMenuItem(let path, _, _):
+            return "Select menu item: \(path.joined(separator: " > "))"
+        case .raiseWindow(let title, _, _):
+            return "Raise window: \"\(title)\""
         case .wait(let duration):
             return "Wait \(duration)s"
         case .sequence(let actions):

--- a/Sample/Sample/Features/Actions/ActionsDemoViewModel.swift
+++ b/Sample/Sample/Features/Actions/ActionsDemoViewModel.swift
@@ -184,6 +184,14 @@ class ActionsDemoViewModel {
             return "Execute AppleScript: \(script.prefix(30))..."
         case .executeAppleScriptFile(let path):
             return "Execute AppleScript file: \(path)"
+        case .pressButton(let label, _, _, _):
+            return "AX press button: \"\(label)\""
+        case .setTextField(let label, _, let value, _, _):
+            return "AX set text field \(label.map { "\"\($0)\"" } ?? "(role)") = \"\(value)\""
+        case .selectMenuItem(let path, _, _):
+            return "AX select menu: \(path.joined(separator: " > "))"
+        case .raiseWindow(let title, _, _):
+            return "AX raise window: \"\(title)\""
         case .wait(let interval):
             return "Wait \(interval)s"
         case .sequence(let actions):

--- a/Sample/Sample/Features/Agent/AgentDemoViewModel.swift
+++ b/Sample/Sample/Features/Agent/AgentDemoViewModel.swift
@@ -133,6 +133,14 @@ class AgentDemoViewModel {
         case .keyShortcut(let keys): return "keyShortcut(\(keys.joined(separator: "+")))"
         case .drag(let fromX, let fromY, let toX, let toY):
             return "drag(\(Int(fromX)),\(Int(fromY))->\(Int(toX)),\(Int(toY)))"
+        case .pressButton(let label, let bundleID):
+            return "pressButton(\"\(label)\"\(bundleID.isEmpty ? "" : " in \(bundleID)"))"
+        case .setTextField(let label, let value, let bundleID):
+            return "setTextField(label:\"\(label)\", value:\"\(value)\"\(bundleID.isEmpty ? "" : " in \(bundleID)"))"
+        case .selectMenuItem(let path, let bundleID):
+            return "selectMenuItem(\(path.joined(separator: " > "))\(bundleID.isEmpty ? "" : " in \(bundleID)"))"
+        case .raiseWindow(let title, let bundleID):
+            return "raiseWindow(\"\(title)\"\(bundleID.isEmpty ? "" : " in \(bundleID)"))"
         }
     }
 }

--- a/Sources/SwiftAutoGUI/Action.swift
+++ b/Sources/SwiftAutoGUI/Action.swift
@@ -213,8 +213,25 @@ public enum Action {
     /// Show a password dialog.
     case password(String, title: String = "Password", defaultAnswer: String = "", button: String = "OK")
     
+    // MARK: - Accessibility (AX)
+
+    /// Press a button by label via the macOS accessibility API.
+    /// Falls back to a CGEvent click at the element's frame center unless
+    /// `axOnly` is true.
+    case pressButton(label: String, app: AXAppScope = .frontmost, exact: Bool = false, axOnly: Bool = false)
+
+    /// Set the value of a text field or text area by label and/or role.
+    /// Defaults to `AXTextField`; pass `role: "AXTextArea"` for multi-line.
+    case setTextField(label: String? = nil, role: String = "AXTextField", value: String, app: AXAppScope = .frontmost, exact: Bool = false)
+
+    /// Select a menu item by hierarchical path, e.g. `["File", "Save As…"]`.
+    case selectMenuItem(path: [String], app: AXAppScope = .frontmost, exact: Bool = false)
+
+    /// Bring a window to the front by title.
+    case raiseWindow(title: String, app: AXAppScope = .frontmost, exact: Bool = false)
+
     // MARK: - AppleScript
-    
+
     /// Execute an AppleScript.
     case executeAppleScript(String)
     
@@ -353,6 +370,18 @@ public enum Action {
         case .password(let text, let title, let defaultAnswer, _):
             return SwiftAutoGUI.password(text, title: title, default: defaultAnswer)
             
+        case .pressButton(let label, let app, let exact, let axOnly):
+            return await SwiftAutoGUI.pressButton(label: label, app: app, exact: exact, axOnly: axOnly)
+
+        case .setTextField(let label, let role, let value, let app, let exact):
+            return SwiftAutoGUI.setTextField(label: label, role: role, value: value, app: app, exact: exact)
+
+        case .selectMenuItem(let path, let app, let exact):
+            return SwiftAutoGUI.selectMenuItem(path: path, app: app, exact: exact)
+
+        case .raiseWindow(let title, let app, let exact):
+            return SwiftAutoGUI.raiseWindow(title: title, app: app, exact: exact)
+
         case .executeAppleScript(let script):
             do {
                 return try SwiftAutoGUI.executeAppleScript(script)

--- a/Sources/SwiftAutoGUI/ActionGenerator.swift
+++ b/Sources/SwiftAutoGUI/ActionGenerator.swift
@@ -45,6 +45,20 @@ public enum BasicAction: Sendable, Codable {
     /// Drag mouse from one position to another.
     case drag(fromX: Double, fromY: Double, toX: Double, toY: Double)
 
+    /// Press a button by accessibility label. `bundleID` is empty to target the
+    /// frontmost app; otherwise pass a value like "com.apple.calculator".
+    case pressButton(label: String, bundleID: String)
+
+    /// Set a text field's value via the accessibility API.
+    /// `label` may be empty to match by role only. `bundleID` empty = frontmost.
+    case setTextField(label: String, value: String, bundleID: String)
+
+    /// Select a menu item by hierarchical path, e.g. `["File", "Save As…"]`.
+    case selectMenuItem(path: [String], bundleID: String)
+
+    /// Bring a window to the front by title.
+    case raiseWindow(title: String, bundleID: String)
+
     /// Convert to an executable ``Action``.
     public func toAction() -> Action {
         switch self {
@@ -70,7 +84,23 @@ public enum BasicAction: Sendable, Codable {
             return .keyShortcut(mapped)
         case .drag(let fromX, let fromY, let toX, let toY):
             return .drag(from: CGPoint(x: fromX, y: fromY), to: CGPoint(x: toX, y: toY))
+        case .pressButton(let label, let bundleID):
+            return .pressButton(label: label, app: scope(bundleID))
+        case .setTextField(let label, let value, let bundleID):
+            return .setTextField(
+                label: label.isEmpty ? nil : label,
+                value: value,
+                app: scope(bundleID)
+            )
+        case .selectMenuItem(let path, let bundleID):
+            return .selectMenuItem(path: path, app: scope(bundleID))
+        case .raiseWindow(let title, let bundleID):
+            return .raiseWindow(title: title, app: scope(bundleID))
         }
+    }
+
+    private func scope(_ bundleID: String) -> AXAppScope {
+        bundleID.isEmpty ? .frontmost : .bundleID(bundleID)
     }
 
     // MARK: - Tagged Union Codable
@@ -79,11 +109,13 @@ public enum BasicAction: Sendable, Codable {
         case type
         case text, x, y, clicks, duration, keys
         case fromX, fromY, toX, toY
+        case label, value, path, title, bundleID
     }
 
     private enum ActionType: String, Codable {
         case write, move, leftClick, rightClick, doubleClick
         case vscroll, hscroll, wait, keyShortcut, drag
+        case pressButton, setTextField, selectMenuItem, raiseWindow
     }
 
     public init(from decoder: Decoder) throws {
@@ -122,6 +154,23 @@ public enum BasicAction: Sendable, Codable {
             let toX = try container.decodeIfPresent(Double.self, forKey: .toX) ?? 0
             let toY = try container.decodeIfPresent(Double.self, forKey: .toY) ?? 0
             self = .drag(fromX: fromX, fromY: fromY, toX: toX, toY: toY)
+        case .pressButton:
+            let label = try container.decodeIfPresent(String.self, forKey: .label) ?? ""
+            let bundleID = try container.decodeIfPresent(String.self, forKey: .bundleID) ?? ""
+            self = .pressButton(label: label, bundleID: bundleID)
+        case .setTextField:
+            let label = try container.decodeIfPresent(String.self, forKey: .label) ?? ""
+            let value = try container.decodeIfPresent(String.self, forKey: .value) ?? ""
+            let bundleID = try container.decodeIfPresent(String.self, forKey: .bundleID) ?? ""
+            self = .setTextField(label: label, value: value, bundleID: bundleID)
+        case .selectMenuItem:
+            let path = try container.decodeIfPresent([String].self, forKey: .path) ?? []
+            let bundleID = try container.decodeIfPresent(String.self, forKey: .bundleID) ?? ""
+            self = .selectMenuItem(path: path, bundleID: bundleID)
+        case .raiseWindow:
+            let title = try container.decodeIfPresent(String.self, forKey: .title) ?? ""
+            let bundleID = try container.decodeIfPresent(String.self, forKey: .bundleID) ?? ""
+            self = .raiseWindow(title: title, bundleID: bundleID)
         }
     }
 
@@ -160,6 +209,23 @@ public enum BasicAction: Sendable, Codable {
             try container.encode(fromY, forKey: .fromY)
             try container.encode(toX, forKey: .toX)
             try container.encode(toY, forKey: .toY)
+        case .pressButton(let label, let bundleID):
+            try container.encode(ActionType.pressButton, forKey: .type)
+            try container.encode(label, forKey: .label)
+            try container.encode(bundleID, forKey: .bundleID)
+        case .setTextField(let label, let value, let bundleID):
+            try container.encode(ActionType.setTextField, forKey: .type)
+            try container.encode(label, forKey: .label)
+            try container.encode(value, forKey: .value)
+            try container.encode(bundleID, forKey: .bundleID)
+        case .selectMenuItem(let path, let bundleID):
+            try container.encode(ActionType.selectMenuItem, forKey: .type)
+            try container.encode(path, forKey: .path)
+            try container.encode(bundleID, forKey: .bundleID)
+        case .raiseWindow(let title, let bundleID):
+            try container.encode(ActionType.raiseWindow, forKey: .type)
+            try container.encode(title, forKey: .title)
+            try container.encode(bundleID, forKey: .bundleID)
         }
     }
 }

--- a/Sources/SwiftAutoGUI/OpenAIBackend.swift
+++ b/Sources/SwiftAutoGUI/OpenAIBackend.swift
@@ -136,6 +136,17 @@ extension OpenAIBackend {
         "returnKey", "space", "delete", "tab", "escape", "upArrow", "downArrow", "leftArrow", "rightArrow", \
         "f1"-"f20".
         - drag: Drag mouse from one position to another. Parameters: fromX, fromY, toX, toY (numbers)
+        - pressButton: Press a button by accessibility label (semantic, no coordinates needed). \
+        Parameters: label (string, e.g. "OK"), bundleID (string, empty = frontmost app, otherwise e.g. "com.apple.calculator")
+        - setTextField: Set a text field's value via accessibility. \
+        Parameters: label (string, may be empty for role-only match), value (string), bundleID (string, empty = frontmost)
+        - selectMenuItem: Select a menu item by hierarchical path. \
+        Parameters: path (array of strings, e.g. ["File", "Save As…"]), bundleID (string, empty = frontmost)
+        - raiseWindow: Bring a window to the front by title. \
+        Parameters: title (string), bundleID (string, empty = frontmost)
+
+        Prefer pressButton/setTextField/selectMenuItem/raiseWindow over coordinate-based actions \
+        when the user identifies a target by name — they are more reliable than guessing coordinates.
 
         Respond with a JSON object containing an "actions" array. Each action must have a "type" field \
         and the relevant parameters for that type. For parameters not relevant to the action type, \

--- a/Sources/SwiftAutoGUI/OpenAIVisionBackend.swift
+++ b/Sources/SwiftAutoGUI/OpenAIVisionBackend.swift
@@ -196,6 +196,14 @@ extension OpenAIVisionBackend {
         case .keyShortcut(let keys): return "keyShortcut(\(keys.joined(separator: "+")))"
         case .drag(let fromX, let fromY, let toX, let toY):
             return "drag(\(Int(fromX)),\(Int(fromY)) -> \(Int(toX)),\(Int(toY)))"
+        case .pressButton(let label, let bundleID):
+            return "pressButton(\"\(label)\"\(bundleID.isEmpty ? "" : " in \(bundleID)"))"
+        case .setTextField(let label, let value, let bundleID):
+            return "setTextField(label:\"\(label)\", value:\"\(value)\"\(bundleID.isEmpty ? "" : " in \(bundleID)"))"
+        case .selectMenuItem(let path, let bundleID):
+            return "selectMenuItem(\(path.joined(separator: " > "))\(bundleID.isEmpty ? "" : " in \(bundleID)"))"
+        case .raiseWindow(let title, let bundleID):
+            return "raiseWindow(\"\(title)\"\(bundleID.isEmpty ? "" : " in \(bundleID)"))"
         }
     }
 }
@@ -224,6 +232,17 @@ extension OpenAIVisionBackend {
         "returnKey", "space", "delete", "tab", "escape", "upArrow", "downArrow", "leftArrow", "rightArrow", \
         "f1"-"f20".
         - drag: Drag mouse from one position to another. Parameters: fromX, fromY, toX, toY (numbers)
+        - pressButton: Press a button by accessibility label (semantic, no coordinates needed). \
+        Parameters: label (string, e.g. "OK"), bundleID (string, empty = frontmost app, otherwise e.g. "com.apple.calculator")
+        - setTextField: Set a text field's value via accessibility. \
+        Parameters: label (string, may be empty for role-only match), value (string), bundleID (string, empty = frontmost)
+        - selectMenuItem: Select a menu item by hierarchical path. \
+        Parameters: path (array of strings, e.g. ["File", "Save As…"]), bundleID (string, empty = frontmost)
+        - raiseWindow: Bring a window to the front by title. \
+        Parameters: title (string), bundleID (string, empty = frontmost)
+
+        Prefer the AX-based actions (pressButton, setTextField, selectMenuItem, raiseWindow) when the \
+        accessibility tree provides labels. They are more reliable than coordinate-based clicks.
 
         Instructions:
         1. Analyze the screenshot to understand the current screen state.
@@ -300,6 +319,23 @@ extension OpenAIVisionBackend {
             let toX = (dict["toX"] as? NSNumber)?.doubleValue ?? 0
             let toY = (dict["toY"] as? NSNumber)?.doubleValue ?? 0
             return .drag(fromX: fromX, fromY: fromY, toX: toX, toY: toY)
+        case "pressButton":
+            let label = dict["label"] as? String ?? ""
+            let bundleID = dict["bundleID"] as? String ?? ""
+            return .pressButton(label: label, bundleID: bundleID)
+        case "setTextField":
+            let label = dict["label"] as? String ?? ""
+            let value = dict["value"] as? String ?? ""
+            let bundleID = dict["bundleID"] as? String ?? ""
+            return .setTextField(label: label, value: value, bundleID: bundleID)
+        case "selectMenuItem":
+            let path = dict["path"] as? [String] ?? []
+            let bundleID = dict["bundleID"] as? String ?? ""
+            return .selectMenuItem(path: path, bundleID: bundleID)
+        case "raiseWindow":
+            let title = dict["title"] as? String ?? ""
+            let bundleID = dict["bundleID"] as? String ?? ""
+            return .raiseWindow(title: title, bundleID: bundleID)
         default:
             return nil
         }
@@ -382,7 +418,8 @@ extension OpenAIVisionBackend {
                 "type": "string",
                 "description": "The action type.",
                 "enum": ["write", "move", "leftClick", "rightClick", "doubleClick",
-                         "vscroll", "hscroll", "wait", "keyShortcut", "drag"]
+                         "vscroll", "hscroll", "wait", "keyShortcut", "drag",
+                         "pressButton", "setTextField", "selectMenuItem", "raiseWindow"]
             ] as [String: Any],
             "text": ["type": ["string", "null"], "description": "Text to type. Used with 'write' action."] as [String: Any],
             "x": ["type": ["number", "null"], "description": "X coordinate. Used with 'move' action."] as [String: Any],
@@ -394,8 +431,15 @@ extension OpenAIVisionBackend {
             "fromY": ["type": ["number", "null"], "description": "Start Y. Used with 'drag'."] as [String: Any],
             "toX": ["type": ["number", "null"], "description": "End X. Used with 'drag'."] as [String: Any],
             "toY": ["type": ["number", "null"], "description": "End Y. Used with 'drag'."] as [String: Any],
+            "label": ["type": ["string", "null"], "description": "Accessibility label. Used with 'pressButton' and 'setTextField'."] as [String: Any],
+            "value": ["type": ["string", "null"], "description": "New value. Used with 'setTextField'."] as [String: Any],
+            "path": ["type": ["array", "null"], "description": "Menu path components, e.g. [\"File\", \"Save As…\"]. Used with 'selectMenuItem'.", "items": ["type": "string"]] as [String: Any],
+            "title": ["type": ["string", "null"], "description": "Window title. Used with 'raiseWindow'."] as [String: Any],
+            "bundleID": ["type": ["string", "null"], "description": "Bundle identifier of the target app, or empty/null for frontmost. Used with all AX actions."] as [String: Any],
         ] as [String: Any],
-        "required": ["type", "text", "x", "y", "clicks", "duration", "keys", "fromX", "fromY", "toX", "toY"],
+        "required": ["type", "text", "x", "y", "clicks", "duration", "keys",
+                     "fromX", "fromY", "toX", "toY",
+                     "label", "value", "path", "title", "bundleID"],
         "additionalProperties": false
     ] as [String: Any]
 

--- a/Sources/sagui/AXCommand.swift
+++ b/Sources/sagui/AXCommand.swift
@@ -1,0 +1,219 @@
+import ArgumentParser
+import SwiftAutoGUI
+import Foundation
+
+/// Accessibility-based GUI automation for the sagui CLI.
+///
+/// Wraps the `SwiftAutoGUI` AX API: press buttons by label, set text fields,
+/// select menu items by path, raise windows, dump the AX tree, and find
+/// elements by role. These commands are coordinate-free and tend to be more
+/// robust than `sagui mouse` for cooperative apps.
+///
+/// ## Usage
+///
+/// ```bash
+/// # Press a button in the frontmost app (case-insensitive contains match)
+/// sagui ax press --label "5"
+///
+/// # Press a button in a specific app by bundle id
+/// sagui ax press --label "Save" --bundle-id com.apple.TextEdit
+///
+/// # Set a text field's value
+/// sagui ax set --role AXTextArea --value "hello" --bundle-id com.apple.TextEdit
+///
+/// # Select a menu item by path
+/// sagui ax menu File "Save As…" --bundle-id com.apple.TextEdit
+///
+/// # Print the focused window's AX tree (useful for debugging)
+/// sagui ax tree
+///
+/// # List elements by role in the frontmost app
+/// sagui ax find --role AXButton
+/// ```
+///
+/// ## Topics
+///
+/// ### Subcommands
+/// - ``Press``
+/// - ``Set``
+/// - ``Menu``
+/// - ``Tree``
+/// - ``Find``
+struct AXCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "ax",
+        abstract: "Accessibility-based GUI automation (semantic, coordinate-free).",
+        subcommands: [Press.self, Set.self, Menu.self, Tree.self, Find.self]
+    )
+}
+
+// MARK: - Shared option parsing
+
+struct AppOption: ParsableArguments {
+    @Option(name: .customLong("bundle-id"), help: "Target app bundle identifier (default: frontmost).")
+    var bundleID: String?
+
+    @Option(name: .customLong("pid"), help: "Target app process ID (default: frontmost).")
+    var pid: Int32?
+
+    func scope() -> AXAppScope {
+        if let pid { return .pid(pid) }
+        if let bundleID, !bundleID.isEmpty { return .bundleID(bundleID) }
+        return .frontmost
+    }
+}
+
+// MARK: - Subcommands
+
+extension AXCommand {
+    /// Press a button by accessibility label.
+    struct Press: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Press a button by accessibility label."
+        )
+
+        @Option(help: "Label to match (case-insensitive contains by default).")
+        var label: String
+
+        @Flag(help: "Require exact label equality instead of contains match.")
+        var exact = false
+
+        @Flag(name: .customLong("ax-only"), help: "Skip the CGEvent click fallback if AX press fails.")
+        var axOnly = false
+
+        @OptionGroup var app: AppOption
+
+        @MainActor
+        func run() async throws {
+            let success = await SwiftAutoGUI.pressButton(
+                label: label,
+                app: app.scope(),
+                exact: exact,
+                axOnly: axOnly
+            )
+            if !success {
+                throw RuntimeError("No matching button or press failed.")
+            }
+        }
+    }
+
+    /// Set the value of a text field or text area.
+    struct Set: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Set the value of a text field by label and/or role."
+        )
+
+        @Option(help: "Label to match (optional; if omitted, role-only match).")
+        var label: String?
+
+        @Option(help: "AX role to match (default: AXTextField; use AXTextArea for multi-line).")
+        var role: String = "AXTextField"
+
+        @Option(help: "New value to set.")
+        var value: String
+
+        @Flag(help: "Require exact label equality instead of contains match.")
+        var exact = false
+
+        @OptionGroup var app: AppOption
+
+        @MainActor
+        func run() async throws {
+            let success = SwiftAutoGUI.setTextField(
+                label: label,
+                role: role,
+                value: value,
+                app: app.scope(),
+                exact: exact
+            )
+            if !success {
+                throw RuntimeError("No matching text field or set failed.")
+            }
+        }
+    }
+
+    /// Select a menu item by hierarchical path.
+    struct Menu: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Select a menu item by path, e.g. 'sagui ax menu File \"Save As…\"'."
+        )
+
+        @Argument(help: "Path components: top-level menu, then submenu items.")
+        var path: [String]
+
+        @Flag(help: "Require exact label equality instead of contains match.")
+        var exact = false
+
+        @OptionGroup var app: AppOption
+
+        @MainActor
+        func run() async throws {
+            guard !path.isEmpty else {
+                throw ValidationError("Pass at least one path component, e.g. File 'Save As…'.")
+            }
+            let success = SwiftAutoGUI.selectMenuItem(
+                path: path,
+                app: app.scope(),
+                exact: exact
+            )
+            if !success {
+                throw RuntimeError("Menu item not found or pick failed.")
+            }
+        }
+    }
+
+    /// Print the accessibility tree of the focused window.
+    struct Tree: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Print the focused window's accessibility tree (debug aid)."
+        )
+
+        @Option(help: "Maximum tree depth.")
+        var maxDepth: Int = 10
+
+        @Option(help: "Maximum total nodes.")
+        var maxNodes: Int = 1000
+
+        @MainActor
+        func run() async throws {
+            let context = ScreenContextProvider.gather(options: .init(
+                maxDepth: maxDepth,
+                maxNodes: maxNodes
+            ))
+            print(context.formatted())
+        }
+    }
+
+    /// List elements matching a role (and optional label) in the frontmost or
+    /// chosen app. One per line: `<role>: <label>`.
+    struct Find: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "List elements matching a role and/or label."
+        )
+
+        @Option(help: "AX role to match (e.g. AXButton, AXTextField).")
+        var role: String?
+
+        @Option(help: "Label substring to match (case-insensitive contains).")
+        var label: String?
+
+        @Option(help: "Maximum results.")
+        var limit: Int = 50
+
+        @OptionGroup var app: AppOption
+
+        @MainActor
+        func run() async throws {
+            let options = AXMatchOptions(
+                labelMatch: label.map { .containsCaseInsensitive($0) }
+            )
+            let elements = AXSearch.findElements(role: role, options: options, scope: app.scope())
+            for element in elements.prefix(limit) {
+                let r = AXAction.role(of: element) ?? "AXUnknown"
+                let l = AXAction.label(of: element) ?? ""
+                print("\(r): \(l)")
+            }
+        }
+    }
+}
+

--- a/Sources/sagui/SaguiCLI.swift
+++ b/Sources/sagui/SaguiCLI.swift
@@ -27,12 +27,13 @@ import ArgumentParser
 /// - ``KeyCommand``
 /// - ``MouseCommand``
 /// - ``ScreenCommand``
+/// - ``AXCommand``
 @main
 struct SaguiCLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "sagui",
         abstract: "Control mouse and keyboard on macOS from the command line.",
         discussion: "Requires accessibility permissions in System Settings > Privacy & Security > Accessibility.",
-        subcommands: [KeyCommand.self, MouseCommand.self, ScreenCommand.self, AgentCommand.self]
+        subcommands: [KeyCommand.self, MouseCommand.self, ScreenCommand.self, AXCommand.self, AgentCommand.self]
     )
 }

--- a/Tests/SwiftAutoGUITests/ActionGeneratorTests.swift
+++ b/Tests/SwiftAutoGUITests/ActionGeneratorTests.swift
@@ -122,6 +122,55 @@ struct ActionGeneratorTests {
             #expect(toX == 300)
             #expect(toY == 400)
         }
+
+        @Test("pressButton round-trip")
+        func pressButtonRoundTrip() throws {
+            let action = BasicAction.pressButton(label: "Save", bundleID: "com.apple.TextEdit")
+            let roundTripped = try roundTrip(action)
+            guard case .pressButton(let label, let bundleID) = roundTripped else {
+                Issue.record("Expected .pressButton, got \(roundTripped)")
+                return
+            }
+            #expect(label == "Save")
+            #expect(bundleID == "com.apple.TextEdit")
+        }
+
+        @Test("setTextField round-trip preserves empty label")
+        func setTextFieldRoundTrip() throws {
+            let action = BasicAction.setTextField(label: "", value: "hello", bundleID: "")
+            let roundTripped = try roundTrip(action)
+            guard case .setTextField(let label, let value, let bundleID) = roundTripped else {
+                Issue.record("Expected .setTextField, got \(roundTripped)")
+                return
+            }
+            #expect(label == "")
+            #expect(value == "hello")
+            #expect(bundleID == "")
+        }
+
+        @Test("selectMenuItem round-trip preserves path")
+        func selectMenuItemRoundTrip() throws {
+            let action = BasicAction.selectMenuItem(path: ["File", "Save As…"], bundleID: "com.apple.TextEdit")
+            let roundTripped = try roundTrip(action)
+            guard case .selectMenuItem(let path, let bundleID) = roundTripped else {
+                Issue.record("Expected .selectMenuItem, got \(roundTripped)")
+                return
+            }
+            #expect(path == ["File", "Save As…"])
+            #expect(bundleID == "com.apple.TextEdit")
+        }
+
+        @Test("raiseWindow round-trip")
+        func raiseWindowRoundTrip() throws {
+            let action = BasicAction.raiseWindow(title: "Untitled", bundleID: "")
+            let roundTripped = try roundTrip(action)
+            guard case .raiseWindow(let title, let bundleID) = roundTripped else {
+                Issue.record("Expected .raiseWindow, got \(roundTripped)")
+                return
+            }
+            #expect(title == "Untitled")
+            #expect(bundleID == "")
+        }
     }
 
     // MARK: - OpenAI JSON Response Parsing Tests
@@ -257,6 +306,36 @@ struct ActionGeneratorTests {
             }
             #expect(duration == 2.5)
         }
+
+        @Test("parse pressButton action")
+        func parsePressButton() throws {
+            let json = """
+            {"actions": [{"type": "pressButton", "label": "OK", "bundleID": "com.apple.calculator", "text": null, "x": null, "y": null, "clicks": null, "duration": null, "keys": null, "fromX": null, "fromY": null, "toX": null, "toY": null, "value": null, "path": null, "title": null}]}
+            """
+            let actions = try decodeActions(from: json)
+            #expect(actions.count == 1)
+            guard case .pressButton(let label, let bundleID) = actions[0] else {
+                Issue.record("Expected .pressButton")
+                return
+            }
+            #expect(label == "OK")
+            #expect(bundleID == "com.apple.calculator")
+        }
+
+        @Test("parse selectMenuItem action with array path")
+        func parseSelectMenuItem() throws {
+            let json = """
+            {"actions": [{"type": "selectMenuItem", "path": ["File", "Save As…"], "bundleID": "", "text": null, "x": null, "y": null, "clicks": null, "duration": null, "keys": null, "fromX": null, "fromY": null, "toX": null, "toY": null, "label": null, "value": null, "title": null}]}
+            """
+            let actions = try decodeActions(from: json)
+            #expect(actions.count == 1)
+            guard case .selectMenuItem(let path, let bundleID) = actions[0] else {
+                Issue.record("Expected .selectMenuItem")
+                return
+            }
+            #expect(path == ["File", "Save As…"])
+            #expect(bundleID == "")
+        }
     }
 
     // MARK: - BasicAction to Action Conversion Tests
@@ -307,6 +386,77 @@ struct ActionGeneratorTests {
                 return
             }
             #expect(duration == 0)
+        }
+
+        @Test("pressButton with bundleID maps to .bundleID scope")
+        func pressButtonWithBundleID() {
+            let basic = BasicAction.pressButton(label: "Save", bundleID: "com.apple.TextEdit")
+            let action = basic.toAction()
+            guard case .pressButton(let label, let app, let exact, let axOnly) = action else {
+                Issue.record("Expected Action.pressButton")
+                return
+            }
+            #expect(label == "Save")
+            #expect(exact == false)
+            #expect(axOnly == false)
+            guard case .bundleID(let id) = app else {
+                Issue.record("Expected .bundleID scope, got \(app)")
+                return
+            }
+            #expect(id == "com.apple.TextEdit")
+        }
+
+        @Test("pressButton with empty bundleID maps to .frontmost")
+        func pressButtonFrontmost() {
+            let basic = BasicAction.pressButton(label: "OK", bundleID: "")
+            let action = basic.toAction()
+            guard case .pressButton(_, let app, _, _) = action else {
+                Issue.record("Expected Action.pressButton")
+                return
+            }
+            guard case .frontmost = app else {
+                Issue.record("Expected .frontmost scope, got \(app)")
+                return
+            }
+        }
+
+        @Test("setTextField with empty label converts to nil")
+        func setTextFieldEmptyLabel() {
+            let basic = BasicAction.setTextField(label: "", value: "hello", bundleID: "")
+            let action = basic.toAction()
+            guard case .setTextField(let label, _, let value, _, _) = action else {
+                Issue.record("Expected Action.setTextField")
+                return
+            }
+            #expect(label == nil)
+            #expect(value == "hello")
+        }
+
+        @Test("selectMenuItem preserves path and scope")
+        func selectMenuItemConversion() {
+            let basic = BasicAction.selectMenuItem(path: ["File", "New"], bundleID: "com.apple.TextEdit")
+            let action = basic.toAction()
+            guard case .selectMenuItem(let path, let app, _) = action else {
+                Issue.record("Expected Action.selectMenuItem")
+                return
+            }
+            #expect(path == ["File", "New"])
+            guard case .bundleID(let id) = app else {
+                Issue.record("Expected .bundleID")
+                return
+            }
+            #expect(id == "com.apple.TextEdit")
+        }
+
+        @Test("raiseWindow preserves title")
+        func raiseWindowConversion() {
+            let basic = BasicAction.raiseWindow(title: "Untitled", bundleID: "")
+            let action = basic.toAction()
+            guard case .raiseWindow(let title, _, _) = action else {
+                Issue.record("Expected Action.raiseWindow")
+                return
+            }
+            #expect(title == "Untitled")
         }
     }
 

--- a/Tests/SwiftAutoGUITests/AppleScriptTests.swift
+++ b/Tests/SwiftAutoGUITests/AppleScriptTests.swift
@@ -15,27 +15,6 @@ struct AppleScriptTests {
         }
     }
     
-    @Test("Execute AppleScript from file")
-    func testExecuteAppleScriptFile() throws {
-        // Create a temporary AppleScript file
-        let tempDir = FileManager.default.temporaryDirectory
-        let scriptPath = tempDir.appendingPathComponent("test_script.applescript").path
-        
-        let scriptContent = """
-        on run
-            return "Hello from file"
-        end run
-        """
-        
-        try scriptContent.write(toFile: scriptPath, atomically: true, encoding: .utf8)
-        defer {
-            try? FileManager.default.removeItem(atPath: scriptPath)
-        }
-        
-        let result = try SwiftAutoGUI.executeAppleScriptFile(scriptPath)
-        #expect(result == "Hello from file")
-    }
-    
     @Test("Execute AppleScript from non-existent file throws error")
     func testExecuteAppleScriptFileNotFound() {
         let nonExistentPath = "/tmp/non_existent_script.applescript"

--- a/scripts/demo-ax.sh
+++ b/scripts/demo-ax.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Demo script for the SwiftAutoGUI AX (accessibility) actions.
+#
+# Drives the macOS Calculator and TextEdit through the `sagui ax` CLI
+# subcommand to show off semantic, coordinate-free GUI automation.
+#
+# Prerequisites:
+#   - Your terminal app needs Accessibility permission in
+#     System Settings > Privacy & Security > Accessibility.
+#   - Build the package once before running:  swift build
+#
+# Usage:
+#   scripts/demo-ax.sh           # run all sections
+#   scripts/demo-ax.sh calc      # Calculator only
+#   scripts/demo-ax.sh textedit  # TextEdit only
+#   scripts/demo-ax.sh discover  # introspection (tree + find) only
+
+set -e
+cd "$(dirname "$0")/.."
+
+SAGUI=".build/debug/sagui"
+if [[ ! -x "$SAGUI" ]]; then
+    echo "Building sagui..."
+    swift build
+fi
+
+CALC_BUNDLE="com.apple.calculator"
+TEXTEDIT_BUNDLE="com.apple.TextEdit"
+
+section() {
+    printf '\n\033[1;34m=== %s ===\033[0m\n' "$1"
+}
+
+calc_demo() {
+    section "Calculator: 5 + 3 ="
+    open -a Calculator
+    sleep 1
+    # Calculator labels operator buttons by their *verb*, not the symbol shown
+    # on the button face: "+" => "Add", "=" => "Equals", "-" => "Subtract", etc.
+    "$SAGUI" ax press --label "5"      --bundle-id "$CALC_BUNDLE"
+    "$SAGUI" ax press --label "Add"    --bundle-id "$CALC_BUNDLE"
+    "$SAGUI" ax press --label "3"      --bundle-id "$CALC_BUNDLE"
+    "$SAGUI" ax press --label "Equals" --bundle-id "$CALC_BUNDLE"
+    echo "Calculator should now display 8."
+}
+
+textedit_demo() {
+    section "TextEdit: new doc + type"
+    open -a TextEdit
+    sleep 1
+    "$SAGUI" ax menu File "New" --bundle-id "$TEXTEDIT_BUNDLE"
+    sleep 1
+    "$SAGUI" ax set --role AXTextArea \
+                    --value "Hello from sagui ax!" \
+                    --bundle-id "$TEXTEDIT_BUNDLE"
+}
+
+discover_demo() {
+    section "Discovery: AX tree of frontmost window"
+    "$SAGUI" ax tree --max-depth 4 --max-nodes 80
+
+    section "Discovery: list buttons in Calculator"
+    open -a Calculator
+    sleep 1
+    "$SAGUI" ax find --role AXButton --bundle-id "$CALC_BUNDLE" --limit 30
+}
+
+case "${1:-all}" in
+    all)
+        discover_demo
+        calc_demo
+        textedit_demo
+        ;;
+    calc|calculator)    calc_demo ;;
+    textedit|text)      textedit_demo ;;
+    discover|introspect) discover_demo ;;
+    *)
+        echo "Unknown section: $1"
+        echo "Usage: $0 [all|calc|textedit|discover]"
+        exit 1
+        ;;
+esac
+
+section "Done"


### PR DESCRIPTION
## Summary

Implements **Phases 4–5** of #86, completing the work started in #91. The AI backends can now emit semantic AX actions, and a new `sagui ax` CLI subcommand group makes them accessible from the terminal.

- **Phase 4 (`Action.swift`, `ActionGenerator.swift`, `OpenAIBackend.swift`, `OpenAIVisionBackend.swift`)** — adds `pressButton`, `setTextField`, `selectMenuItem`, `raiseWindow` cases to both `Action` and the AI-facing `BasicAction`. `BasicAction.toAction()` maps an empty `bundleID` string to `.frontmost` and a non-empty one to `.bundleID(...)` so the `@Generable` schema stays string-only. Tagged-union `Codable` extended for the new fields (`label`, `value`, `path`, `title`, `bundleID`). OpenAI Responses API system prompts and JSON schemas updated; the strict-mode required list now includes the new fields with nullable types.
- **Phase 5 (`AXCommand.swift`)** — new `sagui ax` subcommand with five subcommands:
  - `press --label "OK" [--bundle-id <id>] [--exact] [--ax-only]`
  - `set [--label "Search"] [--role AXTextField] --value "hello" [--bundle-id <id>]`
  - `menu File "Save As…" [--bundle-id <id>]`
  - `tree [--max-depth N] [--max-nodes N]` (debug aid; prints the focused window's AX tree)
  - `find [--role AXButton] [--label "Save"] [--bundle-id <id>]`

  Registered alongside existing subcommands in `SaguiCLI.swift`.

CGEvent-based automation is unchanged — this is additive.

## Test plan

- [x] \`swift build\` — clean
- [x] \`swift test --parallel\` — 114 tests pass (10 new in \`ActionGeneratorTests\`, 104 prior, no regressions)
- [x] \`swift run sagui ax --help\` — subcommand registered and discoverable
- [x] Manual smoke against Calculator: \`sagui ax press --label "5" --bundle-id com.apple.calculator\` etc. (Note: Calculator labels operator buttons by their verb — \"Add\", \"Equals\", \"Subtract\" — not by the symbol on the button face. Run \`sagui ax find --role AXButton --bundle-id com.apple.calculator\` to discover real labels.)
- [ ] Manual AI backend test (Foundation Models / OpenAI) emitting an AX action

## Note on the failing AppleScript test

The CI run for #91 surfaced a pre-existing flake in \`AppleScriptTests / Execute AppleScript from file\` (\`executionFailed(\"Error -1751: \")\`) — that's a sandbox/permission failure on the macOS-26 runner, unrelated to this PR's changes. Removed in this PR per request, since it can't run reliably on the CI runner. The other three AppleScript tests still cover error paths and descriptions.

## Closes

Closes #86 once merged (with #91 already landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)