### PR TITLE
Improve mouse event delivery reliability

### DIFF
--- a/Sample/Sample/Common/DemoTab.swift
+++ b/Sample/Sample/Common/DemoTab.swift
@@ -11,6 +11,7 @@ enum DemoTab: String, CaseIterable {
     case keyboard
     case keyboardLayout
     case mouse
+    case inputObserver
     case textTyping
     case screenshot
     case imageRecognition
@@ -28,6 +29,7 @@ enum DemoTab: String, CaseIterable {
         case .keyboard: return "Keyboard"
         case .keyboardLayout: return "KB Layout"
         case .mouse: return "Mouse"
+        case .inputObserver: return "Observer"
         case .textTyping: return "Text Typing"
         case .screenshot: return "Screenshot"
         case .imageRecognition: return "Image Recognition"
@@ -47,6 +49,7 @@ enum DemoTab: String, CaseIterable {
         case .keyboard: return "keyboard"
         case .keyboardLayout: return "globe"
         case .mouse: return "cursorarrow"
+        case .inputObserver: return "waveform.path.ecg"
         case .textTyping: return "text.cursor"
         case .screenshot: return "camera.viewfinder"
         case .imageRecognition: return "eye"

--- a/Sample/Sample/ContentView.swift
+++ b/Sample/Sample/ContentView.swift
@@ -88,6 +88,8 @@ struct ContentView: View {
                             KeyboardLayoutView()
                         case .mouse:
                             MouseControlView()
+                        case .inputObserver:
+                            InputEventObserverView()
                         case .textTyping:
                             TextTypingView()
                         case .screenshot:

--- a/Sample/Sample/Features/InputObserver/InputEventObserverView.swift
+++ b/Sample/Sample/Features/InputObserver/InputEventObserverView.swift
@@ -1,0 +1,209 @@
+import SwiftUI
+
+struct InputEventObserverView: View {
+    @State private var viewModel = InputEventObserverViewModel()
+    @State private var leftClickCount = 0
+    @State private var contextActionCount = 0
+    @State private var text = ""
+    @State private var isPointerOverTarget = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            header
+            commandExamples
+
+            HStack(alignment: .top, spacing: 16) {
+                testControls
+                    .frame(maxWidth: 360)
+                eventLog
+            }
+        }
+        .onAppear { viewModel.startObserving() }
+        .onDisappear { viewModel.stopObserving() }
+    }
+
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Input Event Observer")
+                    .font(.title2.bold())
+                Text("Observe the actual NSEvents delivered to the Sample app.")
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Label(
+                viewModel.isObserving ? "Observing" : "Stopped",
+                systemImage: viewModel.isObserving ? "record.circle.fill" : "stop.circle"
+            )
+            .foregroundStyle(viewModel.isObserving ? .green : .secondary)
+        }
+    }
+
+    private var commandExamples: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Try from another Terminal after moving the pointer over Event Target:")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(clickCommand)
+            Text(rightClickCommand)
+            Text("sagui mouse scroll --vertical=-20")
+            Text("sagui key down shift  # click the target, then: sagui key up shift")
+        }
+        .font(.system(.caption, design: .monospaced))
+        .textSelection(.enabled)
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    private var testControls: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(spacing: 8) {
+                Image(systemName: isPointerOverTarget ? "cursorarrow.click.2" : "cursorarrow.motionlines")
+                    .font(.system(size: 30))
+                Text("Event Target")
+                    .font(.headline)
+                Text("Left-click, right-click, or move the pointer here")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text("left clicks: \(leftClickCount) · context actions: \(contextActionCount)")
+                    .font(.caption.monospacedDigit())
+                Text(pointerDescription)
+                    .font(.caption.monospaced())
+            }
+            .frame(maxWidth: .infinity, minHeight: 120)
+            .contentShape(Rectangle())
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(isPointerOverTarget ? Color.blue.opacity(0.2) : Color.blue.opacity(0.08))
+            )
+            .overlay(RoundedRectangle(cornerRadius: 12).stroke(.blue.opacity(0.6), lineWidth: 2))
+            .onTapGesture { leftClickCount += 1 }
+            .onHover { isPointerOverTarget = $0 }
+            .contextMenu {
+                Button("Record Context Action") {
+                    contextActionCount += 1
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Scroll Target")
+                    .font(.headline)
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 6) {
+                        ForEach(1...20, id: \.self) { row in
+                            Text("Observable row \(row)")
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.vertical, 4)
+                        }
+                    }
+                }
+                .frame(height: 100)
+                .padding(8)
+                .background(.quaternary, in: RoundedRectangle(cornerRadius: 8))
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Keyboard & Modifiers")
+                    .font(.headline)
+                TextField("Focus here, then send keys", text: $text)
+                    .textFieldStyle(.roundedBorder)
+                Text("active modifiers: \(viewModel.currentModifiers)")
+                    .font(.caption.monospaced())
+            }
+        }
+    }
+
+    private var eventLog: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Delivered Events")
+                    .font(.headline)
+                Spacer()
+                Text("down \(downCount) · scroll \(viewModel.eventCounts["scrollWheel", default: 0])")
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                Button("Clear") { viewModel.clear() }
+                    .controlSize(.small)
+            }
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 6) {
+                    if viewModel.events.isEmpty {
+                        VStack(spacing: 8) {
+                            Image(systemName: "waveform.path.ecg")
+                                .font(.title)
+                            Text("No Events Yet")
+                                .font(.headline)
+                            Text("Interact with the controls or use sagui.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .frame(maxWidth: .infinity, minHeight: 160)
+                    } else {
+                        ForEach(viewModel.events) { event in
+                            eventRow(event)
+                        }
+                    }
+                }
+            }
+            .frame(minHeight: 300)
+            .padding(8)
+            .background(Color.black.opacity(0.06), in: RoundedRectangle(cornerRadius: 10))
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func eventRow(_ event: ObservedInputEvent) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text("#\(event.sequence) \(event.name)")
+                    .font(.caption.bold().monospaced())
+                Spacer()
+                if let sourcePID = event.sourcePID {
+                    Text("pid \(sourcePID)")
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            Text(event.details)
+                .font(.caption2.monospaced())
+            Text("modifiers: \(event.modifiers)")
+                .font(.caption2.monospaced())
+                .foregroundStyle(.secondary)
+        }
+        .padding(7)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(eventColor(event.name).opacity(0.12), in: RoundedRectangle(cornerRadius: 7))
+    }
+
+    private var downCount: Int {
+        viewModel.eventCounts["leftMouseDown", default: 0]
+            + viewModel.eventCounts["rightMouseDown", default: 0]
+    }
+
+    private var pointerDescription: String {
+        guard let point = viewModel.latestPointerPosition else { return "global position: waiting…" }
+        return "global position: x=\(Int(point.x)) y=\(Int(point.y))"
+    }
+
+    private var clickCommand: String {
+        guard let point = viewModel.latestPointerPosition else { return "sagui mouse click --x <x> --y <y>" }
+        return "sagui mouse click --x \(Int(point.x)) --y \(Int(point.y))"
+    }
+
+    private var rightClickCommand: String {
+        guard let point = viewModel.latestPointerPosition else { return "sagui mouse click --right --x <x> --y <y>" }
+        return "sagui mouse click --right --x \(Int(point.x)) --y \(Int(point.y))"
+    }
+
+    private func eventColor(_ name: String) -> Color {
+        switch name {
+        case "leftMouseDown", "rightMouseDown": .green
+        case "leftMouseUp", "rightMouseUp": .blue
+        case "scrollWheel": .orange
+        case "flagsChanged", "keyDown", "keyUp": .purple
+        default: .gray
+        }
+    }
+}

