### PR TITLE
Add structured native app-control actions to BasicAction

### DIFF
--- a/.agents/skills/agent-smoke-test/SKILL.md
+++ b/.agents/skills/agent-smoke-test/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: agent-smoke-test
+description: Run manual development checks for SwiftAutoGUI AI Agent actions through the local sagui CLI. Use when Claude or Codex needs to test app-control or Accessibility BasicAction generation on macOS.
+---
+
+# SwiftAutoGUI Agent Smoke Test
+
+Run examples from the repository root. Always source `~/.zshrc` so the latest
+`OPENAI_API_KEY` is available.
+
+Build once:
+
+```bash
+swift build --product sagui
+```
+
+Search for Swift in Safari:
+
+```bash
+source ~/.zshrc && .build/debug/sagui agent \
+  "Search for Swift in Safari." \
+  --max-iterations 10 --delay 1
+```
+
+Get the frontmost application:
+
+```bash
+source ~/.zshrc && .build/debug/sagui agent \
+  "Use exactly one getFrontmostApp action, then mark the goal done." \
+  --max-iterations 1 --delay 0
+```
+
+Activate Calculator:
+
+```bash
+source ~/.zshrc && .build/debug/sagui agent \
+  "Use exactly one activateApp action with app name Calculator, then mark the goal done." \
+  --max-iterations 1 --delay 0
+```
+
+Press Calculator button 7 with Accessibility:
+
+```bash
+source ~/.zshrc && .build/debug/sagui agent \
+  "Calculator is open. Use exactly one pressButton action with label 7 and bundleID com.apple.calculator. Do not use mouse or keyboard actions." \
+  --max-iterations 1 --delay 0
+```
+
+Set the first TextEdit text field:
+
+```bash
+source ~/.zshrc && .build/debug/sagui agent \
+  "TextEdit has a Save sheet open. Use exactly one setTextField action with an empty label, value SWIFTAUTOGUI_AGENT_TEST, and bundleID com.apple.TextEdit." \
+  --max-iterations 1 --delay 0
+```
+
+Select a TextEdit menu item:
+
+```bash
+source ~/.zshrc && .build/debug/sagui agent \
+  "TextEdit has a rich-text document open. Use exactly one selectMenuItem action with path [Format, Make Plain Text] and bundleID com.apple.TextEdit." \
+  --max-iterations 1 --delay 0
+```
+
+Raise a Calculator window:
+
+```bash
+source ~/.zshrc && .build/debug/sagui agent \
+  "Use exactly one raiseWindow action with title Calculator and bundleID com.apple.calculator." \
+  --max-iterations 1 --delay 0
+```
+
+Open a URL:
+
+```bash
+source ~/.zshrc && .build/debug/sagui agent \
+  "Use exactly one openURL action with URL https://example.com." \
+  --max-iterations 1 --delay 0
+```
+
+Quit Calculator:
+
+```bash
+source ~/.zshrc && .build/debug/sagui agent \
+  "Use exactly one quitApp action with app name Calculator." \
+  --max-iterations 1 --delay 0
+```
+
+Check the `Actions:` line in each command output to confirm which
+`BasicAction` the Agent generated.

--- a/.claude/skills/agent-smoke-test
+++ b/.claude/skills/agent-smoke-test
@@ -1,0 +1,1 @@
+../../.agents/skills/agent-smoke-test

