### PR TITLE
Add command plugin for Metal library generation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,13 @@ swift test                     # Run safe tests (does not generate mouse/keyboar
 swift test --parallel          # Run safe tests in parallel (used in CI)
 SWIFTAUTOGUI_RUN_INPUT_TESTS=1 swift test  # Explicitly run tests that generate real input
 swift test --filter KeyboardTests  # Run safe tests in a single test suite
-scripts/build-metallib.sh       # Rebuild the bundled Metal shader library
+swift package --allow-writing-to-package-directory build-metal-library
+                               # Rebuild the bundled Metal shader library
 ```
+
+Rebuilding the Metal library requires Xcode's optional Metal Toolchain
+component. Package consumers use the committed `.metallib` and do not need the
+component installed.
 
 ### Documentation
 ```bash

--- a/Package.swift
+++ b/Package.swift
@@ -50,5 +50,20 @@ let package = Package(
         .testTarget(
             name: "ImageRecognitionTests",
             dependencies: ["ImageRecognition"]),
+        .plugin(
+            name: "BuildMetalLibraryPlugin",
+            capability: .command(
+                intent: .custom(
+                    verb: "build-metal-library",
+                    description: "Rebuild the bundled Metal shader library."
+                ),
+                permissions: [
+                    .writeToPackageDirectory(
+                        reason: "Update the bundled TemplateMatching.metallib resource."
+                    )
+                ]
+            ),
+            path: "PackagePlugins/BuildMetalLibraryPlugin"
+        ),
     ]
 )

--- a/PackagePlugins/BuildMetalLibraryPlugin/BuildMetalLibraryPlugin.swift
+++ b/PackagePlugins/BuildMetalLibraryPlugin/BuildMetalLibraryPlugin.swift
@@ -1,0 +1,98 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct BuildMetalLibraryPlugin: CommandPlugin {
+    func performCommand(
+        context: PluginContext,
+        arguments: [String]
+    ) async throws {
+        guard arguments.isEmpty else {
+            Diagnostics.error(
+                "build-metal-library does not accept arguments: "
+                    + arguments.joined(separator: " ")
+            )
+            return
+        }
+
+        let packageURL = context.package.directoryURL
+        let sourceURL = packageURL.appending(
+            path: "Sources/ImageRecognition/Shaders/TemplateMatching.metal"
+        )
+        let outputURL = packageURL.appending(
+            path: "Sources/ImageRecognition/Resources/TemplateMatching.metallib"
+        )
+        let workDirectoryURL = context.pluginWorkDirectoryURL.appending(
+            path: "BuildMetalLibrary",
+            directoryHint: .isDirectory
+        )
+        let airURL = workDirectoryURL.appending(path: "TemplateMatching.air")
+
+        try FileManager.default.createDirectory(
+            at: workDirectoryURL,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        try runXcrun(
+            [
+                "-sdk", "macosx",
+                "metal",
+                "-c",
+                "-target", "air64-apple-macos26.0",
+                sourceURL.path,
+                "-o", airURL.path,
+            ],
+            step: "Compile TemplateMatching.metal"
+        )
+        try runXcrun(
+            [
+                "-sdk", "macosx",
+                "metallib",
+                airURL.path,
+                "-o", outputURL.path,
+            ],
+            step: "Link TemplateMatching.metallib"
+        )
+
+        print("Generated \(outputURL.path)")
+    }
+
+    private func runXcrun(
+        _ arguments: [String],
+        step: String
+    ) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
+        process.arguments = arguments
+        process.standardOutput = FileHandle.standardOutput
+        process.standardError = FileHandle.standardError
+
+        print("\(step)...")
+        try process.run()
+        process.waitUntilExit()
+
+        guard process.terminationReason == .exit,
+              process.terminationStatus == 0 else {
+            throw MetalLibraryPluginError.commandFailed(
+                step: step,
+                status: process.terminationStatus
+            )
+        }
+    }
+}
+
+private enum MetalLibraryPluginError: Error, CustomStringConvertible {
+    case commandFailed(step: String, status: Int32)
+
+    var description: String {
+        switch self {
+        case .commandFailed(let step, let status):
+            "\(step) failed with exit status \(status). "
+                + "Install Xcode's Metal Toolchain component and try again."
+        }
+    }
+}

--- a/PackagePlugins/BuildMetalLibraryPlugin/BuildMetalLibraryPlugin.swift
+++ b/PackagePlugins/BuildMetalLibraryPlugin/BuildMetalLibraryPlugin.swift
@@ -7,10 +7,11 @@ struct BuildMetalLibraryPlugin: CommandPlugin {
         context: PluginContext,
         arguments: [String]
     ) async throws {
-        guard arguments.isEmpty else {
+        let unsupportedArguments = unsupportedArguments(in: arguments)
+        guard unsupportedArguments.isEmpty else {
             Diagnostics.error(
-                "build-metal-library does not accept arguments: "
-                    + arguments.joined(separator: " ")
+                "build-metal-library received unsupported arguments: "
+                    + unsupportedArguments.joined(separator: " ")
             )
             return
         }
@@ -59,6 +60,25 @@ struct BuildMetalLibraryPlugin: CommandPlugin {
         )
 
         print("Generated \(outputURL.path)")
+    }
+
+    private func unsupportedArguments(in arguments: [String]) -> [String] {
+        var unsupported: [String] = []
+        var index = 0
+
+        while index < arguments.count {
+            let argument = arguments[index]
+            if argument == "--target", index + 1 < arguments.count {
+                index += 2
+            } else if argument.hasPrefix("--target=") {
+                index += 1
+            } else {
+                unsupported.append(argument)
+                index += 1
+            }
+        }
+
+        return unsupported
     }
 
     private func runXcrun(

--- a/scripts/build-metallib.sh
+++ b/scripts/build-metallib.sh
@@ -3,22 +3,8 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
-source_file="$repo_root/Sources/ImageRecognition/Shaders/TemplateMatching.metal"
-output_file="$repo_root/Sources/ImageRecognition/Resources/TemplateMatching.metallib"
-temporary_directory="$(mktemp -d)"
 
-trap 'rm -rf "$temporary_directory"' EXIT
-
-mkdir -p "$(dirname "$output_file")"
-
-xcrun -sdk macosx metal \
-    -c \
-    -target air64-apple-macos26.0 \
-    "$source_file" \
-    -o "$temporary_directory/TemplateMatching.air"
-
-xcrun -sdk macosx metallib \
-    "$temporary_directory/TemplateMatching.air" \
-    -o "$output_file"
-
-echo "Generated $output_file"
+swift package \
+    --package-path "$repo_root" \
+    --allow-writing-to-package-directory \
+    build-metal-library


### PR DESCRIPTION
## Summary
- add a SwiftPM command plugin named `build-metal-library`
- compile `TemplateMatching.metal` to AIR and link the bundled `.metallib` through `xcrun`
- request package-directory write permission only when the command is invoked
- keep `scripts/build-metallib.sh` as a compatibility wrapper around the plugin
- document the Metal Toolchain requirement for library developers

## Usage
```bash
swift package --allow-writing-to-package-directory build-metal-library
```

Package consumers continue using the committed `.metallib` and do not need the optional Metal Toolchain component.

## Verification
- command appears in `swift package plugin --list`
- plugin regenerates a valid macOS MetalLib
- compatibility script succeeds
- `swift test --parallel` (116 tests)
- `swift build -c release`