### PR TITLE
Bump plugin version to 0.23.0

### DIFF
--- a/plugins/swift-auto-gui/.claude-plugin/plugin.json
+++ b/plugins/swift-auto-gui/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swift-auto-gui",
   "description": "Control macOS GUI applications via mouse, keyboard, screenshots, image recognition, and AppleScript using the sagui CLI.",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "author": {
     "name": "NakaokaRei"
   },


### PR DESCRIPTION
## Summary
- Bump `plugins/swift-auto-gui/.claude-plugin/plugin.json` from 0.22.0 to 0.23.0 to match the upcoming SwiftAutoGUI 0.23.0 tag.
- 0.23.0 includes the deprecated sync API removal (#101) as a breaking change.

## Test plan
- [x] Version string updated in `plugin.json`
- [ ] Tag `0.23.0` after merge per CLAUDE.md release steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)