--- a/Sample/Sample/Features/AIGeneration/AIGenerationDemoViewModel.swift
+++ b/Sample/Sample/Features/AIGeneration/AIGenerationDemoViewModel.swift
@@ -197,6 +197,14 @@ class AIGenerationDemoViewModel {
             return "Execute AppleScript: \(script.prefix(30))..."
         case .executeAppleScriptFile(let path):
             return "Execute AppleScript file: \(path)"
+        case .openURL(let url):
+            return "Open URL: \(url.absoluteString)"
+        case .activateApp(let name):
+            return "Activate app: \(name)"
+        case .quitApp(let name):
+            return "Quit app: \(name)"
+        case .getFrontmostApp:
+            return "Get frontmost app"
         case .pressButton(let label, _, _, _):
             return "Press button: \"\(label)\""
         case .setTextField(let label, _, let value, _, _):

--- a/Sample/Sample/Features/Actions/ActionsDemoViewModel.swift
+++ b/Sample/Sample/Features/Actions/ActionsDemoViewModel.swift
@@ -184,6 +184,14 @@ class ActionsDemoViewModel {
             return "Execute AppleScript: \(script.prefix(30))..."
         case .executeAppleScriptFile(let path):
             return "Execute AppleScript file: \(path)"
+        case .openURL(let url):
+            return "Open URL: \(url.absoluteString)"
+        case .activateApp(let name):
+            return "Activate app: \(name)"
+        case .quitApp(let name):
+            return "Quit app: \(name)"
+        case .getFrontmostApp:
+            return "Get frontmost app"
         case .pressButton(let label, _, _, _):
             return "AX press button: \"\(label)\""
         case .setTextField(let label, _, let value, _, _):

--- a/Sample/Sample/Features/Agent/AgentDemoViewModel.swift
+++ b/Sample/Sample/Features/Agent/AgentDemoViewModel.swift
@@ -133,6 +133,14 @@ class AgentDemoViewModel {
         case .keyShortcut(let keys): return "keyShortcut(\(keys.joined(separator: "+")))"
         case .drag(let fromX, let fromY, let toX, let toY):
             return "drag(\(Int(fromX)),\(Int(fromY))->\(Int(toX)),\(Int(toY)))"
+        case .openURL(let url):
+            return "openURL(\"\(url)\")"
+        case .activateApp(let name):
+            return "activateApp(\"\(name)\")"
+        case .quitApp(let name):
+            return "quitApp(\"\(name)\")"
+        case .getFrontmostApp:
+            return "getFrontmostApp"
         case .pressButton(let label, let bundleID):
             return "pressButton(\"\(label)\"\(bundleID.isEmpty ? "" : " in \(bundleID)"))"
         case .setTextField(let label, let value, let bundleID):

--- a/Sources/SwiftAutoGUI/AI/ActionGenerator.swift
+++ b/Sources/SwiftAutoGUI/AI/ActionGenerator.swift
@@ -59,6 +59,18 @@ public enum BasicAction: Sendable, Codable {
     /// Bring a window to the front by title.
     case raiseWindow(title: String, bundleID: String)
 
+    /// Open an HTTP or HTTPS URL in the default browser.
+    case openURL(url: String)
+
+    /// Launch an application if needed and bring it to the front.
+    case activateApp(name: String)
+
+    /// Gracefully quit an application.
+    case quitApp(name: String)
+
+    /// Get the name of the frontmost application.
+    case getFrontmostApp
+
     /// Convert to an executable ``Action``.
     public func toAction() -> Action {
         switch self {
@@ -96,11 +108,46 @@ public enum BasicAction: Sendable, Codable {
             return .selectMenuItem(path: path, app: scope(bundleID))
         case .raiseWindow(let title, let bundleID):
             return .raiseWindow(title: title, app: scope(bundleID))
+        case .openURL(let url):
+            guard let url = validatedHTTPURL(url) else { return .wait(0) }
+            return .openURL(url)
+        case .activateApp(let name):
+            guard let name = normalizedAppName(name) else { return .wait(0) }
+            return .activateApp(name: name)
+        case .quitApp(let name):
+            guard let name = normalizedAppName(name) else { return .wait(0) }
+            return .quitApp(name: name)
+        case .getFrontmostApp:
+            return .getFrontmostApp
         }
     }
 
     private func scope(_ bundleID: String) -> AXAppScope {
         bundleID.isEmpty ? .frontmost : .bundleID(bundleID)
+    }
+
+    private func validatedHTTPURL(_ value: String) -> URL? {
+        let value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard value.count <= 2_048,
+              let components = URLComponents(string: value),
+              let scheme = components.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              components.host != nil,
+              let url = components.url else {
+            return nil
+        }
+        return url
+    }
+
+    private func normalizedAppName(_ value: String) -> String? {
+        let value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty,
+              value.count <= 128,
+              !value.contains("/"),
+              !value.contains("\0") else {
+            return nil
+        }
+        return value
     }
 
     // MARK: - Tagged Union Codable
@@ -110,12 +157,14 @@ public enum BasicAction: Sendable, Codable {
         case text, x, y, clicks, duration, keys
         case fromX, fromY, toX, toY
         case label, value, path, title, bundleID
+        case url, name
     }
 
     private enum ActionType: String, Codable {
         case write, move, leftClick, rightClick, doubleClick
         case vscroll, hscroll, wait, keyShortcut, drag
         case pressButton, setTextField, selectMenuItem, raiseWindow
+        case openURL, activateApp, quitApp, getFrontmostApp
     }
 
     public init(from decoder: Decoder) throws {
@@ -171,6 +220,17 @@ public enum BasicAction: Sendable, Codable {
             let title = try container.decodeIfPresent(String.self, forKey: .title) ?? ""
             let bundleID = try container.decodeIfPresent(String.self, forKey: .bundleID) ?? ""
             self = .raiseWindow(title: title, bundleID: bundleID)
+        case .openURL:
+            let url = try container.decodeIfPresent(String.self, forKey: .url) ?? ""
+            self = .openURL(url: url)
+        case .activateApp:
+            let name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+            self = .activateApp(name: name)
+        case .quitApp:
+            let name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+            self = .quitApp(name: name)
+        case .getFrontmostApp:
+            self = .getFrontmostApp
         }
     }
 
@@ -226,6 +286,17 @@ public enum BasicAction: Sendable, Codable {
             try container.encode(ActionType.raiseWindow, forKey: .type)
             try container.encode(title, forKey: .title)
             try container.encode(bundleID, forKey: .bundleID)
+        case .openURL(let url):
+            try container.encode(ActionType.openURL, forKey: .type)
+            try container.encode(url, forKey: .url)
+        case .activateApp(let name):
+            try container.encode(ActionType.activateApp, forKey: .type)
+            try container.encode(name, forKey: .name)
+        case .quitApp(let name):
+            try container.encode(ActionType.quitApp, forKey: .type)
+            try container.encode(name, forKey: .name)
+        case .getFrontmostApp:
+            try container.encode(ActionType.getFrontmostApp, forKey: .type)
         }
     }
 }

--- a/Sources/SwiftAutoGUI/AI/OpenAIBackend.swift
+++ b/Sources/SwiftAutoGUI/AI/OpenAIBackend.swift
@@ -144,9 +144,14 @@ extension OpenAIBackend {
         Parameters: path (array of strings, e.g. ["File", "Save As…"]), bundleID (string, empty = frontmost)
         - raiseWindow: Bring a window to the front by title. \
         Parameters: title (string), bundleID (string, empty = frontmost)
+        - openURL: Open an HTTP or HTTPS URL in the default browser. Parameters: url (string)
+        - activateApp: Launch an app if needed and bring it to the front. Parameters: name (string)
+        - quitApp: Gracefully quit an app. Parameters: name (string)
+        - getFrontmostApp: Get the name of the frontmost application. No additional parameters needed.
 
-        Prefer pressButton/setTextField/selectMenuItem/raiseWindow over coordinate-based actions \
-        when the user identifies a target by name — they are more reliable than guessing coordinates.
+        Prefer openURL/activateApp/quitApp and the AX-based actions \
+        (pressButton/setTextField/selectMenuItem/raiseWindow) over coordinate-based actions \
+        when applicable. They are more reliable than guessing coordinates.
 
         Respond with a JSON object containing an "actions" array. Each action must have a "type" field \
         and the relevant parameters for that type. For parameters not relevant to the action type, \

--- a/Sources/SwiftAutoGUI/AI/OpenAIVisionBackend.swift
+++ b/Sources/SwiftAutoGUI/AI/OpenAIVisionBackend.swift
@@ -204,6 +204,14 @@ extension OpenAIVisionBackend {
             return "selectMenuItem(\(path.joined(separator: " > "))\(bundleID.isEmpty ? "" : " in \(bundleID)"))"
         case .raiseWindow(let title, let bundleID):
             return "raiseWindow(\"\(title)\"\(bundleID.isEmpty ? "" : " in \(bundleID)"))"
+        case .openURL(let url):
+            return "openURL(\"\(url)\")"
+        case .activateApp(let name):
+            return "activateApp(\"\(name)\")"
+        case .quitApp(let name):
+            return "quitApp(\"\(name)\")"
+        case .getFrontmostApp:
+            return "getFrontmostApp"
         }
     }
 }
@@ -240,9 +248,14 @@ extension OpenAIVisionBackend {
         Parameters: path (array of strings, e.g. ["File", "Save As…"]), bundleID (string, empty = frontmost)
         - raiseWindow: Bring a window to the front by title. \
         Parameters: title (string), bundleID (string, empty = frontmost)
+        - openURL: Open an HTTP or HTTPS URL in the default browser. Parameters: url (string)
+        - activateApp: Launch an app if needed and bring it to the front. Parameters: name (string)
+        - quitApp: Gracefully quit an app. Parameters: name (string)
+        - getFrontmostApp: Get the name of the frontmost application. No additional parameters needed.
 
-        Prefer the AX-based actions (pressButton, setTextField, selectMenuItem, raiseWindow) when the \
-        accessibility tree provides labels. They are more reliable than coordinate-based clicks.
+        Prefer openURL/activateApp/quitApp and the AX-based actions \
+        (pressButton, setTextField, selectMenuItem, raiseWindow) when applicable. \
+        They are more reliable than coordinate-based clicks.
 
         Instructions:
         1. Analyze the screenshot to understand the current screen state.
@@ -336,6 +349,17 @@ extension OpenAIVisionBackend {
             let title = dict["title"] as? String ?? ""
             let bundleID = dict["bundleID"] as? String ?? ""
             return .raiseWindow(title: title, bundleID: bundleID)
+        case "openURL":
+            let url = dict["url"] as? String ?? ""
+            return .openURL(url: url)
+        case "activateApp":
+            let name = dict["name"] as? String ?? ""
+            return .activateApp(name: name)
+        case "quitApp":
+            let name = dict["name"] as? String ?? ""
+            return .quitApp(name: name)
+        case "getFrontmostApp":
+            return .getFrontmostApp
         default:
             return nil
         }
@@ -419,7 +443,8 @@ extension OpenAIVisionBackend {
                 "description": "The action type.",
                 "enum": ["write", "move", "leftClick", "rightClick", "doubleClick",
                          "vscroll", "hscroll", "wait", "keyShortcut", "drag",
-                         "pressButton", "setTextField", "selectMenuItem", "raiseWindow"]
+                         "pressButton", "setTextField", "selectMenuItem", "raiseWindow",
+                         "openURL", "activateApp", "quitApp", "getFrontmostApp"]
             ] as [String: Any],
             "text": ["type": ["string", "null"], "description": "Text to type. Used with 'write' action."] as [String: Any],
             "x": ["type": ["number", "null"], "description": "X coordinate. Used with 'move' action."] as [String: Any],
@@ -436,10 +461,12 @@ extension OpenAIVisionBackend {
             "path": ["type": ["array", "null"], "description": "Menu path components, e.g. [\"File\", \"Save As…\"]. Used with 'selectMenuItem'.", "items": ["type": "string"]] as [String: Any],
             "title": ["type": ["string", "null"], "description": "Window title. Used with 'raiseWindow'."] as [String: Any],
             "bundleID": ["type": ["string", "null"], "description": "Bundle identifier of the target app, or empty/null for frontmost. Used with all AX actions."] as [String: Any],
+            "url": ["type": ["string", "null"], "description": "HTTP or HTTPS URL. Used with 'openURL'."] as [String: Any],
+            "name": ["type": ["string", "null"], "description": "Application name. Used with 'activateApp' and 'quitApp'."] as [String: Any],
         ] as [String: Any],
         "required": ["type", "text", "x", "y", "clicks", "duration", "keys",
                      "fromX", "fromY", "toX", "toY",
-                     "label", "value", "path", "title", "bundleID"],
+                     "label", "value", "path", "title", "bundleID", "url", "name"],
         "additionalProperties": false
     ] as [String: Any]
 

