### PR TITLE
feat: package skill as Claude Code Marketplace plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "swift-auto-gui",
+  "owner": {
+    "name": "NakaokaRei"
+  },
+  "description": "SwiftAutoGUI macOS automation plugin for Claude Code.",
+  "plugins": [
+    {
+      "name": "swift-auto-gui",
+      "source": "./plugins/swift-auto-gui",
+      "description": "Control macOS GUI applications via mouse, keyboard, screenshots, image recognition, and AppleScript using the sagui CLI.",
+      "homepage": "https://github.com/NakaokaRei/SwiftAutoGUI",
+      "repository": "https://github.com/NakaokaRei/SwiftAutoGUI",
+      "license": "MIT",
+      "keywords": ["macos", "automation", "gui", "mouse", "keyboard", "screenshot"],
+      "category": "automation"
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,3 +74,12 @@ Three subcommands: `KeyCommand`, `MouseCommand`, `ScreenCommand`, each in their 
 ## CI
 
 GitHub Actions workflow (`build.yml`) runs on `macos-26` with four parallel jobs: build, test, docs (xcodebuild docbuild), and sample app build. PRs get automated test result comments.
+
+## Releases
+
+When tagging a new SwiftAutoGUI version (e.g. `0.22.0`):
+
+1. Bump `plugins/swift-auto-gui/.claude-plugin/plugin.json` `version` to match the new git tag.
+2. Then create the git tag.
+
+The Claude Code plugin version is intentionally kept in sync with the library tag — if `plugin.json` `version` doesn't change between releases, existing marketplace users won't receive plugin updates (Claude Code caches by version string).

--- a/README.md
+++ b/README.md
@@ -279,19 +279,29 @@ SwiftAutoGUI.resetLayoutToAutoDetect()
 let key = Key.from(character: "@", layout: .jis)  // .leftBracket
 ```
 
-# Claude Code Skill
+# Claude Code Plugin
 
-SwiftAutoGUI provides a [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skill that enables Claude to control macOS GUI applications via the `sagui` CLI.
+SwiftAutoGUI ships as a [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugin so Claude can control macOS GUI applications via the `sagui` CLI — taking screenshots, clicking buttons, typing text, scrolling, and more.
 
-## Setup
+## Install from the marketplace
 
-1. Clone this repository or add it as a dependency
-2. Copy the `.claude/skills/swift-auto-gui/` directory into your project's `.claude/skills/` directory
-3. Grant Accessibility and Screen Recording permissions to the application running Claude Code (e.g., Terminal.app)
+Inside Claude Code:
 
-Claude Code will automatically discover the skill and use it when you ask it to interact with macOS applications — taking screenshots, clicking buttons, typing text, scrolling, and more.
+```text
+/plugin marketplace add NakaokaRei/SwiftAutoGUI
+/plugin install swift-auto-gui@swift-auto-gui
+```
 
-For details, see [`.claude/skills/swift-auto-gui/SKILL.md`](.claude/skills/swift-auto-gui/SKILL.md).
+This installs the `macos-control` skill, which is invoked as `/swift-auto-gui:macos-control`. The skill walks Claude through installing the `sagui` binary the first time it's needed (Swift 6.2+ toolchain required).
+
+## Permissions
+
+Grant the application running Claude Code (Terminal.app, iTerm, etc.) both:
+
+- **Accessibility** — System Settings → Privacy & Security → Accessibility
+- **Screen Recording** — System Settings → Privacy & Security → Screen Recording
+
+For full skill details, see [`plugins/swift-auto-gui/skills/macos-control/SKILL.md`](plugins/swift-auto-gui/skills/macos-control/SKILL.md).
 
 # Contributors
 

--- a/plugins/swift-auto-gui/.claude-plugin/plugin.json
+++ b/plugins/swift-auto-gui/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swift-auto-gui",
   "description": "Control macOS GUI applications via mouse, keyboard, screenshots, image recognition, and AppleScript using the sagui CLI.",
-  "version": "0.1.0",
+  "version": "0.21.0",
   "author": {
     "name": "NakaokaRei"
   },

--- a/plugins/swift-auto-gui/.claude-plugin/plugin.json
+++ b/plugins/swift-auto-gui/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "swift-auto-gui",
+  "description": "Control macOS GUI applications via mouse, keyboard, screenshots, image recognition, and AppleScript using the sagui CLI.",
+  "version": "0.1.0",
+  "author": {
+    "name": "NakaokaRei"
+  },
+  "homepage": "https://github.com/NakaokaRei/SwiftAutoGUI",
+  "repository": "https://github.com/NakaokaRei/SwiftAutoGUI",
+  "license": "MIT",
+  "keywords": ["macos", "automation", "gui", "mouse", "keyboard", "screenshot"]
+}

--- a/plugins/swift-auto-gui/skills/macos-control/SKILL.md
+++ b/plugins/swift-auto-gui/skills/macos-control/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: swift-auto-gui
+name: macos-control
 description: >
   Control macOS GUI applications via mouse automation, keyboard input, screenshots,
   image recognition, and AppleScript execution. Use when you need to interact with
@@ -7,14 +7,45 @@ description: >
   images on screen.
 ---
 
-# swift-auto-gui
+# macos-control
 
 The `sagui` CLI provides mouse control, keyboard input, screenshot capture, image recognition, and screen queries for macOS automation.
 
-## Prerequisites
+## Preflight: ensure `sagui` is installed
 
-- **Accessibility**: Required for mouse and keyboard commands. Enable in System Settings > Privacy & Security > Accessibility.
-- **Screen Recording**: Required for screenshot and image recognition commands. Enable in System Settings > Privacy & Security > Screen Recording.
+Before issuing any `sagui` command, run:
+
+```bash
+command -v sagui
+```
+
+If the command prints a path, you're ready — continue to the sections below.
+
+If it prints nothing (exit code 1), `sagui` is not installed. **Stop and ask the user for permission to install it** before doing anything else. Show them these steps and wait for confirmation:
+
+```bash
+# Prerequisite: Xcode / Swift 6.2+ toolchain (`swift --version` to verify)
+git clone https://github.com/NakaokaRei/SwiftAutoGUI.git /tmp/SwiftAutoGUI
+cd /tmp/SwiftAutoGUI
+swift build -c release
+# Copy the binary somewhere on $PATH. /usr/local/bin requires sudo:
+sudo cp .build/release/sagui /usr/local/bin/sagui
+# Or, no sudo, into a user dir already on PATH:
+# cp .build/release/sagui ~/.local/bin/sagui
+```
+
+After install, re-run `command -v sagui` to confirm the binary is reachable, then continue.
+
+## Permissions
+
+The first time `sagui` issues an event or screenshot, macOS will prompt for these permissions. Without them, commands silently fail or return blank screenshots.
+
+- **Accessibility** — required for `sagui key` and `sagui mouse`. Enable in System Settings → Privacy & Security → Accessibility for the app running Claude Code (Terminal.app, iTerm, etc.).
+- **Screen Recording** — required for `sagui screen screenshot`, `sagui screen pixel`, and `sagui screen locate*`. Enable in System Settings → Privacy & Security → Screen Recording for the same app.
+
+If a command unexpectedly fails or returns empty output, ask the user to verify both permissions are granted to their terminal app.
+
+This skill is **macOS-only** — `sagui` builds on CoreGraphics. On other platforms, tell the user the skill cannot run and stop.
 
 ## Coordinates
 


### PR DESCRIPTION
## Summary

- Restructures the swift-auto-gui Claude Code skill into a marketplace plugin layout (`.claude-plugin/marketplace.json` + `plugins/swift-auto-gui/.claude-plugin/plugin.json`) so users can install it without cloning this repo.
- Moves `SKILL.md` to `plugins/swift-auto-gui/skills/macos-control/` and adds a preflight section that has Claude check `command -v sagui` and walk the user through a Swift-toolchain install if it's missing.
- Replaces the manual "copy into .claude/skills" README instructions with the `/plugin marketplace add` + `/plugin install` snippet.

Closes #94.

## User-facing install

```text
/plugin marketplace add NakaokaRei/SwiftAutoGUI
/plugin install swift-auto-gui@swift-auto-gui
```

Skill is then invoked as `/swift-auto-gui:macos-control`.

## Decisions made (recorded for the record)

- **Marketplace name**: `swift-auto-gui` (matches the only plugin for now).
- **Inner skill name**: renamed from `swift-auto-gui` to `macos-control` so the invocation isn't `/swift-auto-gui:swift-auto-gui`.
- **Versioning**: pinned `0.1.0` in `plugin.json`. Per Claude Code marketplace docs this must be bumped on every release or existing users won't get updates.

## Test plan

- [x] `claude plugin validate .` passes.
- [ ] In a separate working directory, run `/plugin marketplace add /path/to/SwiftAutoGUI` then `/plugin install swift-auto-gui@swift-auto-gui` and confirm the `macos-control` skill appears.
- [ ] On a machine without `sagui` on `PATH`, exercise the skill and confirm the preflight prompts the user with the Swift-build install steps before issuing any `sagui` command.
- [ ] After install, run a basic flow (`sagui screen size`, `sagui screen screenshot`) end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)