### PR TITLE
Fix sagui input event handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,12 @@ jobs:
             exit 1
           fi
 
+          cli_version="$(sed -n 's/.*static let current = "\([^"]*\)"/\1/p' Sources/sagui/SaguiVersion.swift)"
+          if [[ "$cli_version" == "$VERSION" ]]; then
+            echo "::error::CLI version is already $VERSION."
+            exit 1
+          fi
+
       - name: Update plugin version
         env:
           VERSION: ${{ inputs.version }}
@@ -58,7 +64,11 @@ jobs:
           jq --arg version "$VERSION" '.version = $version' "$manifest" > "$manifest.tmp"
           mv "$manifest.tmp" "$manifest"
 
+          cli_version_file="Sources/sagui/SaguiVersion.swift"
+          sed -i "s/static let current = \"[^\"]*\"/static let current = \"$VERSION\"/" "$cli_version_file"
+
           test "$(jq -r '.version' "$manifest")" = "$VERSION"
+          test "$(sed -n 's/.*static let current = "\([^"]*\)"/\1/p' "$cli_version_file")" = "$VERSION"
 
       - name: Commit version bump
         env:
@@ -68,7 +78,7 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add plugins/swift-auto-gui/.claude-plugin/plugin.json
+          git add plugins/swift-auto-gui/.claude-plugin/plugin.json Sources/sagui/SaguiVersion.swift
           git commit -m "Bump plugin version to $VERSION"
           git push origin HEAD:master
 

--- a/Package.swift
+++ b/Package.swift
@@ -48,6 +48,9 @@ let package = Package(
             name: "SwiftAutoGUITests",
             dependencies: ["SwiftAutoGUI"]),
         .testTarget(
+            name: "SaguiTests",
+            dependencies: ["sagui"]),
+        .testTarget(
             name: "ImageRecognitionTests",
             dependencies: ["ImageRecognition"]),
         .plugin(

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ brew install NakaokaRei/tap/sagui
 After install, grant **Accessibility** permission to your terminal in
 System Settings → Privacy & Security → Accessibility.
 
+```bash
+sagui --version
+sagui key list
+sagui key shortcut return
+sagui mouse click --x 100 --y 200
+sagui mouse click --right --x 100 --y 200
+```
+
 
 # Example Usage
 

--- a/Sources/SwiftAutoGUI/Core/InputEvent.swift
+++ b/Sources/SwiftAutoGUI/Core/InputEvent.swift
@@ -1,0 +1,189 @@
+import CoreGraphics
+
+enum InputEvent {
+    static let clickDelayNanoseconds: UInt64 = 60_000_000
+
+    static func currentFlags() -> CGEventFlags {
+        CGEventSource.flagsState(.hidSystemState)
+    }
+
+    static func modifierFlag(for key: Key) -> CGEventFlags? {
+        switch key {
+        case .command:
+            return .maskCommand
+        case .shift, .rightShift:
+            return .maskShift
+        case .option, .rightOption:
+            return .maskAlternate
+        case .control, .rightControl:
+            return .maskControl
+        case .function:
+            return .maskSecondaryFn
+        default:
+            return nil
+        }
+    }
+
+    static func modifierDeviceFlag(for key: Key) -> CGEventFlags? {
+        switch key {
+        case .control:
+            return CGEventFlags(rawValue: 0x0000_0001)
+        case .shift:
+            return CGEventFlags(rawValue: 0x0000_0002)
+        case .rightShift:
+            return CGEventFlags(rawValue: 0x0000_0004)
+        case .command:
+            return CGEventFlags(rawValue: 0x0000_0008)
+        case .option:
+            return CGEventFlags(rawValue: 0x0000_0020)
+        case .rightOption:
+            return CGEventFlags(rawValue: 0x0000_0040)
+        case .rightControl:
+            return CGEventFlags(rawValue: 0x0000_2000)
+        default:
+            return nil
+        }
+    }
+
+    static func pairedModifierDeviceFlag(for key: Key) -> CGEventFlags? {
+        switch key {
+        case .shift:
+            return modifierDeviceFlag(for: .rightShift)
+        case .rightShift:
+            return modifierDeviceFlag(for: .shift)
+        case .option:
+            return modifierDeviceFlag(for: .rightOption)
+        case .rightOption:
+            return modifierDeviceFlag(for: .option)
+        case .control:
+            return modifierDeviceFlag(for: .rightControl)
+        case .rightControl:
+            return modifierDeviceFlag(for: .control)
+        default:
+            return nil
+        }
+    }
+
+    static func adjustedFlags(
+        for key: Key,
+        down: Bool,
+        currentFlags: CGEventFlags
+    ) -> CGEventFlags {
+        guard let flag = modifierFlag(for: key) else {
+            return currentFlags
+        }
+
+        let deviceFlag = modifierDeviceFlag(for: key) ?? []
+        let keyFlags = flag.union(deviceFlag)
+
+        if down {
+            return currentFlags.union(keyFlags)
+        }
+
+        var adjusted = currentFlags.subtracting(keyFlags)
+        if let pairedFlag = pairedModifierDeviceFlag(for: key),
+           adjusted.contains(pairedFlag) {
+            adjusted.formUnion(flag)
+        }
+        return adjusted
+    }
+
+    static func keyboardEvent(
+        for key: Key,
+        keycode: CGKeyCode,
+        down: Bool,
+        currentFlags: CGEventFlags? = nil,
+        source: CGEventSource? = nil
+    ) -> CGEvent? {
+        let eventSource = source ?? CGEventSource(stateID: .hidSystemState)
+        let event = CGEvent(keyboardEventSource: eventSource, virtualKey: keycode, keyDown: down)
+        guard let event else { return nil }
+
+        let existingFlags = currentFlags ?? self.currentFlags()
+        if let modifierFlag = modifierFlag(for: key) {
+            var flags = adjustedFlags(for: key, down: down, currentFlags: existingFlags)
+            if down {
+                flags.formUnion(event.flags)
+            } else {
+                let deviceFlag = modifierDeviceFlag(for: key) ?? []
+                flags.formUnion(event.flags.subtracting(modifierFlag.union(deviceFlag)))
+            }
+            event.flags = flags
+        } else {
+            event.flags = existingFlags.union(event.flags)
+        }
+        return event
+    }
+
+    static func mouseEvent(
+        type: CGEventType,
+        position: CGPoint,
+        button: CGMouseButton,
+        clickCount: Int64 = 0,
+        flags: CGEventFlags? = nil,
+        source: CGEventSource? = nil
+    ) -> CGEvent? {
+        let eventSource = source ?? CGEventSource(stateID: .hidSystemState)
+        let event = CGEvent(
+            mouseEventSource: eventSource,
+            mouseType: type,
+            mouseCursorPosition: position,
+            mouseButton: button
+        )
+        event?.flags = flags ?? currentFlags()
+        event?.setIntegerValueField(.mouseEventClickState, value: clickCount)
+        return event
+    }
+
+    static func mouseMovedEvent(
+        at position: CGPoint,
+        flags: CGEventFlags? = nil,
+        source: CGEventSource? = nil
+    ) -> CGEvent? {
+        mouseEvent(
+            type: .mouseMoved,
+            position: position,
+            button: .left,
+            flags: flags,
+            source: source
+        )
+    }
+
+    static func scrollEvent(
+        vertical: Int32,
+        horizontal: Int32,
+        at position: CGPoint,
+        flags: CGEventFlags? = nil,
+        source: CGEventSource? = nil
+    ) -> CGEvent? {
+        let eventSource = source ?? CGEventSource(stateID: .hidSystemState)
+        let event = CGEvent(
+            scrollWheelEvent2Source: eventSource,
+            units: .line,
+            wheelCount: horizontal == 0 ? 1 : 2,
+            wheel1: vertical,
+            wheel2: horizontal,
+            wheel3: 0
+        )
+        event?.location = position
+        event?.flags = flags ?? currentFlags()
+        return event
+    }
+
+    static func scrollDeltas(clicks: Int) -> [Int32] {
+        guard clicks != 0 else { return [] }
+
+        var remaining = clicks
+        var deltas: [Int32] = []
+        while remaining != 0 {
+            let delta = min(10, max(-10, remaining))
+            deltas.append(Int32(delta))
+            remaining -= delta
+        }
+        return deltas
+    }
+
+    static func postMouseMoved(at position: CGPoint, source: CGEventSource? = nil) {
+        mouseMovedEvent(at: position, source: source)?.post(tap: .cghidEventTap)
+    }
+}

--- a/Sources/SwiftAutoGUI/Core/InputEvent.swift
+++ b/Sources/SwiftAutoGUI/Core/InputEvent.swift
@@ -184,6 +184,7 @@ enum InputEvent {
     }
 
     static func postMouseMoved(at position: CGPoint, source: CGEventSource? = nil) {
+        CGWarpMouseCursorPosition(position)
         mouseMovedEvent(at: position, source: source)?.post(tap: .cghidEventTap)
     }
 }

--- a/Sources/SwiftAutoGUI/Core/SwiftAutoGUI.swift
+++ b/Sources/SwiftAutoGUI/Core/SwiftAutoGUI.swift
@@ -34,6 +34,7 @@ import AppKit
 /// - ``TweeningFunction``
 ///
 /// ### Mouse Clicks
+/// - ``click(at:button:)``
 /// - ``leftClick()``
 /// - ``rightClick()``
 /// - ``doubleClick(button:)``
@@ -165,12 +166,44 @@ public class SwiftAutoGUI {
     /// await SwiftAutoGUI.sendKeyShortcut([.command, .space])
     /// ```
     public static func sendKeyShortcut(_ keys: [Key]) async {
+        let source = CGEventSource(stateID: .hidSystemState)
+        var flags = InputEvent.currentFlags()
+
         for key in keys {
-            await keyDown(key)
+            if let keycode = key.normalKeycode {
+                let event = InputEvent.keyboardEvent(
+                    for: key,
+                    keycode: keycode,
+                    down: true,
+                    currentFlags: flags,
+                    source: source
+                )
+                flags = event?.flags ?? flags
+                event?.post(tap: .cghidEventTap)
+                try? await Task.sleep(nanoseconds: 10_000_000)
+            } else if let specialKeycode = key.specialKeycode {
+                await specialKeyEvent(specialKeycode, down: true)
+            }
         }
+
         for key in keys.reversed() {
-            await keyUp(key)
+            if let keycode = key.normalKeycode {
+                let event = InputEvent.keyboardEvent(
+                    for: key,
+                    keycode: keycode,
+                    down: false,
+                    currentFlags: flags,
+                    source: source
+                )
+                flags = event?.flags ?? flags
+                event?.post(tap: .cghidEventTap)
+                try? await Task.sleep(nanoseconds: 10_000_000)
+            } else if let specialKeycode = key.specialKeycode {
+                await specialKeyEvent(specialKeycode, down: false)
+            }
         }
+
+        _ = source?.sourceStateID
     }
 
     /// Simulates pressing down a key without releasing it with async delay.
@@ -200,7 +233,7 @@ public class SwiftAutoGUI {
     /// ```
     public static func keyDown(_ key: Key) async {
         if let normalKeycode = key.normalKeycode {
-            await normalKeyEvent(normalKeycode, down: true)
+            await normalKeyEvent(key, keycode: normalKeycode, down: true)
         } else if let specialKeycode = key.specialKeycode {
             await specialKeyEvent(specialKeycode, down: true)
         }
@@ -230,7 +263,7 @@ public class SwiftAutoGUI {
     /// ```
     public static func keyUp(_ key: Key) async {
         if let normalKeycode = key.normalKeycode {
-            await normalKeyEvent(normalKeycode, down: false)
+            await normalKeyEvent(key, keycode: normalKeycode, down: false)
         } else if let specialKeycode = key.specialKeycode {
             await specialKeyEvent(specialKeycode, down: false)
         }
@@ -239,13 +272,16 @@ public class SwiftAutoGUI {
     /// Simulates a normal key event (press or release) with async delay.
     ///
     /// - Parameters:
-    ///   - key: The CGKeyCode value for the key
+    ///   - key: The key to send
+    ///   - keycode: The CGKeyCode value for the key
     ///   - down: true for key press, false for key release
-    private static func normalKeyEvent(_ key: CGKeyCode, down: Bool) async {
-        let source = CGEventSource(stateID: .hidSystemState)
-        let event = CGEvent(keyboardEventSource: source, virtualKey: key, keyDown: down)
+    private static func normalKeyEvent(_ key: Key, keycode: CGKeyCode, down: Bool) async {
+        let event = InputEvent.keyboardEvent(for: key, keycode: keycode, down: down)
         event?.post(tap: .cghidEventTap)
-        try? await Task.sleep(nanoseconds: 10_000_000) // 10ms
+        let delay: UInt64 = InputEvent.modifierFlag(for: key) == nil ? 10_000_000 : 100_000_000
+        try? await Task.sleep(nanoseconds: delay)
+        // Keep the event and its source alive until WindowServer commits modifier state.
+        _ = event?.type
     }
 
     /// Simulates a special key event (press or release) for media and function keys with async delay.
@@ -384,7 +420,7 @@ public class SwiftAutoGUI {
     public static func moveMouse(dx: CGFloat, dy: CGFloat) async {
         let mouseLoc = position()
         let newLoc = CGPoint(x: mouseLoc.x + dx, y: mouseLoc.y + dy)
-        CGDisplayMoveCursorToPoint(0, newLoc)
+        InputEvent.postMouseMoved(at: newLoc)
         try? await Task.sleep(for: .milliseconds(10))
     }
 
@@ -420,21 +456,27 @@ public class SwiftAutoGUI {
     /// }), fps: 24)
     /// ```
     public static func move(to: CGPoint, duration: TimeInterval, tweening: TweeningFunction = .linear, fps: Double = 60.0) async {
+        guard duration > 0, fps > 0 else {
+            InputEvent.postMouseMoved(at: to)
+            try? await Task.sleep(for: .milliseconds(10))
+            return
+        }
+
         let startPosition = position()
         let deltaX = to.x - startPosition.x
         let deltaY = to.y - startPosition.y
         
         let frameInterval = 1.0 / fps
-        let totalFrames = Int(duration * fps)
+        let totalFrames = max(1, Int(duration * fps))
         
-        for frame in 0...totalFrames {
+        for frame in 1...totalFrames {
             let progress = Double(frame) / Double(totalFrames)
             let easedProgress = tweening.apply(progress)
             
             let currentX = startPosition.x + deltaX * easedProgress
             let currentY = startPosition.y + deltaY * easedProgress
             
-            CGDisplayMoveCursorToPoint(0, CGPoint(x: currentX, y: currentY))
+            InputEvent.postMouseMoved(at: CGPoint(x: currentX, y: currentY))
             
             if frame < totalFrames {
                 try? await Task.sleep(nanoseconds: UInt64(frameInterval * 1_000_000_000))
@@ -465,10 +507,7 @@ public class SwiftAutoGUI {
     /// SwiftAutoGUI.leftClick()
     /// ```
     public static func leftClick() {
-        var mouseLoc = NSEvent.mouseLocation
-        mouseLoc = CGPoint(x: mouseLoc.x, y: NSHeight(NSScreen.screens[0].frame) - mouseLoc.y)
-        leftClickDown(position: mouseLoc)
-        leftClickUp(position: mouseLoc)
+        click(at: position())
     }
 
     /// Performs a right mouse button click at the current cursor position.
@@ -492,10 +531,21 @@ public class SwiftAutoGUI {
     /// Thread.sleep(forTimeInterval: 0.5)
     /// ```
     public static func rightClick() {
-        var mouseLoc = NSEvent.mouseLocation
-        mouseLoc = CGPoint(x: mouseLoc.x, y: NSHeight(NSScreen.screens[0].frame) - mouseLoc.y)
-        rightClickDown(position: mouseLoc)
-        rightClickUp(position: mouseLoc)
+        click(at: position(), button: .right)
+    }
+
+    /// Performs a mouse click at a given position.
+    ///
+    /// - Parameters:
+    ///   - position: The position to click in CGWindow coordinates (origin at top-left).
+    ///   - button: The mouse button to click (default: `.left`).
+    public static func click(at position: CGPoint, button: MouseButton = .left) {
+        let source = CGEventSource(stateID: .hidSystemState)
+        InputEvent.postMouseMoved(at: position, source: source)
+        clickDown(position: position, button: button, clickCount: 1, source: source)
+        Thread.sleep(forTimeInterval: Double(InputEvent.clickDelayNanoseconds) / 1_000_000_000)
+        clickUp(position: position, button: button, clickCount: 1, source: source)
+        withExtendedLifetime(source) {}
     }
 
     /// Performs a drag operation by holding the left mouse button from one position to another.
@@ -526,12 +576,18 @@ public class SwiftAutoGUI {
     /// SwiftAutoGUI.leftDragged(to: CGPoint(x: 200, y: 300), from: CGPoint(x: 100, y: 100))
     /// ```
     public static func leftDragged(to: CGPoint, from: CGPoint) {
-        leftClickDown(position: from)
-        let source = CGEventSource(stateID: CGEventSourceStateID.hidSystemState)
-        let event = CGEvent(mouseEventSource: source, mouseType: CGEventType.leftMouseDragged,
-                            mouseCursorPosition: to, mouseButton: CGMouseButton.left)
+        let source = CGEventSource(stateID: .hidSystemState)
+        InputEvent.postMouseMoved(at: from, source: source)
+        clickDown(position: from, button: .left, clickCount: 1, source: source)
+        let event = InputEvent.mouseEvent(
+            type: .leftMouseDragged,
+            position: to,
+            button: .left,
+            source: source
+        )
         event?.post(tap: CGEventTapLocation.cghidEventTap)
-        leftClickUp(position: to)
+        clickUp(position: to, button: .left, clickCount: 1, source: source)
+        withExtendedLifetime(source) {}
     }
 
     /// Scrolls the mouse wheel vertically by the specified number of clicks.
@@ -562,27 +618,7 @@ public class SwiftAutoGUI {
     /// }
     /// ```
     public static func vscroll(clicks: Int) {
-        for _ in 0...Int(abs(clicks) / 10) {
-            let scrollEvent = CGEvent(
-                scrollWheelEvent2Source: nil,
-                units: .line,
-                wheelCount: 1,
-                wheel1: clicks >= 0 ? 10 : -10,
-                wheel2: 0,
-                wheel3: 0
-            )
-            scrollEvent?.post(tap: .cghidEventTap)
-        }
-
-        let scrollEvent = CGEvent(
-            scrollWheelEvent2Source: nil,
-            units: .line,
-            wheelCount: 1,
-            wheel1: Int32(clicks >= 0 ? clicks % 10 : -1 * (-clicks % 10)),
-            wheel2: 0,
-            wheel3: 0
-        )
-        scrollEvent?.post(tap: .cghidEventTap)
+        postScroll(clicks: clicks, vertical: true)
     }
     
     /// Scrolls the mouse wheel vertically with animated movement over a specified duration.
@@ -617,8 +653,13 @@ public class SwiftAutoGUI {
     /// }))
     /// ```
     public static func vscroll(clicks: Int, duration: TimeInterval, tweening: TweeningFunction = .linear, fps: Double = 60.0) async {
+        guard duration > 0, fps > 0 else {
+            vscroll(clicks: clicks)
+            return
+        }
+
         let frameInterval = 1.0 / fps
-        let totalFrames = Int(duration * fps)
+        let totalFrames = max(1, Int(duration * fps))
         let totalClicks = Double(clicks)
         var accumulatedClicks = 0.0
         
@@ -671,27 +712,7 @@ public class SwiftAutoGUI {
     /// SwiftAutoGUI.leftClick()
     /// ```
     public static func hscroll(clicks: Int) {
-        for _ in 0...Int(abs(clicks) / 10) {
-            let scrollEvent = CGEvent(
-                scrollWheelEvent2Source: nil,
-                units: .line,
-                wheelCount: 2,
-                wheel1: 0,
-                wheel2: clicks >= 0 ? 10 : -10,
-                wheel3: 0
-            )
-            scrollEvent?.post(tap: .cghidEventTap)
-        }
-
-        let scrollEvent = CGEvent(
-            scrollWheelEvent2Source: nil,
-            units: .line,
-            wheelCount: 2,
-            wheel1: 0,
-            wheel2: Int32(clicks >= 0 ? clicks % 10 : -1 * (-clicks % 10)),
-            wheel3: 0
-        )
-        scrollEvent?.post(tap: .cghidEventTap)
+        postScroll(clicks: clicks, vertical: false)
     }
     
     /// Scrolls the mouse wheel horizontally with animated movement over a specified duration.
@@ -726,8 +747,13 @@ public class SwiftAutoGUI {
     /// }))
     /// ```
     public static func hscroll(clicks: Int, duration: TimeInterval, tweening: TweeningFunction = .linear, fps: Double = 60.0) async {
+        guard duration > 0, fps > 0 else {
+            hscroll(clicks: clicks)
+            return
+        }
+
         let frameInterval = 1.0 / fps
-        let totalFrames = Int(duration * fps)
+        let totalFrames = max(1, Int(duration * fps))
         let totalClicks = Double(clicks)
         var accumulatedClicks = 0.0
         
@@ -774,9 +800,7 @@ public class SwiftAutoGUI {
     /// await SwiftAutoGUI.doubleClick(button: .right)
     /// ```
     public static func doubleClick(button: MouseButton = .left) async {
-        var mouseLoc = NSEvent.mouseLocation
-        mouseLoc.y = NSHeight(NSScreen.screens[0].frame) - mouseLoc.y
-        await doubleClick(at: mouseLoc, button: button)
+        await doubleClick(at: position(), button: button)
     }
     
     /// Performs a double-click with the specified mouse button at a given position with async delay.
@@ -806,33 +830,7 @@ public class SwiftAutoGUI {
     /// await SwiftAutoGUI.doubleClick()
     /// ```
     public static func doubleClick(at position: CGPoint, button: MouseButton = .left) async {
-        let source = CGEventSource(stateID: .hidSystemState)
-        
-        // Create mouse down and up events with click count set to 2
-        let mouseDownType: CGEventType = button == .left ? .leftMouseDown : .rightMouseDown
-        let mouseUpType: CGEventType = button == .left ? .leftMouseUp : .rightMouseUp
-        
-        // First click
-        let firstDown = CGEvent(mouseEventSource: source, mouseType: mouseDownType,
-                               mouseCursorPosition: position, mouseButton: button.cgMouseButton)
-        firstDown?.post(tap: .cghidEventTap)
-        
-        let firstUp = CGEvent(mouseEventSource: source, mouseType: mouseUpType,
-                             mouseCursorPosition: position, mouseButton: button.cgMouseButton)
-        firstUp?.post(tap: .cghidEventTap)
-        
-        // Second click with click count = 2
-        let secondDown = CGEvent(mouseEventSource: source, mouseType: mouseDownType,
-                                mouseCursorPosition: position, mouseButton: button.cgMouseButton)
-        secondDown?.setIntegerValueField(.mouseEventClickState, value: 2)
-        secondDown?.post(tap: .cghidEventTap)
-        
-        let secondUp = CGEvent(mouseEventSource: source, mouseType: mouseUpType,
-                              mouseCursorPosition: position, mouseButton: button.cgMouseButton)
-        secondUp?.setIntegerValueField(.mouseEventClickState, value: 2)
-        secondUp?.post(tap: .cghidEventTap)
-        
-        try? await Task.sleep(nanoseconds: 10_000_000) // 10ms
+        await click(at: position, button: button, count: 2)
     }
     
     /// Performs a triple-click with the specified mouse button at the current cursor position with async delay.
@@ -854,9 +852,7 @@ public class SwiftAutoGUI {
     /// await SwiftAutoGUI.tripleClick(button: .right)
     /// ```
     public static func tripleClick(button: MouseButton = .left) async {
-        var mouseLoc = NSEvent.mouseLocation
-        mouseLoc.y = NSHeight(NSScreen.screens[0].frame) - mouseLoc.y
-        await tripleClick(at: mouseLoc, button: button)
+        await tripleClick(at: position(), button: button)
     }
     
     /// Performs a triple-click with the specified mouse button at a given position with async delay.
@@ -884,72 +880,81 @@ public class SwiftAutoGUI {
     /// await SwiftAutoGUI.tripleClick(at: CGPoint(x: 100, y: 200), button: .right)
     /// ```
     public static func tripleClick(at position: CGPoint, button: MouseButton = .left) async {
+        await click(at: position, button: button, count: 3)
+    }
+
+    private static func click(at position: CGPoint, button: MouseButton, count: Int) async {
         let source = CGEventSource(stateID: .hidSystemState)
-        
-        // Create mouse down and up events
-        let mouseDownType: CGEventType = button == .left ? .leftMouseDown : .rightMouseDown
-        let mouseUpType: CGEventType = button == .left ? .leftMouseUp : .rightMouseUp
-        
-        // First click
-        let firstDown = CGEvent(mouseEventSource: source, mouseType: mouseDownType,
-                               mouseCursorPosition: position, mouseButton: button.cgMouseButton)
-        firstDown?.post(tap: .cghidEventTap)
-        
-        let firstUp = CGEvent(mouseEventSource: source, mouseType: mouseUpType,
-                             mouseCursorPosition: position, mouseButton: button.cgMouseButton)
-        firstUp?.post(tap: .cghidEventTap)
-        
-        // Second click with click count = 2
-        let secondDown = CGEvent(mouseEventSource: source, mouseType: mouseDownType,
-                                mouseCursorPosition: position, mouseButton: button.cgMouseButton)
-        secondDown?.setIntegerValueField(.mouseEventClickState, value: 2)
-        secondDown?.post(tap: .cghidEventTap)
-        
-        let secondUp = CGEvent(mouseEventSource: source, mouseType: mouseUpType,
-                              mouseCursorPosition: position, mouseButton: button.cgMouseButton)
-        secondUp?.setIntegerValueField(.mouseEventClickState, value: 2)
-        secondUp?.post(tap: .cghidEventTap)
-        
-        // Third click with click count = 3
-        let thirdDown = CGEvent(mouseEventSource: source, mouseType: mouseDownType,
-                               mouseCursorPosition: position, mouseButton: button.cgMouseButton)
-        thirdDown?.setIntegerValueField(.mouseEventClickState, value: 3)
-        thirdDown?.post(tap: .cghidEventTap)
-        
-        let thirdUp = CGEvent(mouseEventSource: source, mouseType: mouseUpType,
-                             mouseCursorPosition: position, mouseButton: button.cgMouseButton)
-        thirdUp?.setIntegerValueField(.mouseEventClickState, value: 3)
-        thirdUp?.post(tap: .cghidEventTap)
-        
-        try? await Task.sleep(nanoseconds: 10_000_000) // 10ms
+        InputEvent.postMouseMoved(at: position, source: source)
+        for clickCount in 1...count {
+            clickDown(
+                position: position,
+                button: button,
+                clickCount: Int64(clickCount),
+                source: source
+            )
+            try? await Task.sleep(nanoseconds: InputEvent.clickDelayNanoseconds)
+            clickUp(
+                position: position,
+                button: button,
+                clickCount: Int64(clickCount),
+                source: source
+            )
+            if clickCount < count {
+                try? await Task.sleep(nanoseconds: InputEvent.clickDelayNanoseconds)
+            }
+        }
+        _ = source?.sourceStateID
     }
 
-    private static func leftClickDown(position: CGPoint) {
-        let source = CGEventSource(stateID: CGEventSourceStateID.hidSystemState)
-        let event = CGEvent(mouseEventSource: source, mouseType: CGEventType.leftMouseDown,
-                            mouseCursorPosition: position, mouseButton: CGMouseButton.left)
-        event?.post(tap: CGEventTapLocation.cghidEventTap)
+    private static func clickDown(
+        position: CGPoint,
+        button: MouseButton,
+        clickCount: Int64,
+        source: CGEventSource?
+    ) {
+        let type: CGEventType = button == .left ? .leftMouseDown : .rightMouseDown
+        InputEvent.mouseEvent(
+            type: type,
+            position: position,
+            button: button.cgMouseButton,
+            clickCount: clickCount,
+            source: source
+        )?.post(tap: .cghidEventTap)
     }
 
-    private static func leftClickUp(position: CGPoint) {
-        let source = CGEventSource(stateID: CGEventSourceStateID.hidSystemState)
-        let event = CGEvent(mouseEventSource: source, mouseType: CGEventType.leftMouseUp,
-                            mouseCursorPosition: position, mouseButton: CGMouseButton.left)
-        event?.post(tap: CGEventTapLocation.cghidEventTap)
+    private static func clickUp(
+        position: CGPoint,
+        button: MouseButton,
+        clickCount: Int64,
+        source: CGEventSource?
+    ) {
+        let type: CGEventType = button == .left ? .leftMouseUp : .rightMouseUp
+        InputEvent.mouseEvent(
+            type: type,
+            position: position,
+            button: button.cgMouseButton,
+            clickCount: clickCount,
+            source: source
+        )?.post(tap: .cghidEventTap)
     }
 
-    private static func rightClickDown(position: CGPoint) {
-        let source = CGEventSource(stateID: CGEventSourceStateID.hidSystemState)
-        let event = CGEvent(mouseEventSource: source, mouseType: CGEventType.rightMouseDown,
-                            mouseCursorPosition: position, mouseButton: CGMouseButton.right)
-        event?.post(tap: CGEventTapLocation.cghidEventTap)
-    }
+    private static func postScroll(clicks: Int, vertical: Bool) {
+        let deltas = InputEvent.scrollDeltas(clicks: clicks)
+        guard !deltas.isEmpty else { return }
 
-    private static func rightClickUp(position: CGPoint) {
-        let source = CGEventSource(stateID: CGEventSourceStateID.hidSystemState)
-        let event = CGEvent(mouseEventSource: source, mouseType: CGEventType.rightMouseUp,
-                            mouseCursorPosition: position, mouseButton: CGMouseButton.right)
-        event?.post(tap: CGEventTapLocation.cghidEventTap)
+        let source = CGEventSource(stateID: .hidSystemState)
+        let mousePosition = position()
+        InputEvent.postMouseMoved(at: mousePosition, source: source)
+        for delta in deltas {
+            InputEvent.scrollEvent(
+                vertical: vertical ? delta : 0,
+                horizontal: vertical ? 0 : delta,
+                at: mousePosition,
+                source: source
+            )?.post(tap: .cghidEventTap)
+        }
+        withExtendedLifetime(source) {}
     }
 
     // MARK: - Accessibility (AX)

--- a/Sources/SwiftAutoGUI/Core/SwiftAutoGUI.swift
+++ b/Sources/SwiftAutoGUI/Core/SwiftAutoGUI.swift
@@ -465,6 +465,7 @@ public class SwiftAutoGUI {
         let startPosition = position()
         let deltaX = to.x - startPosition.x
         let deltaY = to.y - startPosition.y
+        let source = CGEventSource(stateID: .hidSystemState)
         
         let frameInterval = 1.0 / fps
         let totalFrames = max(1, Int(duration * fps))
@@ -476,12 +477,20 @@ public class SwiftAutoGUI {
             let currentX = startPosition.x + deltaX * easedProgress
             let currentY = startPosition.y + deltaY * easedProgress
             
-            InputEvent.postMouseMoved(at: CGPoint(x: currentX, y: currentY))
+            InputEvent.postMouseMoved(
+                at: CGPoint(x: currentX, y: currentY),
+                source: source
+            )
             
             if frame < totalFrames {
                 try? await Task.sleep(nanoseconds: UInt64(frameInterval * 1_000_000_000))
             }
         }
+
+        // CGEvent posting is asynchronous. Give WindowServer a chance to apply the
+        // final event before callers observe the cursor position.
+        try? await Task.sleep(for: .milliseconds(10))
+        withExtendedLifetime(source) {}
     }
 
     /// Performs a left mouse button click at the current cursor position.

--- a/Sources/SwiftAutoGUI/Documentation.docc/SwiftAutoGUI.md
+++ b/Sources/SwiftAutoGUI/Documentation.docc/SwiftAutoGUI.md
@@ -298,6 +298,7 @@ import SwiftAutoGUI
 Task {
     await SwiftAutoGUI.move(to: CGPoint(x: 100, y: 200), duration: 0)
     SwiftAutoGUI.leftClick()
+    SwiftAutoGUI.click(at: CGPoint(x: 300, y: 200), button: .right)
     SwiftAutoGUI.vscroll(clicks: 10)
 }
 

--- a/Sources/SwiftAutoGUI/Input/Keycode.swift
+++ b/Sources/SwiftAutoGUI/Input/Keycode.swift
@@ -12,7 +12,7 @@ import CoreGraphics
 /// SwiftAutoGUI.keyDown(.soundUp)
 /// SwiftAutoGUI.keyUp(.soundUp)
 /// ```
-public enum Key: String, Sendable {
+public enum Key: String, Sendable, CaseIterable {
 
     // normal keycode
     case returnKey

--- a/Sources/sagui/KeyCommand.swift
+++ b/Sources/sagui/KeyCommand.swift
@@ -27,12 +27,32 @@ import SwiftAutoGUI
 /// - ``Down``
 /// - ``Up``
 /// - ``TypeText``
+/// - ``ListKeys``
 struct KeyCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "key",
         abstract: "Keyboard control commands.",
-        subcommands: [Shortcut.self, Down.self, Up.self, TypeText.self]
+        subcommands: [Shortcut.self, Down.self, Up.self, TypeText.self, ListKeys.self]
     )
+}
+
+enum KeyNameResolver {
+    static let aliases: [String: Key] = [
+        "backspace": .delete,
+        "return": .returnKey,
+    ]
+
+    static var names: [String] {
+        Set(Key.allCases.map(\.rawValue) + aliases.keys).sorted()
+    }
+
+    static func resolve(_ name: String) -> Key? {
+        aliases[name] ?? Key(rawValue: name)
+    }
+
+    static func validationError(for name: String) -> ValidationError {
+        ValidationError("Unknown key: '\(name)'. Run 'sagui key list' to see valid key names.")
+    }
 }
 
 extension KeyCommand {
@@ -57,8 +77,8 @@ extension KeyCommand {
 
         func run() async throws {
             let mapped = try keys.map { name -> Key in
-                guard let key = Key(rawValue: name) else {
-                    throw ValidationError("Unknown key: '\(name)'. Examples: a, command, shift, leftArrow, space, f1")
+                guard let key = KeyNameResolver.resolve(name) else {
+                    throw KeyNameResolver.validationError(for: name)
                 }
                 return key
             }
@@ -83,8 +103,8 @@ extension KeyCommand {
         var key: String
 
         func run() async throws {
-            guard let k = Key(rawValue: key) else {
-                throw ValidationError("Unknown key: '\(key)'. Examples: a, command, shift, leftArrow, space, f1")
+            guard let k = KeyNameResolver.resolve(key) else {
+                throw KeyNameResolver.validationError(for: key)
             }
             await SwiftAutoGUI.keyDown(k)
         }
@@ -106,8 +126,8 @@ extension KeyCommand {
         var key: String
 
         func run() async throws {
-            guard let k = Key(rawValue: key) else {
-                throw ValidationError("Unknown key: '\(key)'. Examples: a, command, shift, leftArrow, space, f1")
+            guard let k = KeyNameResolver.resolve(key) else {
+                throw KeyNameResolver.validationError(for: key)
             }
             await SwiftAutoGUI.keyUp(k)
         }
@@ -137,6 +157,20 @@ extension KeyCommand {
         @MainActor
         func run() async throws {
             await SwiftAutoGUI.write(text, interval: interval)
+        }
+    }
+
+    /// List every accepted key name, including aliases.
+    struct ListKeys: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "list",
+            abstract: "List all valid key names."
+        )
+
+        func run() async throws {
+            for name in KeyNameResolver.names {
+                print(name)
+            }
         }
     }
 }

--- a/Sources/sagui/MouseCommand.swift
+++ b/Sources/sagui/MouseCommand.swift
@@ -109,7 +109,7 @@ extension MouseCommand {
         }
     }
 
-    /// Click the mouse at the current cursor position.
+    /// Click the mouse at the current cursor position or at explicit coordinates.
     ///
     /// Supports left click (default), right click, double-click, and triple-click.
     ///
@@ -118,10 +118,11 @@ extension MouseCommand {
     /// sagui mouse click --right      # Right click
     /// sagui mouse click --double     # Double click
     /// sagui mouse click --triple     # Triple click
+    /// sagui mouse click --x 100 --y 200
     /// ```
     struct Click: AsyncParsableCommand {
         static let configuration = CommandConfiguration(
-            abstract: "Click the mouse at the current position."
+            abstract: "Click the mouse at the current position or explicit coordinates."
         )
 
         @Flag(help: "Use right mouse button.")
@@ -133,13 +134,36 @@ extension MouseCommand {
         @Flag(name: .long, help: "Perform a triple-click.")
         var triple = false
 
+        @Option(help: "X coordinate. Must be used with --y.")
+        var x: Double?
+
+        @Option(help: "Y coordinate. Must be used with --x.")
+        var y: Double?
+
+        func validate() throws {
+            if (x == nil) != (y == nil) {
+                throw ValidationError("Specify both --x and --y, or omit both.")
+            }
+        }
+
         func run() async throws {
             let button: SwiftAutoGUI.MouseButton = right ? .right : .left
+            let target = x.flatMap { x in y.map { CGPoint(x: x, y: $0) } }
 
             if triple {
-                await SwiftAutoGUI.tripleClick(button: button)
+                if let target {
+                    await SwiftAutoGUI.tripleClick(at: target, button: button)
+                } else {
+                    await SwiftAutoGUI.tripleClick(button: button)
+                }
             } else if double {
-                await SwiftAutoGUI.doubleClick(button: button)
+                if let target {
+                    await SwiftAutoGUI.doubleClick(at: target, button: button)
+                } else {
+                    await SwiftAutoGUI.doubleClick(button: button)
+                }
+            } else if let target {
+                SwiftAutoGUI.click(at: target, button: button)
             } else {
                 if right {
                     SwiftAutoGUI.rightClick()

--- a/Sources/sagui/SaguiCLI.swift
+++ b/Sources/sagui/SaguiCLI.swift
@@ -34,6 +34,7 @@ struct SaguiCLI: AsyncParsableCommand {
         commandName: "sagui",
         abstract: "Control mouse and keyboard on macOS from the command line.",
         discussion: "Requires accessibility permissions in System Settings > Privacy & Security > Accessibility.",
+        version: SaguiVersion.current,
         subcommands: [KeyCommand.self, MouseCommand.self, ScreenCommand.self, AXCommand.self, AgentCommand.self]
     )
 }

--- a/Sources/sagui/SaguiVersion.swift
+++ b/Sources/sagui/SaguiVersion.swift
@@ -1,0 +1,3 @@
+enum SaguiVersion {
+    static let current = "0.25.0"
+}

--- a/Tests/SaguiTests/SaguiCommandTests.swift
+++ b/Tests/SaguiTests/SaguiCommandTests.swift
@@ -1,0 +1,49 @@
+import Testing
+@testable import sagui
+
+@Suite("sagui Command Tests")
+struct SaguiCommandTests {
+    @Test("Key aliases resolve to Mac keyboard keys")
+    func keyAliases() {
+        #expect(KeyNameResolver.resolve("return") == .returnKey)
+        #expect(KeyNameResolver.resolve("backspace") == .delete)
+        #expect(KeyNameResolver.resolve("enter") == .enter)
+        #expect(KeyNameResolver.resolve("delete") == .delete)
+    }
+
+    @Test("Key list includes cases and aliases in sorted order")
+    func keyList() {
+        #expect(KeyNameResolver.names == KeyNameResolver.names.sorted())
+        #expect(KeyNameResolver.names.contains("return"))
+        #expect(KeyNameResolver.names.contains("backspace"))
+        #expect(KeyNameResolver.names.contains("returnKey"))
+        #expect(KeyNameResolver.names.contains("rightArrow"))
+    }
+
+    @Test("Mouse click accepts a complete coordinate pair")
+    func clickCoordinates() throws {
+        let click = try MouseCommand.Click.parse([
+            "--x", "100", "--y", "200", "--right", "--double",
+        ])
+        #expect(click.x == 100)
+        #expect(click.y == 200)
+        #expect(click.right)
+        #expect(click.double)
+    }
+
+    @Test("Mouse click rejects partial coordinates")
+    func partialClickCoordinates() {
+        #expect(throws: (any Error).self) {
+            try MouseCommand.Click.parse(["--x", "100"])
+        }
+        #expect(throws: (any Error).self) {
+            try MouseCommand.Click.parse(["--y", "200"])
+        }
+    }
+
+    @Test("Root command exposes the current version")
+    func version() {
+        #expect(SaguiCLI.configuration.version == SaguiVersion.current)
+        #expect(SaguiVersion.current == "0.25.0")
+    }
+}

--- a/Tests/SwiftAutoGUITests/InputEventTests.swift
+++ b/Tests/SwiftAutoGUITests/InputEventTests.swift
@@ -1,0 +1,139 @@
+import CoreGraphics
+import Testing
+@testable import SwiftAutoGUI
+
+@Suite("Input Event Tests")
+struct InputEventTests {
+    @Test("Modifier events use flagsChanged and accumulate flags")
+    func modifierEvents() throws {
+        let existing: CGEventFlags = [.maskCommand]
+        let shiftKeycode = try #require(Key.shift.normalKeycode)
+        let down = try #require(InputEvent.keyboardEvent(
+            for: .shift,
+            keycode: shiftKeycode,
+            down: true,
+            currentFlags: existing
+        ))
+        #expect(down.type == .flagsChanged)
+        #expect(down.flags.contains(.maskCommand))
+        #expect(down.flags.contains(.maskShift))
+
+        let up = try #require(InputEvent.keyboardEvent(
+            for: .shift,
+            keycode: shiftKeycode,
+            down: false,
+            currentFlags: down.flags
+        ))
+        #expect(up.type == .flagsChanged)
+        #expect(up.flags.contains(.maskCommand))
+        #expect(!up.flags.contains(.maskShift))
+    }
+
+    @Test("Ordinary key events retain current modifiers")
+    func ordinaryKeyEvent() throws {
+        let keycode = try #require(Key.a.normalKeycode)
+        let event = try #require(InputEvent.keyboardEvent(
+            for: .a,
+            keycode: keycode,
+            down: true,
+            currentFlags: [.maskShift]
+        ))
+        #expect(event.type == .keyDown)
+        #expect(event.flags.contains(.maskShift))
+    }
+
+    @Test("Arrow shortcut events preserve automatic keypad flags")
+    func arrowShortcutEvent() throws {
+        let keycode = try #require(Key.leftArrow.normalKeycode)
+        let event = try #require(InputEvent.keyboardEvent(
+            for: .leftArrow,
+            keycode: keycode,
+            down: true,
+            currentFlags: [.maskControl]
+        ))
+        #expect(event.type == .keyDown)
+        #expect(event.flags.contains(.maskControl))
+        #expect(event.flags.contains(.maskNumericPad))
+    }
+
+    @Test("Releasing one side keeps a paired modifier active")
+    func pairedModifierRelease() throws {
+        let leftShiftDeviceFlag = try #require(InputEvent.modifierDeviceFlag(for: .shift))
+        let rightShiftDeviceFlag = try #require(InputEvent.modifierDeviceFlag(for: .rightShift))
+        let current: CGEventFlags = [.maskShift, leftShiftDeviceFlag, rightShiftDeviceFlag]
+        let adjusted = InputEvent.adjustedFlags(
+            for: .shift,
+            down: false,
+            currentFlags: current
+        )
+        #expect(adjusted.contains(.maskShift))
+        #expect(!adjusted.contains(leftShiftDeviceFlag))
+        #expect(adjusted.contains(rightShiftDeviceFlag))
+    }
+
+    @Test("Shortcut modifiers preserve device flags on a shared source")
+    func shortcutModifierEvents() throws {
+        let source = try #require(CGEventSource(stateID: .hidSystemState))
+        let keycode = try #require(Key.control.normalKeycode)
+        let down = try #require(InputEvent.keyboardEvent(
+            for: .control,
+            keycode: keycode,
+            down: true,
+            currentFlags: [],
+            source: source
+        ))
+        #expect(down.type == .flagsChanged)
+        #expect(down.flags.contains(.maskControl))
+        #expect(down.flags.contains(CGEventFlags(rawValue: 0x0000_0001)))
+
+        let up = try #require(InputEvent.keyboardEvent(
+            for: .control,
+            keycode: keycode,
+            down: false,
+            currentFlags: down.flags,
+            source: source
+        ))
+        #expect(up.type == .flagsChanged)
+        #expect(!up.flags.contains(.maskControl))
+        #expect(!up.flags.contains(CGEventFlags(rawValue: 0x0000_0001)))
+    }
+
+    @Test("Mouse events include location, flags, and click count")
+    func mouseEvent() throws {
+        let point = CGPoint(x: 123, y: 456)
+        let event = try #require(InputEvent.mouseEvent(
+            type: .rightMouseDown,
+            position: point,
+            button: .right,
+            clickCount: 2,
+            flags: [.maskCommand]
+        ))
+        #expect(event.type == .rightMouseDown)
+        #expect(event.location == point)
+        #expect(event.flags.contains(.maskCommand))
+        #expect(event.getIntegerValueField(.mouseEventClickState) == 2)
+    }
+
+    @Test("Scroll events include location, flags, and axes")
+    func scrollEvent() throws {
+        let point = CGPoint(x: 50, y: 75)
+        let event = try #require(InputEvent.scrollEvent(
+            vertical: -4,
+            horizontal: 3,
+            at: point,
+            flags: [.maskAlternate]
+        ))
+        #expect(event.location == point)
+        #expect(event.flags.contains(.maskAlternate))
+        #expect(event.getIntegerValueField(.scrollWheelEventDeltaAxis1) == -4)
+        #expect(event.getIntegerValueField(.scrollWheelEventDeltaAxis2) == 3)
+    }
+
+    @Test("Scroll deltas preserve the requested total", arguments: [0, 1, -1, 9, -9, 10, -10, 11, -11, 25, -25])
+    func scrollDeltas(clicks: Int) {
+        let deltas = InputEvent.scrollDeltas(clicks: clicks)
+        #expect(deltas.reduce(0) { $0 + Int($1) } == clicks)
+        #expect(deltas.allSatisfy { abs($0) <= 10 && $0 != 0 })
+        #expect(clicks != 0 || deltas.isEmpty)
+    }
+}

--- a/plugins/swift-auto-gui/skills/macos-control/SKILL.md
+++ b/plugins/swift-auto-gui/skills/macos-control/SKILL.md
@@ -75,6 +75,9 @@ sagui key down shift                     # Press key without releasing
 sagui key up shift                       # Release a held key
 sagui key type "Hello, World!"           # Type text character by character
 sagui key type "slow" --interval 0.1     # Type with delay between keystrokes
+sagui key shortcut return                # Return key (alias for returnKey)
+sagui key shortcut backspace             # Backspace (alias for delete)
+sagui key list                           # List every valid key name
 ```
 
 | Subcommand | Arguments | Optional |
@@ -83,6 +86,7 @@ sagui key type "slow" --interval 0.1     # Type with delay between keystrokes
 | `down` | `<key>` | |
 | `up` | `<key>` | |
 | `type` | `<text>` | `--interval <seconds>` (default: 0) |
+| `list` | | |
 
 #### Supported key names
 
@@ -98,7 +102,7 @@ sagui key type "slow" --interval 0.1     # Type with delay between keystrokes
 
 **Navigation**: `home`, `end`, `pageUp`, `pageDown`, `help`
 
-**Special**: `returnKey`, `enter`, `tab`, `space`, `escape`, `delete`, `forwardDelete`
+**Special**: `return`, `returnKey`, `enter`, `tab`, `space`, `escape`, `backspace`, `delete`, `forwardDelete`
 
 **Keypad**: `keypad0`-`keypad9`, `keypadDecimal`, `keypadMultiply`, `keypadPlus`, `keypadMinus`, `keypadDivide`, `keypadEnter`, `keypadClear`, `keypadEquals`
 
@@ -118,6 +122,8 @@ sagui mouse click                                                     # Left cli
 sagui mouse click --right                                             # Right click
 sagui mouse click --double                                            # Double-click
 sagui mouse click --triple                                            # Triple-click
+sagui mouse click --x 500 --y 300                                    # Click an exact position
+sagui mouse click --right --x 500 --y 300                            # Right-click an exact position
 sagui mouse drag --from-x 100 --from-y 100 --to-x 400 --to-y 400    # Drag
 sagui mouse scroll --vertical 5                                       # Scroll up
 sagui mouse scroll --vertical -3                                      # Scroll down
@@ -129,7 +135,7 @@ sagui mouse scroll --horizontal 2                                     # Scroll l
 | `position` | | |
 | `move` | `--x`, `--y` | |
 | `move-relative` | `--dx`, `--dy` | |
-| `click` | | `--right`, `--double`, `--triple` |
+| `click` | | `--x <point>` and `--y <point>`, `--right`, `--double`, `--triple` |
 | `drag` | `--from-x`, `--from-y`, `--to-x`, `--to-y` | |
 | `scroll` | | `--vertical <clicks>`, `--horizontal <clicks>` |
 
@@ -175,19 +181,19 @@ sagui agent "Fill in the form" --model gpt-5.4 --max-iterations 10
 1. `sagui screen size` — get screen dimensions.
 2. `sagui screen screenshot --output /tmp/screen.png` — capture current state.
 3. Read the screenshot image to identify target coordinates.
-4. `sagui mouse move --x <x> --y <y>` and `sagui mouse click` — interact.
+4. `sagui mouse click --x <x> --y <y>` — interact at the identified position.
 5. `sagui key type "text"` or `sagui key shortcut command a` — keyboard input.
 6. `sagui screen screenshot --output /tmp/verify.png` — verify result.
 
 ### Image-based interaction
 
 1. `sagui screen locate-center target.png` — find element position.
-2. `sagui mouse move --x <x> --y <y>` — move to found coordinates.
-3. `sagui mouse click` — click the element.
+2. `sagui mouse click --x <x> --y <y>` — click the found coordinates atomically.
 
 ## Notes
 
 - All mouse and keyboard commands require Accessibility permissions.
+- Use `sagui --version` when reporting issues or checking a CI environment.
 - Screenshot and image recognition commands require Screen Recording permissions.
 - `key type` supports any Unicode character. Use `key shortcut` with modifier keys for keyboard shortcuts.
 - Scroll: positive vertical = up, negative = down; positive horizontal = left, negative = right.


### PR DESCRIPTION
## Summary

- Preserve modifier state across separate `sagui` processes while retaining device-dependent flags needed by shortcuts such as Control+Left
- Route mouse clicks and scrolls through consistent positioned CGEvents, add coordinate clicks, and fix exact scroll chunking
- Add `return`/`backspace` aliases, `key list`, `--version`, release-version synchronization, documentation, and regression tests

## Validation

- `swift test` — 144 tests passed
- `swift build -c release`
- `swift package generate-documentation`
- Manually verified Shift remains held across separate `sagui` processes and is released by `key up`

Fixes #113