--- a/Sources/SwiftAutoGUI/Actions/Action.swift
+++ b/Sources/SwiftAutoGUI/Actions/Action.swift
@@ -88,6 +88,12 @@ import AppKit
 /// - ``executeAppleScript(_:)``
 /// - ``executeAppleScriptFile(_:)``
 ///
+/// ### Application Control
+/// - ``openURL(_:)``
+/// - ``activateApp(name:)``
+/// - ``quitApp(name:)``
+/// - ``getFrontmostApp``
+///
 /// ### Control Flow Actions
 /// - ``wait(_:)``
 /// - ``sequence(_:)``
@@ -229,6 +235,20 @@ public enum Action {
 
     /// Bring a window to the front by title.
     case raiseWindow(title: String, app: AXAppScope = .frontmost, exact: Bool = false)
+
+    // MARK: - Application Control
+
+    /// Open a URL in its default application.
+    case openURL(URL)
+
+    /// Launch an application if needed and bring all of its windows forward.
+    case activateApp(name: String)
+
+    /// Gracefully terminate a running application.
+    case quitApp(name: String)
+
+    /// Get the localized name of the frontmost application.
+    case getFrontmostApp
 
     // MARK: - AppleScript
 
@@ -382,9 +402,21 @@ public enum Action {
         case .raiseWindow(let title, let app, let exact):
             return SwiftAutoGUI.raiseWindow(title: title, app: app, exact: exact)
 
+        case .openURL(let url):
+            return SwiftAutoGUI.openURL(url)
+
+        case .activateApp(let name):
+            return await SwiftAutoGUI.activateApp(named: name)
+
+        case .quitApp(let name):
+            return SwiftAutoGUI.quitApp(named: name)
+
+        case .getFrontmostApp:
+            return SwiftAutoGUI.frontmostAppName()
+
         case .executeAppleScript(let script):
             do {
-                return try SwiftAutoGUI.executeAppleScript(script)
+                return try await SwiftAutoGUI.executeAppleScriptAsync(script)
             } catch {
                 print("AppleScript execution failed: \(error)")
                 return nil
@@ -392,7 +424,7 @@ public enum Action {
             
         case .executeAppleScriptFile(let path):
             do {
-                return try SwiftAutoGUI.executeAppleScriptFile(path)
+                return try await SwiftAutoGUI.executeAppleScriptFileAsync(path)
             } catch {
                 print("AppleScript file execution failed: \(error)")
                 return nil

--- a/Sources/SwiftAutoGUI/Core/SwiftAutoGUI.swift
+++ b/Sources/SwiftAutoGUI/Core/SwiftAutoGUI.swift
@@ -71,8 +71,16 @@ import AppKit
 ///
 /// ### AppleScript Execution
 /// - ``executeAppleScript(_:)``
+/// - ``executeAppleScriptAsync(_:)``
 /// - ``executeAppleScriptFile(_:)``
+/// - ``executeAppleScriptFileAsync(_:)``
 /// - ``AppleScriptError``
+///
+/// ### Application Control
+/// - ``openURL(_:)``
+/// - ``activateApp(named:)``
+/// - ``quitApp(named:)``
+/// - ``frontmostAppName()``
 public class SwiftAutoGUI {
 
     // MARK: Keyboard Layout

--- a/Sources/SwiftAutoGUI/System/AppControl.swift
+++ b/Sources/SwiftAutoGUI/System/AppControl.swift
@@ -1,0 +1,96 @@
+import AppKit
+import Foundation
+
+/// Native macOS application-control helpers.
+///
+/// These operations use Launch Services and `NSRunningApplication` instead of
+/// AppleScript, so structured AI parameters are never interpolated into code.
+extension SwiftAutoGUI {
+
+    /// Opens a URL in its default application.
+    @MainActor
+    @discardableResult
+    public static func openURL(_ url: URL) -> Bool {
+        NSWorkspace.shared.open(url)
+    }
+
+    /// Launches an application if needed and brings all of its windows forward.
+    @MainActor
+    @discardableResult
+    public static func activateApp(named name: String) async -> Bool {
+        if let application = runningApplication(named: name) {
+            return application.activate(options: [.activateAllWindows])
+        }
+
+        guard let applicationURL = applicationURL(named: name) else {
+            return false
+        }
+
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.activates = true
+
+        return await withCheckedContinuation { continuation in
+            NSWorkspace.shared.openApplication(
+                at: applicationURL,
+                configuration: configuration
+            ) { application, _ in
+                guard let application else {
+                    continuation.resume(returning: false)
+                    return
+                }
+                continuation.resume(
+                    returning: application.activate(options: [.activateAllWindows])
+                )
+            }
+        }
+    }
+
+    /// Gracefully terminates a running application.
+    @MainActor
+    @discardableResult
+    public static func quitApp(named name: String) -> Bool {
+        runningApplication(named: name)?.terminate() ?? false
+    }
+
+    /// Returns the localized name of the frontmost application.
+    @MainActor
+    public static func frontmostAppName() -> String? {
+        NSWorkspace.shared.frontmostApplication?.localizedName
+    }
+
+    @MainActor
+    private static func runningApplication(named name: String) -> NSRunningApplication? {
+        NSWorkspace.shared.runningApplications.first { application in
+            application.localizedName?.caseInsensitiveCompare(name) == .orderedSame ||
+                application.bundleIdentifier?.caseInsensitiveCompare(name) == .orderedSame
+        }
+    }
+
+    @MainActor
+    private static func applicationURL(named name: String) -> URL? {
+        if name.contains("."),
+           let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: name) {
+            return url
+        }
+
+        let applicationName = name.hasSuffix(".app") ? name : "\(name).app"
+        let searchDirectories = [
+            URL(fileURLWithPath: "/Applications", isDirectory: true),
+            URL(fileURLWithPath: "/System/Applications", isDirectory: true),
+            URL(fileURLWithPath: "/System/Applications/Utilities", isDirectory: true),
+            FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent("Applications", isDirectory: true)
+        ]
+
+        for directory in searchDirectories {
+            let candidate = directory.appendingPathComponent(
+                applicationName,
+                isDirectory: true
+            )
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                return candidate
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/SwiftAutoGUI/System/AppleScript.swift
+++ b/Sources/SwiftAutoGUI/System/AppleScript.swift
@@ -60,7 +60,11 @@ import Foundation
 /// }
 /// ```
 extension SwiftAutoGUI {
-    
+
+    private static let appleScriptQueue = DispatchQueue(
+        label: "SwiftAutoGUI.AppleScript"
+    )
+
     /// Executes an AppleScript string and returns the result.
     ///
     /// This method executes the provided AppleScript code synchronously and returns
@@ -126,6 +130,22 @@ extension SwiftAutoGUI {
         
         return eventDescriptor.stringValue
     }
+
+    /// Executes AppleScript on a dedicated serial queue.
+    ///
+    /// Prefer this method from asynchronous or UI-driven code so a slow target
+    /// application does not block the main actor.
+    public static func executeAppleScriptAsync(_ script: String) async throws -> String? {
+        try await withCheckedThrowingContinuation { continuation in
+            appleScriptQueue.async {
+                do {
+                    continuation.resume(returning: try executeAppleScript(script))
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
     
     /// Executes an AppleScript from a file.
     ///
@@ -152,9 +172,24 @@ extension SwiftAutoGUI {
         let scriptContent = try String(contentsOf: fileURL, encoding: .utf8)
         return try executeAppleScript(scriptContent)
     }
+
+    /// Loads and executes an AppleScript file on a dedicated serial queue.
+    public static func executeAppleScriptFileAsync(_ filePath: String) async throws -> String? {
+        try await withCheckedThrowingContinuation { continuation in
+            appleScriptQueue.async {
+                do {
+                    continuation.resume(
+                        returning: try executeAppleScriptFile(filePath)
+                    )
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
     
     /// Represents errors that can occur during AppleScript execution.
-    public enum AppleScriptError: LocalizedError {
+    public enum AppleScriptError: LocalizedError, Sendable {
         case compilationFailed(String)
         case executionFailed(String)
         case fileNotFound(String)

--- a/Tests/SwiftAutoGUITests/ActionGeneratorTests.swift
+++ b/Tests/SwiftAutoGUITests/ActionGeneratorTests.swift
@@ -171,6 +171,45 @@ struct ActionGeneratorTests {
             #expect(title == "Untitled")
             #expect(bundleID == "")
         }
+
+        @Test("openURL round-trip")
+        func openURLRoundTrip() throws {
+            let roundTripped = try roundTrip(.openURL(url: "https://example.com/path?q=swift"))
+            guard case .openURL(let url) = roundTripped else {
+                Issue.record("Expected .openURL, got \(roundTripped)")
+                return
+            }
+            #expect(url == "https://example.com/path?q=swift")
+        }
+
+        @Test("activateApp round-trip")
+        func activateAppRoundTrip() throws {
+            let roundTripped = try roundTrip(.activateApp(name: "Safari"))
+            guard case .activateApp(let name) = roundTripped else {
+                Issue.record("Expected .activateApp, got \(roundTripped)")
+                return
+            }
+            #expect(name == "Safari")
+        }
+
+        @Test("quitApp round-trip")
+        func quitAppRoundTrip() throws {
+            let roundTripped = try roundTrip(.quitApp(name: "Google Chrome"))
+            guard case .quitApp(let name) = roundTripped else {
+                Issue.record("Expected .quitApp, got \(roundTripped)")
+                return
+            }
+            #expect(name == "Google Chrome")
+        }
+
+        @Test("getFrontmostApp round-trip")
+        func getFrontmostAppRoundTrip() throws {
+            let roundTripped = try roundTrip(.getFrontmostApp)
+            guard case .getFrontmostApp = roundTripped else {
+                Issue.record("Expected .getFrontmostApp, got \(roundTripped)")
+                return
+            }
+        }
     }
 
     // MARK: - OpenAI JSON Response Parsing Tests
@@ -336,6 +375,70 @@ struct ActionGeneratorTests {
             #expect(path == ["File", "Save As…"])
             #expect(bundleID == "")
         }
+
+        @Test("parse Tier 1 app-control actions")
+        func parseAppControlActions() throws {
+            let json = """
+            {"actions": [
+                {"type": "openURL", "url": "https://example.com"},
+                {"type": "activateApp", "name": "Safari"},
+                {"type": "quitApp", "name": "TextEdit"},
+                {"type": "getFrontmostApp"}
+            ]}
+            """
+            let actions = try decodeActions(from: json)
+            #expect(actions.count == 4)
+
+            guard case .openURL(let url) = actions[0] else {
+                Issue.record("Expected .openURL")
+                return
+            }
+            #expect(url == "https://example.com")
+
+            guard case .activateApp(let activateName) = actions[1] else {
+                Issue.record("Expected .activateApp")
+                return
+            }
+            #expect(activateName == "Safari")
+
+            guard case .quitApp(let quitName) = actions[2] else {
+                Issue.record("Expected .quitApp")
+                return
+            }
+            #expect(quitName == "TextEdit")
+
+            guard case .getFrontmostApp = actions[3] else {
+                Issue.record("Expected .getFrontmostApp")
+                return
+            }
+        }
+
+        @Test("Vision parser supports Tier 1 app-control actions")
+        func visionParserSupportsAppControlActions() {
+            let dictionaries: [[String: Any]] = [
+                ["type": "openURL", "url": "https://example.com"],
+                ["type": "activateApp", "name": "Safari"],
+                ["type": "quitApp", "name": "TextEdit"],
+                ["type": "getFrontmostApp"]
+            ]
+            let actions = dictionaries.compactMap(OpenAIVisionBackend.parseAction)
+            #expect(actions.count == 4)
+
+            guard case .openURL(let url) = actions[0] else {
+                Issue.record("Expected .openURL")
+                return
+            }
+            #expect(url == "https://example.com")
+
+            guard case .activateApp(let activateName) = actions[1],
+                  case .quitApp(let quitName) = actions[2],
+                  case .getFrontmostApp = actions[3] else {
+                Issue.record("Expected all Tier 1 app-control actions")
+                return
+            }
+            #expect(activateName == "Safari")
+            #expect(quitName == "TextEdit")
+        }
     }
 
     // MARK: - BasicAction to Action Conversion Tests
@@ -458,6 +561,80 @@ struct ActionGeneratorTests {
             }
             #expect(title == "Untitled")
         }
+
+        @Test("openURL converts to native Action.openURL")
+        func openURLConversion() {
+            let action = BasicAction.openURL(url: "https://example.com/path?q=swift").toAction()
+            guard case .openURL(let url) = action else {
+                Issue.record("Expected Action.openURL")
+                return
+            }
+            #expect(url.absoluteString == "https://example.com/path?q=swift")
+        }
+
+        @Test("openURL rejects non-HTTP schemes")
+        func openURLRejectsUnsafeScheme() {
+            let action = BasicAction.openURL(url: "javascript:alert(1)").toAction()
+            guard case .wait(let duration) = action else {
+                Issue.record("Expected Action.wait for invalid URL")
+                return
+            }
+            #expect(duration == 0)
+        }
+
+        @Test("activateApp converts to native Action.activateApp")
+        func activateAppConversion() {
+            let action = BasicAction.activateApp(name: "Safari").toAction()
+            guard case .activateApp(let name) = action else {
+                Issue.record("Expected Action.activateApp")
+                return
+            }
+            #expect(name == "Safari")
+        }
+
+        @Test("quitApp converts to native Action.quitApp")
+        func quitAppConversion() {
+            let action = BasicAction.quitApp(name: "Google Chrome").toAction()
+            guard case .quitApp(let name) = action else {
+                Issue.record("Expected Action.quitApp")
+                return
+            }
+            #expect(name == "Google Chrome")
+        }
+
+        @Test("app names are passed as data without AppleScript interpolation")
+        func appNamesRemainData() {
+            let name = #"Example "App" & Tools"#
+
+            guard case .activateApp(let activatedName) =
+                    BasicAction.activateApp(name: name).toAction(),
+                  case .quitApp(let quitName) =
+                    BasicAction.quitApp(name: name).toAction() else {
+                Issue.record("Expected native app-control actions")
+                return
+            }
+            #expect(activatedName == name)
+            #expect(quitName == name)
+        }
+
+        @Test("app actions reject path traversal")
+        func appActionsRejectPathTraversal() {
+            let action = BasicAction.activateApp(name: "../Calculator").toAction()
+            guard case .wait(let duration) = action else {
+                Issue.record("Expected Action.wait for an invalid app path")
+                return
+            }
+            #expect(duration == 0)
+        }
+
+        @Test("getFrontmostApp converts to native action")
+        func getFrontmostAppConversion() {
+            let action = BasicAction.getFrontmostApp.toAction()
+            guard case .getFrontmostApp = action else {
+                Issue.record("Expected Action.getFrontmostApp")
+                return
+            }
+        }
     }
 
     // MARK: - Backend and API Tests
@@ -483,6 +660,24 @@ struct ActionGeneratorTests {
             let backend = OpenAIBackend(apiKey: "test-key")
             let generator = ActionGenerator(backend: backend)
             #expect(generator.backend.isAvailable)
+        }
+
+        @Test("OpenAI action schema includes Tier 1 app-control fields")
+        func actionSchemaIncludesAppControlFields() {
+            let schema = OpenAIVisionBackend.actionItemSchemaDict
+            let properties = schema["properties"] as? [String: Any]
+            let required = schema["required"] as? [String]
+            let typeProperty = properties?["type"] as? [String: Any]
+            let actionTypes = typeProperty?["enum"] as? [String]
+
+            #expect(properties?["url"] != nil)
+            #expect(properties?["name"] != nil)
+            #expect(required?.contains("url") == true)
+            #expect(required?.contains("name") == true)
+            #expect(actionTypes?.contains("openURL") == true)
+            #expect(actionTypes?.contains("activateApp") == true)
+            #expect(actionTypes?.contains("quitApp") == true)
+            #expect(actionTypes?.contains("getFrontmostApp") == true)
         }
     }
 }

--- a/Tests/SwiftAutoGUITests/AppleScriptTests.swift
+++ b/Tests/SwiftAutoGUITests/AppleScriptTests.swift
@@ -14,6 +14,15 @@ struct AppleScriptTests {
             _ = try SwiftAutoGUI.executeAppleScript(script)
         }
     }
+
+    @Test("Execute invalid AppleScript asynchronously throws error")
+    func testInvalidAppleScriptAsync() async {
+        let script = "this is not valid AppleScript"
+
+        await #expect(throws: SwiftAutoGUI.AppleScriptError.self) {
+            _ = try await SwiftAutoGUI.executeAppleScriptAsync(script)
+        }
+    }
     
     @Test("Execute AppleScript from non-existent file throws error")
     func testExecuteAppleScriptFileNotFound() {


### PR DESCRIPTION
## Summary

- add `openURL`, `activateApp`, `quitApp`, and `getFrontmostApp` to `BasicAction`
- expose the actions through both OpenAI backends, including prompts, parsing, history descriptions, and strict JSON schema
- implement Tier 1 app control with native macOS APIs instead of interpolated AppleScript:
  - `NSWorkspace.open` for URLs
  - `NSRunningApplication.activate` for activation
  - `NSRunningApplication.terminate` for quitting
  - `NSWorkspace.frontmostApplication` for frontmost-app lookup
- move generic `Action.executeAppleScript` execution onto a dedicated serial queue to avoid blocking the main actor
- add a repository-local Claude/Codex skill with manual `sagui agent` smoke-test commands

This incorporates the implementation concerns raised in the issue discussion, while retaining the structured AI action interface proposed by the issue.

## Validation

- `swift test` (131 tests passed)
- `swift package generate-documentation`
- live `sagui agent` checks for `getFrontmostApp` and `activateApp`
- verified Calculator became the frontmost app after native activation

Closes #82