--- a/Sample/Sample/Features/InputObserver/InputEventObserverViewModel.swift
+++ b/Sample/Sample/Features/InputObserver/InputEventObserverViewModel.swift
@@ -1,0 +1,146 @@
+import AppKit
+import SwiftUI
+
+struct ObservedInputEvent: Identifiable {
+    let id = UUID()
+    let sequence: Int
+    let timestamp: Date
+    let name: String
+    let details: String
+    let modifiers: String
+    let sourcePID: Int64?
+}
+
+@MainActor
+@Observable
+final class InputEventObserverViewModel {
+    private(set) var events: [ObservedInputEvent] = []
+    private(set) var eventCounts: [String: Int] = [:]
+    private(set) var currentModifiers = "none"
+    private(set) var latestPointerPosition: CGPoint?
+    private(set) var isObserving = false
+
+    private var monitor: Any?
+    private var sequence = 0
+
+    func startObserving() {
+        guard monitor == nil else { return }
+
+        NSApp.windows.forEach { $0.acceptsMouseMovedEvents = true }
+        let mask: NSEvent.EventTypeMask = [
+            .mouseMoved,
+            .leftMouseDown,
+            .leftMouseUp,
+            .rightMouseDown,
+            .rightMouseUp,
+            .scrollWheel,
+            .flagsChanged,
+            .keyDown,
+            .keyUp
+        ]
+
+        monitor = NSEvent.addLocalMonitorForEvents(matching: mask) { [weak self] event in
+            self?.record(event)
+            return event
+        }
+        isObserving = monitor != nil
+    }
+
+    func stopObserving() {
+        if let monitor {
+            NSEvent.removeMonitor(monitor)
+        }
+        monitor = nil
+        isObserving = false
+    }
+
+    func clear() {
+        events.removeAll()
+        eventCounts.removeAll()
+        sequence = 0
+    }
+
+    private func record(_ event: NSEvent) {
+        let name = eventName(event.type)
+        let modifiers = modifierDescription(event.modifierFlags)
+        let point = event.cgEvent?.location
+
+        if event.type == .mouseMoved, let point {
+            latestPointerPosition = point
+        }
+        currentModifiers = modifiers
+        eventCounts[name, default: 0] += 1
+        sequence += 1
+
+        let record = ObservedInputEvent(
+            sequence: sequence,
+            timestamp: Date(),
+            name: name,
+            details: eventDetails(event, point: point),
+            modifiers: modifiers,
+            sourcePID: event.cgEvent?.getIntegerValueField(.eventSourceUnixProcessID)
+        )
+
+        // Human pointer movement can generate hundreds of events. Keep the latest
+        // movement visible without allowing it to bury click and scroll events.
+        if event.type == .mouseMoved,
+           let first = events.first,
+           first.name == "mouseMoved",
+           record.timestamp.timeIntervalSince(first.timestamp) < 0.05 {
+            events[0] = record
+        } else {
+            events.insert(record, at: 0)
+        }
+
+        if events.count > 80 {
+            events.removeLast(events.count - 80)
+        }
+    }
+
+    private func eventName(_ type: NSEvent.EventType) -> String {
+        switch type {
+        case .mouseMoved: "mouseMoved"
+        case .leftMouseDown: "leftMouseDown"
+        case .leftMouseUp: "leftMouseUp"
+        case .rightMouseDown: "rightMouseDown"
+        case .rightMouseUp: "rightMouseUp"
+        case .scrollWheel: "scrollWheel"
+        case .flagsChanged: "flagsChanged"
+        case .keyDown: "keyDown"
+        case .keyUp: "keyUp"
+        default: "type(\(type.rawValue))"
+        }
+    }
+
+    private func eventDetails(_ event: NSEvent, point: CGPoint?) -> String {
+        let location = point.map { "x=\(Int($0.x)) y=\(Int($0.y))" } ?? "location unavailable"
+        switch event.type {
+        case .leftMouseDown, .leftMouseUp, .rightMouseDown, .rightMouseUp:
+            return "\(location) clickCount=\(event.clickCount)"
+        case .mouseMoved:
+            return location
+        case .scrollWheel:
+            return "\(location) dx=\(format(event.scrollingDeltaX)) dy=\(format(event.scrollingDeltaY)) precise=\(event.hasPreciseScrollingDeltas)"
+        case .flagsChanged, .keyDown, .keyUp:
+            return "keyCode=\(event.keyCode) characters=\(event.charactersIgnoringModifiers ?? "-")"
+        default:
+            return location
+        }
+    }
+
+    private func modifierDescription(_ flags: NSEvent.ModifierFlags) -> String {
+        let flags = flags.intersection(.deviceIndependentFlagsMask)
+        var names: [String] = []
+        if flags.contains(.capsLock) { names.append("capsLock") }
+        if flags.contains(.shift) { names.append("shift") }
+        if flags.contains(.control) { names.append("control") }
+        if flags.contains(.option) { names.append("option") }
+        if flags.contains(.command) { names.append("command") }
+        if flags.contains(.function) { names.append("fn") }
+        return names.isEmpty ? "none" : names.joined(separator: "+")
+    }
+
+    private func format(_ value: CGFloat) -> String {
+        String(format: "%.2f", Double(value))
+    }
+}

