### PR TITLE
chore: enable Swift-Concurrency-Agent-Skill plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "enabledPlugins": {
+    "swift-concurrency@swift-concurrency-agent-skill": true
+  },
+  "extraKnownMarketplaces": {
+    "swift-concurrency-agent-skill": {
+      "source": {
+        "source": "github",
+        "repo": "AvdLee/Swift-Concurrency-Agent-Skill"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Registers `AvdLee/Swift-Concurrency-Agent-Skill` as a known marketplace via committed `.claude/settings.json`.
- Enables the `swift-concurrency` plugin so teammates working on the repo with Claude Code are prompted to install the skill on first open.

## Test plan
- [ ] Open the repo in Claude Code with the branch checked out and confirm the install prompt appears.
- [ ] After install, verify the `swift-concurrency` skill is discoverable (e.g. ask Claude to "use the swift-concurrency skill").

🤖 Generated with [Claude Code](https://claude.com/claude-code)