### PR TITLE
Update OpenAI agent models to GPT-5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,23 @@ SwiftAutoGUI includes an Agent that can autonomously observe the screen, reason 
 ```swift
 import SwiftAutoGUI
 
-let backend = OpenAIVisionBackend(apiKey: "sk-...", model: "gpt-4o")
+let backend = OpenAIVisionBackend(apiKey: "sk-...", model: "gpt-5.6-sol")
 let agent = Agent(backend: backend, maxIterations: 15)
 
 let result = try await agent.run(goal: "Open Safari and search for Swift")
 print("Completed: \(result.completed), Steps: \(result.iterationsUsed)")
 ```
+
+The CLI prints the effective reasoning effort when it starts and the model-provided
+reasoning summary for every agent step:
+
+```bash
+sagui agent "Open Safari and search for Swift" --reasoning-effort low
+```
+
+`--reasoning-effort` accepts `none`, `low`, `medium`, `high`, `xhigh`, or `max`.
+It defaults to `low` for GPT-5.6 models. The per-step `Reasoning:` line is the
+agent's concise explanation of its chosen actions, not the model's hidden chain of thought.
 
 ## Basic Usage
 

--- a/Sample/Sample/Features/AIGeneration/AIGenerationDemoViewModel.swift
+++ b/Sample/Sample/Features/AIGeneration/AIGenerationDemoViewModel.swift
@@ -27,9 +27,12 @@ class AIGenerationDemoViewModel {
 
     var selectedBackend: Backend = .foundationModels
     var openAIKey: String = ""
-    var openAIModel: String = "gpt-4.1-nano"
+    var openAIModel: String = OpenAIBackend.defaultModel
 
     static let availableOpenAIModels = [
+        "gpt-5.6-luna",
+        "gpt-5.6-terra",
+        "gpt-5.6-sol",
         "gpt-4.1-nano",
         "gpt-4.1-mini",
         "gpt-4.1",

--- a/Sample/Sample/Features/Agent/AgentDemoViewModel.swift
+++ b/Sample/Sample/Features/Agent/AgentDemoViewModel.swift
@@ -16,12 +16,15 @@ class AgentDemoViewModel {
     // MARK: - Backend Settings
 
     var openAIKey: String = ""
-    var openAIModel: String = "gpt-5.4"
+    var openAIModel: String = OpenAIVisionBackend.defaultModel
     var maxIterations: Int = 20
     var delayBetweenSteps: Double = 1.0
     var useScreenContext: Bool = true
 
     static let availableModels = [
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
         "gpt-5.4",
         "gpt-5.4-mini",
         "gpt-5.4-nano",

--- a/Sources/SwiftAutoGUI/AI/ActionGenerator.swift
+++ b/Sources/SwiftAutoGUI/AI/ActionGenerator.swift
@@ -360,9 +360,18 @@ public struct ActionGenerator: Sendable {
     ///
     /// - Parameters:
     ///   - openAIKey: Your OpenAI API key.
-    ///   - model: The model to use (default: `gpt-4.1-nano`).
-    public init(openAIKey: String, model: String = "gpt-4.1-nano") {
-        self.backend = OpenAIBackend(apiKey: openAIKey, model: model)
+    ///   - model: The model to use (default: `gpt-5.6-luna`).
+    ///   - reasoningEffort: Optional reasoning effort sent to the Responses API.
+    public init(
+        openAIKey: String,
+        model: String = OpenAIBackend.defaultModel,
+        reasoningEffort: String? = nil
+    ) {
+        self.backend = OpenAIBackend(
+            apiKey: openAIKey,
+            model: model,
+            reasoningEffort: reasoningEffort
+        )
     }
 
     // MARK: - Instance Methods

--- a/Sources/SwiftAutoGUI/AI/OpenAIBackend.swift
+++ b/Sources/SwiftAutoGUI/AI/OpenAIBackend.swift
@@ -20,7 +20,7 @@ import Foundation
 /// await action.execute()
 ///
 /// // With a specific model
-/// let backend = OpenAIBackend(apiKey: "sk-...", model: "gpt-4o")
+/// let backend = OpenAIBackend(apiKey: "sk-...", model: "gpt-5.6-terra")
 /// ```
 ///
 /// ## Security
@@ -28,19 +28,35 @@ import Foundation
 /// Never hard-code API keys in source code. Use environment variables or secure storage.
 public struct OpenAIBackend: ActionGenerating, Sendable {
 
+    /// The default OpenAI model used for text-to-action generation.
+    public static let defaultModel = "gpt-5.6-luna"
+
+    /// The reasoning effort used by default for GPT-5.6 models.
+    public static let defaultReasoningEffort = "none"
+
     private let apiKey: String
     private let model: String
+    private let reasoningEffort: String?
     private let baseURL: String
 
     /// Creates an OpenAI backend.
     ///
     /// - Parameters:
     ///   - apiKey: Your OpenAI API key.
-    ///   - model: The model to use (default: `gpt-4.1-nano`).
+    ///   - model: The model to use (default: `gpt-5.6-luna`).
+    ///   - reasoningEffort: Optional reasoning effort sent to the Responses API. When omitted,
+    ///     GPT-5.6 models use `none` for low-latency action conversion.
     ///   - baseURL: The API base URL (default: OpenAI).
-    public init(apiKey: String, model: String = "gpt-4.1-nano", baseURL: String = "https://api.openai.com/v1") {
+    public init(
+        apiKey: String,
+        model: String = OpenAIBackend.defaultModel,
+        reasoningEffort: String? = nil,
+        baseURL: String = "https://api.openai.com/v1"
+    ) {
         self.apiKey = apiKey
         self.model = model
+        self.reasoningEffort = reasoningEffort
+            ?? (model.hasPrefix("gpt-5.6") ? Self.defaultReasoningEffort : nil)
         self.baseURL = baseURL
     }
 
@@ -56,7 +72,7 @@ public struct OpenAIBackend: ActionGenerating, Sendable {
     }
 
     public func generateActionSequence(from prompt: String) async throws -> [Action] {
-        let requestBody: [String: Any] = [
+        var requestBody: [String: Any] = [
             "model": model,
             "instructions": Self.systemPrompt,
             "input": prompt,
@@ -69,6 +85,9 @@ public struct OpenAIBackend: ActionGenerating, Sendable {
                 ] as [String: Any]
             ] as [String: Any]
         ]
+        if let reasoningEffort {
+            requestBody["reasoning"] = ["effort": reasoningEffort]
+        }
 
         let requestData = try JSONSerialization.data(withJSONObject: requestBody)
 

--- a/Sources/SwiftAutoGUI/AI/OpenAIVisionBackend.swift
+++ b/Sources/SwiftAutoGUI/AI/OpenAIVisionBackend.swift
@@ -29,19 +29,35 @@ import Foundation
 /// ```
 public struct OpenAIVisionBackend: VisionActionGenerating, Sendable {
 
+    /// The default OpenAI model used for vision-based agent actions.
+    public static let defaultModel = "gpt-5.6-sol"
+
+    /// The reasoning effort used by default for GPT-5.6 models.
+    public static let defaultReasoningEffort = "low"
+
     private let apiKey: String
     private let model: String
+    private let reasoningEffort: String?
     private let baseURL: String
 
     /// Creates an OpenAI vision backend.
     ///
     /// - Parameters:
     ///   - apiKey: Your OpenAI API key.
-    ///   - model: The vision-capable model to use (default: `gpt-4o`).
+    ///   - model: The vision-capable model to use (default: `gpt-5.6-sol`).
+    ///   - reasoningEffort: Optional reasoning effort sent to the Responses API. When omitted,
+    ///     GPT-5.6 models use `low` to balance agent planning quality and latency.
     ///   - baseURL: The API base URL (default: OpenAI).
-    public init(apiKey: String, model: String = "gpt-4o", baseURL: String = "https://api.openai.com/v1") {
+    public init(
+        apiKey: String,
+        model: String = OpenAIVisionBackend.defaultModel,
+        reasoningEffort: String? = nil,
+        baseURL: String = "https://api.openai.com/v1"
+    ) {
         self.apiKey = apiKey
         self.model = model
+        self.reasoningEffort = reasoningEffort
+            ?? (model.hasPrefix("gpt-5.6") ? Self.defaultReasoningEffort : nil)
         self.baseURL = baseURL
     }
 
@@ -78,7 +94,7 @@ public struct OpenAIVisionBackend: VisionActionGenerating, Sendable {
             screenContext: screenContext
         )
 
-        let requestBody: [String: Any] = [
+        var requestBody: [String: Any] = [
             "model": model,
             "instructions": Self.buildSystemPrompt(screenSize: screenSize, hasScreenContext: screenContext != nil),
             "input": input,
@@ -91,6 +107,9 @@ public struct OpenAIVisionBackend: VisionActionGenerating, Sendable {
                 ] as [String: Any]
             ] as [String: Any]
         ]
+        if let reasoningEffort {
+            requestBody["reasoning"] = ["effort": reasoningEffort]
+        }
 
         let requestData = try JSONSerialization.data(withJSONObject: requestBody)
 

--- a/Sources/SwiftAutoGUI/Documentation.docc/SwiftAutoGUI.md
+++ b/Sources/SwiftAutoGUI/Documentation.docc/SwiftAutoGUI.md
@@ -46,7 +46,7 @@ SwiftAutoGUI includes an ``Agent`` that can autonomously observe the screen, rea
 ```swift
 import SwiftAutoGUI
 
-let backend = OpenAIVisionBackend(apiKey: "sk-...", model: "gpt-4o")
+let backend = OpenAIVisionBackend(apiKey: "sk-...", model: "gpt-5.6-sol")
 let agent = Agent(backend: backend, maxIterations: 15)
 
 let result = try await agent.run(goal: "Open Safari and search for Swift")
@@ -90,12 +90,17 @@ struct MyBackend: VisionActionGenerating {
 sagui agent "Open Safari and search for Swift" --api-key sk-...
 
 # With options
-sagui agent "Click the trash icon" --model gpt-4o --max-iterations 15 --delay 2.0
+sagui agent "Click the trash icon" --model gpt-5.6-sol --reasoning-effort low --max-iterations 15 --delay 2.0
 
 # Using environment variable for the API key
 export OPENAI_API_KEY=sk-...
 sagui agent "Open Terminal"
 ```
+
+The command prints the effective reasoning effort at startup and a `Reasoning:`
+summary for each step. `--reasoning-effort` accepts `none`, `low`, `medium`,
+`high`, `xhigh`, or `max`, and defaults to `low` for GPT-5.6 models. The step
+summary explains the selected actions; it is not the model's hidden chain of thought.
 
 ## Action Pattern
 

--- a/Sources/sagui/AgentCommand.swift
+++ b/Sources/sagui/AgentCommand.swift
@@ -11,9 +11,20 @@ import SwiftAutoGUI
 ///
 /// ```bash
 /// sagui agent "Open Safari and search for Swift" --api-key sk-...
-/// sagui agent "Click the trash icon" --model gpt-4o --max-iterations 15
+/// sagui agent "Click the trash icon" --model gpt-5.6-sol --reasoning-effort low --max-iterations 15
 /// ```
 struct AgentCommand: AsyncParsableCommand {
+    enum ReasoningEffort: String, CaseIterable, ExpressibleByArgument {
+        case none
+        case low
+        case medium
+        case high
+        case xhigh
+        case max
+    }
+
+    static let defaultModel = OpenAIVisionBackend.defaultModel
+
     static let configuration = CommandConfiguration(
         commandName: "agent",
         abstract: "Run an AI agent to accomplish a goal using screen observation."
@@ -26,7 +37,10 @@ struct AgentCommand: AsyncParsableCommand {
     var apiKey: String?
 
     @Option(help: "Vision model to use.")
-    var model: String = "gpt-5.4"
+    var model: String = Self.defaultModel
+
+    @Option(help: "Reasoning effort: none, low, medium, high, xhigh, or max. Defaults to low for GPT-5.6 models.")
+    var reasoningEffort: ReasoningEffort?
 
     @Option(help: "Maximum number of iterations.")
     var maxIterations: Int = 20
@@ -44,7 +58,11 @@ struct AgentCommand: AsyncParsableCommand {
             throw ValidationError("Provide --api-key or set OPENAI_API_KEY environment variable.")
         }
 
-        let backend = OpenAIVisionBackend(apiKey: key, model: model)
+        let backend = OpenAIVisionBackend(
+            apiKey: key,
+            model: model,
+            reasoningEffort: reasoningEffort?.rawValue
+        )
         let contextOptions: ScreenContextProvider.Options? = noScreenContext ? nil : ScreenContextProvider.Options()
         let agent = Agent(
             backend: backend,
@@ -54,7 +72,9 @@ struct AgentCommand: AsyncParsableCommand {
         )
 
         print("Agent starting with goal: \"\(goal)\"")
-        print("Model: \(model), Max iterations: \(maxIterations), Delay: \(delay)s, Screen context: \(!noScreenContext)")
+        print("Model: \(model)")
+        print("Reasoning effort: \(effectiveReasoningEffort)")
+        print("Max iterations: \(maxIterations), Delay: \(delay)s, Screen context: \(!noScreenContext)")
         print("---")
 
         let result = try await agent.run(goal: goal) { step in
@@ -62,7 +82,7 @@ struct AgentCommand: AsyncParsableCommand {
                 from: step.timestamp, dateStyle: .none, timeStyle: .medium
             )
             let actionSummary = step.actions.map { "\($0)" }.joined(separator: ", ")
-            print("[\(timestamp)] \(step.reasoning)")
+            print("[\(timestamp)] Reasoning: \(step.reasoning)")
             print("  Actions: \(actionSummary)")
             print("---")
         }
@@ -70,5 +90,15 @@ struct AgentCommand: AsyncParsableCommand {
         print("Agent finished.")
         print("Completed: \(result.completed)")
         print("Iterations used: \(result.iterationsUsed)")
+    }
+
+    var effectiveReasoningEffort: String {
+        if let reasoningEffort {
+            return reasoningEffort.rawValue
+        }
+        if model.hasPrefix("gpt-5.6") {
+            return OpenAIVisionBackend.defaultReasoningEffort
+        }
+        return "model default"
     }
 }

--- a/Tests/SaguiTests/SaguiCommandTests.swift
+++ b/Tests/SaguiTests/SaguiCommandTests.swift
@@ -48,4 +48,44 @@ struct SaguiCommandTests {
         #expect(components.count == 3)
         #expect(components.allSatisfy { Int($0) != nil })
     }
+
+    @Test("Agent defaults to the current flagship model")
+    func agentDefaultModel() throws {
+        let command = try AgentCommand.parse(["Inspect the frontmost app"])
+        #expect(command.model == "gpt-5.6-sol")
+        #expect(command.reasoningEffort == nil)
+        #expect(command.effectiveReasoningEffort == "low")
+    }
+
+    @Test("Agent accepts an explicit model override")
+    func agentModelOverride() throws {
+        let command = try AgentCommand.parse([
+            "Inspect the frontmost app",
+            "--model", "gpt-5.6-terra",
+        ])
+        #expect(command.model == "gpt-5.6-terra")
+    }
+
+    @Test(
+        "Agent accepts every GPT-5.6 reasoning effort",
+        arguments: AgentCommand.ReasoningEffort.allCases
+    )
+    func agentReasoningEffort(effort: AgentCommand.ReasoningEffort) throws {
+        let command = try AgentCommand.parse([
+            "Inspect the frontmost app",
+            "--reasoning-effort", effort.rawValue,
+        ])
+        #expect(command.reasoningEffort == effort)
+        #expect(command.effectiveReasoningEffort == effort.rawValue)
+    }
+
+    @Test("Agent rejects an unknown reasoning effort")
+    func agentRejectsUnknownReasoningEffort() {
+        #expect(throws: (any Error).self) {
+            try AgentCommand.parse([
+                "Inspect the frontmost app",
+                "--reasoning-effort", "extreme",
+            ])
+        }
+    }
 }

--- a/Tests/SwiftAutoGUITests/ActionGeneratorTests.swift
+++ b/Tests/SwiftAutoGUITests/ActionGeneratorTests.swift
@@ -642,6 +642,18 @@ struct ActionGeneratorTests {
     @Suite("Backend and API")
     struct BackendTests {
 
+        @Test("Vision backend defaults to the current flagship model")
+        func visionBackendDefaults() {
+            #expect(OpenAIVisionBackend.defaultModel == "gpt-5.6-sol")
+            #expect(OpenAIVisionBackend.defaultReasoningEffort == "low")
+        }
+
+        @Test("Text backend defaults to the efficient model")
+        func textBackendDefaults() {
+            #expect(OpenAIBackend.defaultModel == "gpt-5.6-luna")
+            #expect(OpenAIBackend.defaultReasoningEffort == "none")
+        }
+
         @Test("OpenAIBackend is always available")
         func openAIBackendAvailable() {
             let backend = OpenAIBackend(apiKey: "test-key")

--- a/plugins/swift-auto-gui/skills/macos-control/SKILL.md
+++ b/plugins/swift-auto-gui/skills/macos-control/SKILL.md
@@ -165,14 +165,18 @@ sagui screen locate-center button.png                      # Find image center (
 ### agent — AI-powered automation
 
 ```bash
-sagui agent "Open Safari and search for Swift"                    # Run with on-device model
+sagui agent "Open Safari and search for Swift"                    # Uses OPENAI_API_KEY and default model
 sagui agent "Click the submit button" --api-key sk-...            # Run with OpenAI
-sagui agent "Fill in the form" --model gpt-5.4 --max-iterations 10
+sagui agent "Fill in the form" --model gpt-5.6-sol --reasoning-effort low --max-iterations 10
 ```
 
 | Required | Optional |
 |---|---|
-| `<goal>` (string) | `--api-key <key>` (or `OPENAI_API_KEY` env), `--model <model>` (default: `gpt-5.4`), `--max-iterations <n>` (default: 20), `--delay <seconds>` (default: 1.0), `--no-screen-context` |
+| `<goal>` (string) | `--api-key <key>` (or `OPENAI_API_KEY` env), `--model <model>` (default: `gpt-5.6-sol`), `--reasoning-effort <none|low|medium|high|xhigh|max>` (default: `low` for GPT-5.6), `--max-iterations <n>` (default: 20), `--delay <seconds>` (default: 1.0), `--no-screen-context` |
+
+The command prints the effective reasoning effort at startup and a concise
+`Reasoning:` summary for every step. This summary explains the selected actions;
+it is not the model's hidden chain of thought.
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

- use GPT-5.6 Luna with `none` reasoning for text-to-action generation
- use GPT-5.6 Sol with `low` reasoning for vision-based agent execution
- add `--reasoning-effort` to `sagui agent` and print the effective effort plus per-step reasoning summaries
- update Sample model pickers, README, DocC, and the bundled macOS control skill
- add CLI parsing and backend-default coverage

## Testing

- `swift test` (151 tests passed)
- `swift build -c release --product sagui`
- Sample app `xcodebuild`
- `swift package generate-documentation`
- `./.build/debug/sagui agent --help`