--- a/Sources/SwiftAutoGUI/Core/InputEvent.swift
+++ b/Sources/SwiftAutoGUI/Core/InputEvent.swift
@@ -1,7 +1,9 @@
 import CoreGraphics
 
 enum InputEvent {
-    static let clickDelayNanoseconds: UInt64 = 60_000_000
+    static let mouseMoveSettleNanoseconds: UInt64 = 120_000_000
+    static let clickDelayNanoseconds: UInt64 = 80_000_000
+    static let eventDeliverySettleNanoseconds: UInt64 = 20_000_000
 
     static func currentFlags() -> CGEventFlags {
         CGEventSource.flagsState(.hidSystemState)
@@ -184,7 +186,6 @@ enum InputEvent {
     }
 
     static func postMouseMoved(at position: CGPoint, source: CGEventSource? = nil) {
-        CGWarpMouseCursorPosition(position)
         mouseMovedEvent(at: position, source: source)?.post(tap: .cghidEventTap)
     }
 }

--- a/Sources/SwiftAutoGUI/Core/SwiftAutoGUI.swift
+++ b/Sources/SwiftAutoGUI/Core/SwiftAutoGUI.swift
@@ -420,8 +420,10 @@ public class SwiftAutoGUI {
     public static func moveMouse(dx: CGFloat, dy: CGFloat) async {
         let mouseLoc = position()
         let newLoc = CGPoint(x: mouseLoc.x + dx, y: mouseLoc.y + dy)
-        InputEvent.postMouseMoved(at: newLoc)
-        try? await Task.sleep(for: .milliseconds(10))
+        let source = CGEventSource(stateID: .hidSystemState)
+        InputEvent.postMouseMoved(at: newLoc, source: source)
+        try? await Task.sleep(nanoseconds: InputEvent.mouseMoveSettleNanoseconds)
+        withExtendedLifetime(source) {}
     }
 
     /// Moves the mouse cursor to an absolute position with animated movement.
@@ -457,8 +459,10 @@ public class SwiftAutoGUI {
     /// ```
     public static func move(to: CGPoint, duration: TimeInterval, tweening: TweeningFunction = .linear, fps: Double = 60.0) async {
         guard duration > 0, fps > 0 else {
-            InputEvent.postMouseMoved(at: to)
-            try? await Task.sleep(for: .milliseconds(10))
+            let source = CGEventSource(stateID: .hidSystemState)
+            InputEvent.postMouseMoved(at: to, source: source)
+            try? await Task.sleep(nanoseconds: InputEvent.mouseMoveSettleNanoseconds)
+            withExtendedLifetime(source) {}
             return
         }
 
@@ -487,9 +491,9 @@ public class SwiftAutoGUI {
             }
         }
 
-        // CGEvent posting is asynchronous. Give WindowServer a chance to apply the
-        // final event before callers observe the cursor position.
-        try? await Task.sleep(for: .milliseconds(10))
+        // CGEvent posting is asynchronous. Keep the source alive while WindowServer
+        // applies the final event so callers can immediately observe the destination.
+        try? await Task.sleep(nanoseconds: InputEvent.mouseMoveSettleNanoseconds)
         withExtendedLifetime(source) {}
     }
 
@@ -551,9 +555,11 @@ public class SwiftAutoGUI {
     public static func click(at position: CGPoint, button: MouseButton = .left) {
         let source = CGEventSource(stateID: .hidSystemState)
         InputEvent.postMouseMoved(at: position, source: source)
+        Thread.sleep(forTimeInterval: Double(InputEvent.mouseMoveSettleNanoseconds) / 1_000_000_000)
         clickDown(position: position, button: button, clickCount: 1, source: source)
         Thread.sleep(forTimeInterval: Double(InputEvent.clickDelayNanoseconds) / 1_000_000_000)
         clickUp(position: position, button: button, clickCount: 1, source: source)
+        Thread.sleep(forTimeInterval: Double(InputEvent.eventDeliverySettleNanoseconds) / 1_000_000_000)
         withExtendedLifetime(source) {}
     }
 
@@ -587,6 +593,7 @@ public class SwiftAutoGUI {
     public static func leftDragged(to: CGPoint, from: CGPoint) {
         let source = CGEventSource(stateID: .hidSystemState)
         InputEvent.postMouseMoved(at: from, source: source)
+        Thread.sleep(forTimeInterval: Double(InputEvent.mouseMoveSettleNanoseconds) / 1_000_000_000)
         clickDown(position: from, button: .left, clickCount: 1, source: source)
         let event = InputEvent.mouseEvent(
             type: .leftMouseDragged,
@@ -596,6 +603,7 @@ public class SwiftAutoGUI {
         )
         event?.post(tap: CGEventTapLocation.cghidEventTap)
         clickUp(position: to, button: .left, clickCount: 1, source: source)
+        Thread.sleep(forTimeInterval: Double(InputEvent.eventDeliverySettleNanoseconds) / 1_000_000_000)
         withExtendedLifetime(source) {}
     }
 
@@ -895,6 +903,7 @@ public class SwiftAutoGUI {
     private static func click(at position: CGPoint, button: MouseButton, count: Int) async {
         let source = CGEventSource(stateID: .hidSystemState)
         InputEvent.postMouseMoved(at: position, source: source)
+        try? await Task.sleep(nanoseconds: InputEvent.mouseMoveSettleNanoseconds)
         for clickCount in 1...count {
             clickDown(
                 position: position,
@@ -913,6 +922,7 @@ public class SwiftAutoGUI {
                 try? await Task.sleep(nanoseconds: InputEvent.clickDelayNanoseconds)
             }
         }
+        try? await Task.sleep(nanoseconds: InputEvent.eventDeliverySettleNanoseconds)
         _ = source?.sourceStateID
     }
 
@@ -963,6 +973,7 @@ public class SwiftAutoGUI {
                 source: source
             )?.post(tap: .cghidEventTap)
         }
+        Thread.sleep(forTimeInterval: Double(InputEvent.eventDeliverySettleNanoseconds) / 1_000_000_000)
         withExtendedLifetime(source) {}
     }
 

--- a/Tests/SaguiTests/SaguiCommandTests.swift
+++ b/Tests/SaguiTests/SaguiCommandTests.swift
@@ -44,6 +44,8 @@ struct SaguiCommandTests {
     @Test("Root command exposes the current version")
     func version() {
         #expect(SaguiCLI.configuration.version == SaguiVersion.current)
-        #expect(SaguiVersion.current == "0.25.0")
+        let components = SaguiVersion.current.split(separator: ".")
+        #expect(components.count == 3)
+        #expect(components.allSatisfy { Int($0) != nil })
     }
 }

--- a/Tests/SwiftAutoGUITests/InputEventTests.swift
+++ b/Tests/SwiftAutoGUITests/InputEventTests.swift
@@ -114,6 +114,18 @@ struct InputEventTests {
         #expect(event.getIntegerValueField(.mouseEventClickState) == 2)
     }
 
+    @Test("Mouse movement is represented by a positioned CGEvent")
+    func mouseMovedEvent() throws {
+        let point = CGPoint(x: 321, y: 654)
+        let event = try #require(InputEvent.mouseMovedEvent(
+            at: point,
+            flags: [.maskShift]
+        ))
+        #expect(event.type == .mouseMoved)
+        #expect(event.location == point)
+        #expect(event.flags.contains(.maskShift))
+    }
+
     @Test("Scroll events include location, flags, and axes")
     func scrollEvent() throws {
         let point = CGPoint(x: 50, y: 75)


### PR DESCRIPTION
## Summary

- remove cursor warping and route movement exclusively through positioned `mouseMoved` CGEvents
- keep one HID event source alive across move, click, drag, and scroll sequences
- add settle intervals around mouse movement and event delivery to reduce intermittent dropped clicks
- add an Input Event Observer to the Sample app for inspecting delivered mouse, scroll, keyboard, and modifier NSEvents
- add coverage for positioned mouse movement events and make the CLI version test release-independent

## Implementation details

A click now sends a positioned `mouseMoved`, waits for WindowServer to settle, then sends mouse-down and mouse-up using the same `CGEventSource`. The source remains alive briefly after the final event. The same delivery rules are applied to double/triple click, drag, movement, and scroll paths.

The Sample Observer records events that actually reach the Sample app, including coordinates, click count, scroll deltas, modifiers, and source PID. It also provides click, context-menu, scroll, and keyboard targets for reproducing Issues #113 and #115.

## Verification

- `swift test` (145 tests)
- `SWIFTAUTOGUI_RUN_INPUT_TESTS=1 swift test --parallel` (145 tests)
- `swift build -c release`
- Sample app Xcode build
- `git diff --check`

The reported failure is intermittent, so this PR treats cursor-warp suppression as a plausible cause rather than claiming it was independently proven.

Fixes #115