### PR TITLE
chore(plugin): bump to 0.22.0

### DIFF
--- a/plugins/swift-auto-gui/.claude-plugin/plugin.json
+++ b/plugins/swift-auto-gui/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swift-auto-gui",
   "description": "Control macOS GUI applications via mouse, keyboard, screenshots, image recognition, and AppleScript using the sagui CLI.",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "author": {
     "name": "NakaokaRei"
   },


### PR DESCRIPTION
The previous 0.21.0 git tag was cut before the plugin existed, so the 0.21.0 ref does not actually contain a plugin. Bumping to 0.22.0 makes the next tag (0.22.0) the first git ref that ships both the library and the marketplace plugin together.