### PR TITLE
Add semantic element targeting and verified Agent execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,11 @@ SwiftAutoGUI includes an Agent that can autonomously observe the screen, reason 
 import SwiftAutoGUI
 
 let backend = OpenAIVisionBackend(apiKey: "sk-...", model: "gpt-5.6-sol")
-let agent = Agent(backend: backend, maxIterations: 15)
+let agent = Agent(
+    backend: backend,
+    maxIterations: 15,
+    visionMode: .automatic
+)
 
 let result = try await agent.run(goal: "Open Safari and search for Swift")
 print("Completed: \(result.completed), Steps: \(result.iterationsUsed)")
@@ -91,11 +95,23 @@ reasoning summary for every agent step:
 
 ```bash
 sagui agent "Open Safari and search for Swift" --reasoning-effort low
+sagui agent "Press the Save button" --vision-mode automatic
 ```
 
 `--reasoning-effort` accepts `none`, `low`, `medium`, `high`, `xhigh`, or `max`.
 It defaults to `low` for GPT-5.6 models. The per-step `Reasoning:` line is the
 agent's concise explanation of its chosen actions, not the model's hidden chain of thought.
+
+When screen context is enabled, actionable Accessibility elements receive step-local
+identifiers such as `[#12]`. The agent can target these identifiers directly, resolves
+them again immediately before execution, and rejects stale elements safely. Each action
+returns a structured result describing the execution method, failure, UI change, and
+focus change. If an action changes the UI, the remaining batch is stopped and the agent
+observes the new state before continuing.
+
+`--vision-mode` accepts `always`, `automatic`, or `never`. `automatic` omits the
+screenshot when actionable Accessibility elements are available; `always` preserves
+the original behavior and remains the default.
 
 ## Basic Usage
 

--- a/Sample/Sample/Features/Agent/AgentDemoViewModel.swift
+++ b/Sample/Sample/Features/Agent/AgentDemoViewModel.swift
@@ -88,10 +88,14 @@ class AgentDemoViewModel {
                     guard let self else { return }
                     Task { @MainActor in
                         let actionSummary = step.actions.map { self.describeAction($0) }.joined(separator: ", ")
+                        let resultSummary = step.executionResults.map { result in
+                            "\(result.succeeded ? "✓" : "✗") \(result.method.rawValue)" +
+                                (result.screenChanged ? " (UI changed)" : "")
+                        }.joined(separator: ", ")
                         self.steps.append(StepDisplay(
                             number: self.steps.count + 1,
                             reasoning: step.reasoning,
-                            actions: actionSummary,
+                            actions: actionSummary + (resultSummary.isEmpty ? "" : "\n\(resultSummary)"),
                             timestamp: step.timestamp
                         ))
                     }
@@ -146,8 +150,12 @@ class AgentDemoViewModel {
             return "getFrontmostApp"
         case .pressButton(let label, let bundleID):
             return "pressButton(\"\(label)\"\(bundleID.isEmpty ? "" : " in \(bundleID)"))"
+        case .pressElement(let elementID):
+            return "pressElement(#\(elementID))"
         case .setTextField(let label, let value, let bundleID):
             return "setTextField(label:\"\(label)\", value:\"\(value)\"\(bundleID.isEmpty ? "" : " in \(bundleID)"))"
+        case .setElementValue(let elementID, let value):
+            return "setElementValue(#\(elementID), value:\"\(value)\")"
         case .selectMenuItem(let path, let bundleID):
             return "selectMenuItem(\(path.joined(separator: " > "))\(bundleID.isEmpty ? "" : " in \(bundleID)"))"
         case .raiseWindow(let title, let bundleID):

--- a/Sample/Sample/Features/ScreenContext/ScreenContextDemoView.swift
+++ b/Sample/Sample/Features/ScreenContext/ScreenContextDemoView.swift
@@ -27,6 +27,7 @@ struct ScreenContextDemoView: View {
                     HStack(spacing: 12) {
                         badge("\(context.visibleWindows.count) windows", icon: "macwindow")
                         badge("\(viewModel.nodeCount) nodes", icon: "list.bullet.indent")
+                        badge("\(viewModel.actionableElementCount) actionable", icon: "scope")
                     }
                 }
             }
@@ -81,7 +82,10 @@ struct ScreenContextDemoView: View {
             if viewModel.formattedOutput.isEmpty {
                 emptyState
             } else {
-                contextDisplay
+                VStack(alignment: .leading, spacing: 12) {
+                    elementActionObserver
+                    contextDisplay
+                }
             }
         }
     }
@@ -144,6 +148,57 @@ struct ScreenContextDemoView: View {
     }
 
     // MARK: - Context Display
+
+    private var elementActionObserver: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Label("Element Action Observer", systemImage: "scope")
+                    .font(.headline)
+                Spacer()
+                if viewModel.isExecuting { ProgressView().scaleEffect(0.7) }
+            }
+
+            Text("Choose a [#N] identifier from the AX tree below. Actions are resolved against the captured hierarchy and rejected if the element became stale.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            HStack(spacing: 8) {
+                Text("Element #")
+                    .font(.caption)
+                TextField("ID", value: $viewModel.selectedElementID, format: .number)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 60)
+                Button("Press") { viewModel.pressSelectedElement() }
+                    .disabled(viewModel.isExecuting)
+
+                Divider().frame(height: 20)
+
+                TextField("Value", text: $viewModel.elementValue)
+                    .textFieldStyle(.roundedBorder)
+                Button("Set Value") { viewModel.setSelectedElementValue() }
+                    .disabled(viewModel.isExecuting)
+            }
+
+            Text(viewModel.executionLog)
+                .font(.system(.caption2, design: .monospaced))
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(8)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(colorScheme == .dark ? Color.black.opacity(0.3) : Color.gray.opacity(0.06))
+                )
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.teal.opacity(0.08))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.teal.opacity(0.25), lineWidth: 1)
+        )
+    }
 
     private var contextDisplay: some View {
         VStack(alignment: .leading, spacing: 12) {

--- a/Sample/Sample/Features/ScreenContext/ScreenContextViewModel.swift
+++ b/Sample/Sample/Features/ScreenContext/ScreenContextViewModel.swift
@@ -20,6 +20,10 @@ class ScreenContextViewModel {
     var maxNodes: Int = 200
     var maxValueLength: Int = 100
     var includeAXTree: Bool = true
+    var selectedElementID: Int = 1
+    var elementValue: String = ""
+    var executionLog: String = "No element action executed yet."
+    var isExecuting = false
 
     private var refreshTask: Task<Void, Never>?
 
@@ -57,6 +61,62 @@ class ScreenContextViewModel {
     var nodeCount: Int {
         guard let tree = context?.focusedWindowAXTree else { return 0 }
         return countNodes(tree)
+    }
+
+    var actionableElementCount: Int {
+        context?.actionableElementCount ?? 0
+    }
+
+    func pressSelectedElement() {
+        execute(.pressElement(elementID: selectedElementID))
+    }
+
+    func setSelectedElementValue() {
+        execute(.setElementValue(elementID: selectedElementID, value: elementValue))
+    }
+
+    private func execute(_ action: BasicAction) {
+        guard let context else {
+            executionLog = "Capture a screen context first."
+            return
+        }
+        isExecuting = true
+        Task {
+            let execution = await AgentActionExecutor.execute(
+                action,
+                in: context,
+                screenContextOptions: currentOptions()
+            )
+            self.context = execution.screenContext
+            if let updated = execution.screenContext {
+                formattedOutput = updated.formatted()
+            }
+            executionLog = describe(execution.result)
+            isExecuting = false
+        }
+    }
+
+    private func currentOptions() -> ScreenContextProvider.Options {
+        ScreenContextProvider.Options(
+            maxDepth: maxDepth,
+            maxNodes: maxNodes,
+            maxValueLength: maxValueLength,
+            includeAXTree: includeAXTree
+        )
+    }
+
+    private func describe(_ result: ActionExecutionResult) -> String {
+        var lines = [
+            "Result: \(result.succeeded ? "succeeded" : "failed")",
+            "Method: \(result.method.rawValue)",
+            "Screen changed: \(result.screenChanged)",
+            "Focused app changed: \(result.focusedAppChanged)",
+            "Focused element changed: \(result.focusedElementChanged)",
+        ]
+        if let reason = result.failureReason {
+            lines.append("Reason: \(reason)")
+        }
+        return lines.joined(separator: "\n")
     }
 
     private func countNodes(_ node: AXNode) -> Int {

--- a/Sources/SwiftAutoGUI/AI/ActionGenerator.swift
+++ b/Sources/SwiftAutoGUI/AI/ActionGenerator.swift
@@ -49,9 +49,15 @@ public enum BasicAction: Sendable, Codable {
     /// frontmost app; otherwise pass a value like "com.apple.calculator".
     case pressButton(label: String, bundleID: String)
 
+    /// Press a step-local element from the current screen observation.
+    case pressElement(elementID: Int)
+
     /// Set a text field's value via the accessibility API.
     /// `label` may be empty to match by role only. `bundleID` empty = frontmost.
     case setTextField(label: String, value: String, bundleID: String)
+
+    /// Set the value of a step-local element from the current observation.
+    case setElementValue(elementID: Int, value: String)
 
     /// Select a menu item by hierarchical path, e.g. `["File", "Save As…"]`.
     case selectMenuItem(path: [String], bundleID: String)
@@ -98,12 +104,18 @@ public enum BasicAction: Sendable, Codable {
             return .drag(from: CGPoint(x: fromX, y: fromY), to: CGPoint(x: toX, y: toY))
         case .pressButton(let label, let bundleID):
             return .pressButton(label: label, app: scope(bundleID))
+        case .pressElement:
+            // Element IDs require the ScreenContext captured by Agent and are
+            // executed by AgentActionExecutor. A standalone conversion is a no-op.
+            return .wait(0)
         case .setTextField(let label, let value, let bundleID):
             return .setTextField(
                 label: label.isEmpty ? nil : label,
                 value: value,
                 app: scope(bundleID)
             )
+        case .setElementValue:
+            return .wait(0)
         case .selectMenuItem(let path, let bundleID):
             return .selectMenuItem(path: path, app: scope(bundleID))
         case .raiseWindow(let title, let bundleID):
@@ -156,14 +168,14 @@ public enum BasicAction: Sendable, Codable {
         case type
         case text, x, y, clicks, duration, keys
         case fromX, fromY, toX, toY
-        case label, value, path, title, bundleID
+        case label, value, path, title, bundleID, elementID
         case url, name
     }
 
     private enum ActionType: String, Codable {
         case write, move, leftClick, rightClick, doubleClick
         case vscroll, hscroll, wait, keyShortcut, drag
-        case pressButton, setTextField, selectMenuItem, raiseWindow
+        case pressButton, pressElement, setTextField, setElementValue, selectMenuItem, raiseWindow
         case openURL, activateApp, quitApp, getFrontmostApp
     }
 
@@ -207,11 +219,18 @@ public enum BasicAction: Sendable, Codable {
             let label = try container.decodeIfPresent(String.self, forKey: .label) ?? ""
             let bundleID = try container.decodeIfPresent(String.self, forKey: .bundleID) ?? ""
             self = .pressButton(label: label, bundleID: bundleID)
+        case .pressElement:
+            let elementID = try container.decodeIfPresent(Int.self, forKey: .elementID) ?? 0
+            self = .pressElement(elementID: elementID)
         case .setTextField:
             let label = try container.decodeIfPresent(String.self, forKey: .label) ?? ""
             let value = try container.decodeIfPresent(String.self, forKey: .value) ?? ""
             let bundleID = try container.decodeIfPresent(String.self, forKey: .bundleID) ?? ""
             self = .setTextField(label: label, value: value, bundleID: bundleID)
+        case .setElementValue:
+            let elementID = try container.decodeIfPresent(Int.self, forKey: .elementID) ?? 0
+            let value = try container.decodeIfPresent(String.self, forKey: .value) ?? ""
+            self = .setElementValue(elementID: elementID, value: value)
         case .selectMenuItem:
             let path = try container.decodeIfPresent([String].self, forKey: .path) ?? []
             let bundleID = try container.decodeIfPresent(String.self, forKey: .bundleID) ?? ""
@@ -273,11 +292,18 @@ public enum BasicAction: Sendable, Codable {
             try container.encode(ActionType.pressButton, forKey: .type)
             try container.encode(label, forKey: .label)
             try container.encode(bundleID, forKey: .bundleID)
+        case .pressElement(let elementID):
+            try container.encode(ActionType.pressElement, forKey: .type)
+            try container.encode(elementID, forKey: .elementID)
         case .setTextField(let label, let value, let bundleID):
             try container.encode(ActionType.setTextField, forKey: .type)
             try container.encode(label, forKey: .label)
             try container.encode(value, forKey: .value)
             try container.encode(bundleID, forKey: .bundleID)
+        case .setElementValue(let elementID, let value):
+            try container.encode(ActionType.setElementValue, forKey: .type)
+            try container.encode(elementID, forKey: .elementID)
+            try container.encode(value, forKey: .value)
         case .selectMenuItem(let path, let bundleID):
             try container.encode(ActionType.selectMenuItem, forKey: .type)
             try container.encode(path, forKey: .path)

--- a/Sources/SwiftAutoGUI/AI/OpenAIVisionBackend.swift
+++ b/Sources/SwiftAutoGUI/AI/OpenAIVisionBackend.swift
@@ -86,6 +86,22 @@ public struct OpenAIVisionBackend: VisionActionGenerating, Sendable {
         history: [AgentStep],
         screenContext: ScreenContext?
     ) async throws -> AgentResponse {
+        try await generateActions(
+            goal: goal,
+            screenshot: Optional(screenshot),
+            screenSize: screenSize,
+            history: history,
+            screenContext: screenContext
+        )
+    }
+
+    public func generateActions(
+        goal: String,
+        screenshot: Data?,
+        screenSize: CGSize,
+        history: [AgentStep],
+        screenContext: ScreenContext?
+    ) async throws -> AgentResponse {
         let input = buildInput(
             goal: goal,
             screenshot: screenshot,
@@ -96,7 +112,11 @@ public struct OpenAIVisionBackend: VisionActionGenerating, Sendable {
 
         var requestBody: [String: Any] = [
             "model": model,
-            "instructions": Self.buildSystemPrompt(screenSize: screenSize, hasScreenContext: screenContext != nil),
+            "instructions": Self.buildSystemPrompt(
+                screenSize: screenSize,
+                hasScreenContext: screenContext != nil,
+                hasScreenshot: screenshot != nil
+            ),
             "input": input,
             "text": [
                 "format": [
@@ -157,7 +177,7 @@ public struct OpenAIVisionBackend: VisionActionGenerating, Sendable {
 extension OpenAIVisionBackend {
     private func buildInput(
         goal: String,
-        screenshot: Data,
+        screenshot: Data?,
         screenSize: CGSize,
         history: [AgentStep],
         screenContext: ScreenContext? = nil
@@ -167,14 +187,18 @@ extension OpenAIVisionBackend {
         // History steps
         for (index, step) in history.enumerated() {
             let actionSummary = step.actions.map { describeBasicAction($0) }.joined(separator: ", ")
+            let resultSummary = step.executionResults.map { result in
+                let status = result.succeeded ? "succeeded" : "failed"
+                let change = result.screenChanged ? ", UI changed" : ""
+                let reason = result.failureReason.map { ", reason: \($0)" } ?? ""
+                return "\(status) via \(result.method.rawValue)\(change)\(reason)"
+            }.joined(separator: "; ")
             input.append([
                 "role": "assistant",
-                "content": "Step \(index + 1): \(step.reasoning)\nActions executed: \(actionSummary)"
+                "content": "Step \(index + 1): \(step.reasoning)\nActions executed: \(actionSummary)" +
+                    (resultSummary.isEmpty ? "" : "\nExecution results: \(resultSummary)")
             ])
         }
-
-        // Current screenshot + goal + screen context
-        let base64 = screenshot.base64EncodedString()
 
         var userText = "Goal: \(goal)\n"
         if let context = screenContext {
@@ -182,21 +206,26 @@ extension OpenAIVisionBackend {
             userText += context.formatted()
             userText += "\n--- End Screen Context ---\n"
         }
-        userText += "\nThis is the current screenshot. What actions should I take next?"
+        userText += screenshot == nil
+            ? "\nUse the structured screen context to decide what actions to take next."
+            : "\nThis is the current screenshot. What actions should I take next?"
+
+        var content: [[String: Any]] = []
+        if let screenshot {
+            content.append([
+                "type": "input_image",
+                "image_url": "data:image/jpeg;base64,\(screenshot.base64EncodedString())",
+                "detail": "low"
+            ])
+        }
+        content.append([
+            "type": "input_text",
+            "text": userText
+        ])
 
         input.append([
             "role": "user",
-            "content": [
-                [
-                    "type": "input_image",
-                    "image_url": "data:image/jpeg;base64,\(base64)",
-                    "detail": "low"
-                ] as [String: Any],
-                [
-                    "type": "input_text",
-                    "text": userText
-                ] as [String: Any]
-            ] as [[String: Any]]
+            "content": content
         ] as [String: Any])
 
         return input
@@ -217,8 +246,12 @@ extension OpenAIVisionBackend {
             return "drag(\(Int(fromX)),\(Int(fromY)) -> \(Int(toX)),\(Int(toY)))"
         case .pressButton(let label, let bundleID):
             return "pressButton(\"\(label)\"\(bundleID.isEmpty ? "" : " in \(bundleID)"))"
+        case .pressElement(let elementID):
+            return "pressElement(#\(elementID))"
         case .setTextField(let label, let value, let bundleID):
             return "setTextField(label:\"\(label)\", value:\"\(value)\"\(bundleID.isEmpty ? "" : " in \(bundleID)"))"
+        case .setElementValue(let elementID, let value):
+            return "setElementValue(#\(elementID), value:\"\(value)\")"
         case .selectMenuItem(let path, let bundleID):
             return "selectMenuItem(\(path.joined(separator: " > "))\(bundleID.isEmpty ? "" : " in \(bundleID)"))"
         case .raiseWindow(let title, let bundleID):
@@ -238,10 +271,14 @@ extension OpenAIVisionBackend {
 // MARK: - System Prompt
 
 extension OpenAIVisionBackend {
-    static func buildSystemPrompt(screenSize: CGSize, hasScreenContext: Bool = false) -> String {
+    static func buildSystemPrompt(
+        screenSize: CGSize,
+        hasScreenContext: Bool = false,
+        hasScreenshot: Bool = true
+    ) -> String {
         var prompt = """
         You are an AI agent controlling a macOS computer to achieve a user's goal. \
-        You will receive screenshots of the current screen state and must decide what actions to take.
+        You will receive a current screen observation and must decide what actions to take.
 
         Screen size: \(Int(screenSize.width)) x \(Int(screenSize.height)) pixels (origin at top-left).
 
@@ -261,8 +298,12 @@ extension OpenAIVisionBackend {
         - drag: Drag mouse from one position to another. Parameters: fromX, fromY, toX, toY (numbers)
         - pressButton: Press a button by accessibility label (semantic, no coordinates needed). \
         Parameters: label (string, e.g. "OK"), bundleID (string, empty = frontmost app, otherwise e.g. "com.apple.calculator")
+        - pressElement: Press an actionable element from the current AX tree. \
+        Parameters: elementID (integer from a [#N] marker in the current screen context)
         - setTextField: Set a text field's value via accessibility. \
         Parameters: label (string, may be empty for role-only match), value (string), bundleID (string, empty = frontmost)
+        - setElementValue: Set the value of an actionable element from the current AX tree. \
+        Parameters: elementID (integer from a [#N] marker), value (string)
         - selectMenuItem: Select a menu item by hierarchical path. \
         Parameters: path (array of strings, e.g. ["File", "Save As…"]), bundleID (string, empty = frontmost)
         - raiseWindow: Bring a window to the front by title. \
@@ -273,25 +314,29 @@ extension OpenAIVisionBackend {
         - getFrontmostApp: Get the name of the frontmost application. No additional parameters needed.
 
         Prefer openURL/activateApp/quitApp and the AX-based actions \
-        (pressButton, setTextField, selectMenuItem, raiseWindow) when applicable. \
+        (pressElement, setElementValue, pressButton, setTextField, selectMenuItem, raiseWindow) when applicable. \
         They are more reliable than coordinate-based clicks.
 
         Instructions:
-        1. Analyze the screenshot to understand the current screen state.
+        1. Analyze the current observation to understand the screen state.
         2. Decide the next action(s) to move toward the goal.
         3. Set isDone to true ONLY when the goal has been fully achieved.
         4. Provide brief reasoning about what you see and why you chose these actions.
-        5. Use move + leftClick to click on UI elements. First move to the element, then click.
+        5. When no semantic element action is available, use move + leftClick. First move to the element, then click.
         6. Keep action sequences short (1-3 actions per step) to allow re-observation.
 
         Respond with a JSON object containing "reasoning", "isDone", and "actions" fields.
         """
 
+        if !hasScreenshot {
+            prompt += "\n\nNo screenshot is included in this step. Use only the structured screen context and prior execution results."
+        }
+
         if hasScreenContext {
             prompt += """
 
 
-            You will also receive structured screen context alongside the screenshot. This includes:
+            You will also receive structured screen context in the observation. This includes:
             - The frontmost application name and bundle identifier
             - The current keyboard input source / IME mode (e.g., "U.S.", "日本語ローマ字")
             - A list of visible windows with their titles, owning apps, and screen bounds
@@ -301,6 +346,9 @@ extension OpenAIVisionBackend {
             give exact coordinates you can use with move/click actions. Prefer using accessibility tree \
             coordinates over guessing positions from the screenshot when available. \
             The accessibility tree may be truncated ([...]) for deeply nested elements.
+
+            Actionable AX elements are marked [#N] and list their supported actions. Prefer pressElement \
+            and setElementValue with these step-local IDs. Never reuse an element ID from an older step.
 
             When the keyboard input source indicates a non-ASCII input mode (e.g., Japanese), \
             consider switching to an ASCII-capable source before using the 'write' action for English text. \
@@ -355,11 +403,18 @@ extension OpenAIVisionBackend {
             let label = dict["label"] as? String ?? ""
             let bundleID = dict["bundleID"] as? String ?? ""
             return .pressButton(label: label, bundleID: bundleID)
+        case "pressElement":
+            let elementID = (dict["elementID"] as? NSNumber)?.intValue ?? 0
+            return .pressElement(elementID: elementID)
         case "setTextField":
             let label = dict["label"] as? String ?? ""
             let value = dict["value"] as? String ?? ""
             let bundleID = dict["bundleID"] as? String ?? ""
             return .setTextField(label: label, value: value, bundleID: bundleID)
+        case "setElementValue":
+            let elementID = (dict["elementID"] as? NSNumber)?.intValue ?? 0
+            let value = dict["value"] as? String ?? ""
+            return .setElementValue(elementID: elementID, value: value)
         case "selectMenuItem":
             let path = dict["path"] as? [String] ?? []
             let bundleID = dict["bundleID"] as? String ?? ""
@@ -462,7 +517,7 @@ extension OpenAIVisionBackend {
                 "description": "The action type.",
                 "enum": ["write", "move", "leftClick", "rightClick", "doubleClick",
                          "vscroll", "hscroll", "wait", "keyShortcut", "drag",
-                         "pressButton", "setTextField", "selectMenuItem", "raiseWindow",
+                         "pressButton", "pressElement", "setTextField", "setElementValue", "selectMenuItem", "raiseWindow",
                          "openURL", "activateApp", "quitApp", "getFrontmostApp"]
             ] as [String: Any],
             "text": ["type": ["string", "null"], "description": "Text to type. Used with 'write' action."] as [String: Any],
@@ -480,12 +535,13 @@ extension OpenAIVisionBackend {
             "path": ["type": ["array", "null"], "description": "Menu path components, e.g. [\"File\", \"Save As…\"]. Used with 'selectMenuItem'.", "items": ["type": "string"]] as [String: Any],
             "title": ["type": ["string", "null"], "description": "Window title. Used with 'raiseWindow'."] as [String: Any],
             "bundleID": ["type": ["string", "null"], "description": "Bundle identifier of the target app, or empty/null for frontmost. Used with all AX actions."] as [String: Any],
+            "elementID": ["type": ["integer", "null"], "description": "Step-local [#N] element identifier. Used with element actions."] as [String: Any],
             "url": ["type": ["string", "null"], "description": "HTTP or HTTPS URL. Used with 'openURL'."] as [String: Any],
             "name": ["type": ["string", "null"], "description": "Application name. Used with 'activateApp' and 'quitApp'."] as [String: Any],
         ] as [String: Any],
         "required": ["type", "text", "x", "y", "clicks", "duration", "keys",
                      "fromX", "fromY", "toX", "toY",
-                     "label", "value", "path", "title", "bundleID", "url", "name"],
+                     "label", "value", "path", "title", "bundleID", "elementID", "url", "name"],
         "additionalProperties": false
     ] as [String: Any]
 

--- a/Sources/SwiftAutoGUI/AI/ScreenContext.swift
+++ b/Sources/SwiftAutoGUI/AI/ScreenContext.swift
@@ -25,14 +25,39 @@ public struct ScreenContext: Sendable, Codable {
     /// The accessibility tree of the focused window (nil if unavailable).
     public let focusedWindowAXTree: AXNode?
 
+    /// The element that currently owns keyboard focus, if exposed by Accessibility.
+    public let focusedElement: FocusedElementInfo?
+
     /// The current keyboard input source / IME mode (nil if unavailable).
     public let keyboardInputSource: InputSourceInfo?
 
-    public init(frontmostApp: AppInfo?, visibleWindows: [WindowInfo], focusedWindowAXTree: AXNode?, keyboardInputSource: InputSourceInfo? = nil) {
+    public init(
+        frontmostApp: AppInfo?,
+        visibleWindows: [WindowInfo],
+        focusedWindowAXTree: AXNode?,
+        keyboardInputSource: InputSourceInfo? = nil,
+        focusedElement: FocusedElementInfo? = nil
+    ) {
         self.frontmostApp = frontmostApp
         self.visibleWindows = visibleWindows
         self.focusedWindowAXTree = focusedWindowAXTree
         self.keyboardInputSource = keyboardInputSource
+        self.focusedElement = focusedElement
+    }
+}
+
+/// Compact identity of the UI element that currently owns keyboard focus.
+public struct FocusedElementInfo: Sendable, Codable, Equatable {
+    public let role: String
+    public let label: String?
+    public let value: String?
+    public let frame: CodableRect
+
+    public init(role: String, label: String?, value: String?, frame: CodableRect) {
+        self.role = role
+        self.label = label
+        self.value = value
+        self.frame = frame
     }
 }
 
@@ -85,6 +110,20 @@ public struct WindowInfo: Sendable, Codable {
 /// Represents a single UI element with its role, label, value, position, and children.
 /// The tree is depth- and node-limited to control token usage when sent to an LLM.
 public struct AXNode: Sendable, Codable {
+    private enum CodingKeys: String, CodingKey {
+        case elementID, path, actions, role, label, value, frame, isEnabled, children
+    }
+    /// Step-local identifier used by an agent to target this element.
+    /// Only actionable elements receive an identifier.
+    public let elementID: Int?
+
+    /// Child-index path from the focused window, used to resolve a live element.
+    public let path: [Int]
+
+    /// Accessibility actions advertised by the element. `AXSetValue` is added
+    /// when the value attribute is writable.
+    public let actions: [String]
+
     /// The accessibility role (e.g. "AXButton", "AXTextField", "AXWindow").
     public let role: String
 
@@ -104,13 +143,39 @@ public struct AXNode: Sendable, Codable {
     /// An empty array means the element genuinely has no children.
     public let children: [AXNode]?
 
-    public init(role: String, label: String?, value: String?, frame: CodableRect, isEnabled: Bool, children: [AXNode]?) {
+    public init(
+        role: String,
+        label: String?,
+        value: String?,
+        frame: CodableRect,
+        isEnabled: Bool,
+        children: [AXNode]?,
+        elementID: Int? = nil,
+        path: [Int] = [],
+        actions: [String] = []
+    ) {
+        self.elementID = elementID
+        self.path = path
+        self.actions = actions
         self.role = role
         self.label = label
         self.value = value
         self.frame = frame
         self.isEnabled = isEnabled
         self.children = children
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        elementID = try container.decodeIfPresent(Int.self, forKey: .elementID)
+        path = try container.decodeIfPresent([Int].self, forKey: .path) ?? []
+        actions = try container.decodeIfPresent([String].self, forKey: .actions) ?? []
+        role = try container.decode(String.self, forKey: .role)
+        label = try container.decodeIfPresent(String.self, forKey: .label)
+        value = try container.decodeIfPresent(String.self, forKey: .value)
+        frame = try container.decode(CodableRect.self, forKey: .frame)
+        isEnabled = try container.decode(Bool.self, forKey: .isEnabled)
+        children = try container.decodeIfPresent([AXNode].self, forKey: .children)
     }
 }
 
@@ -179,16 +244,25 @@ public struct ScreenContextProvider: Sendable {
         let inputSource = gatherKeyboardInputSource()
 
         var axTree: AXNode?
+        var focusedElement: FocusedElementInfo?
         if options.includeAXTree, let app = frontmostApp {
             var nodeCount = 0
-            axTree = gatherAXTree(pid: app.pid, options: options, nodeCount: &nodeCount)
+            var nextElementID = 1
+            axTree = gatherAXTree(
+                pid: app.pid,
+                options: options,
+                nodeCount: &nodeCount,
+                nextElementID: &nextElementID
+            )
+            focusedElement = gatherFocusedElement(pid: app.pid, maxValueLength: options.maxValueLength)
         }
 
         return ScreenContext(
             frontmostApp: frontmostApp,
             visibleWindows: visibleWindows,
             focusedWindowAXTree: axTree,
-            keyboardInputSource: inputSource
+            keyboardInputSource: inputSource,
+            focusedElement: focusedElement
         )
     }
 }
@@ -271,7 +345,12 @@ extension ScreenContextProvider {
 extension ScreenContextProvider {
 
     @MainActor
-    private static func gatherAXTree(pid: Int32, options: Options, nodeCount: inout Int) -> AXNode? {
+    private static func gatherAXTree(
+        pid: Int32,
+        options: Options,
+        nodeCount: inout Int,
+        nextElementID: inout Int
+    ) -> AXNode? {
         let appElement = AXUIElementCreateApplication(pid)
 
         // Get the focused window
@@ -288,7 +367,38 @@ extension ScreenContextProvider {
 
         // The CFTypeRef is actually an AXUIElement
         let axWindow = windowElement as! AXUIElement
-        return buildAXNode(from: axWindow, options: options, depth: 0, nodeCount: &nodeCount)
+        return buildAXNode(
+            from: axWindow,
+            options: options,
+            depth: 0,
+            path: [],
+            nodeCount: &nodeCount,
+            nextElementID: &nextElementID
+        )
+    }
+
+    @MainActor
+    private static func gatherFocusedElement(pid: Int32, maxValueLength: Int) -> FocusedElementInfo? {
+        let appElement = AXUIElementCreateApplication(pid)
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            appElement,
+            kAXFocusedUIElementAttribute as CFString,
+            &value
+        ) == .success, let value else { return nil }
+
+        let element = value as! AXUIElement
+        let rawValue = axStringAttribute(element, kAXValueAttribute)
+        let truncated = rawValue.map {
+            $0.count > maxValueLength ? String($0.prefix(maxValueLength)) + "..." : $0
+        }
+        return FocusedElementInfo(
+            role: axStringAttribute(element, kAXRoleAttribute) ?? "AXUnknown",
+            label: axStringAttribute(element, kAXTitleAttribute)
+                ?? axStringAttribute(element, kAXDescriptionAttribute),
+            value: truncated,
+            frame: CodableRect(axFrame(element) ?? .zero)
+        )
     }
 
     @MainActor
@@ -296,7 +406,9 @@ extension ScreenContextProvider {
         from element: AXUIElement,
         options: Options,
         depth: Int,
-        nodeCount: inout Int
+        path: [Int],
+        nodeCount: inout Int,
+        nextElementID: inout Int
     ) -> AXNode? {
         guard nodeCount < options.maxNodes else { return nil }
         nodeCount += 1
@@ -317,13 +429,31 @@ extension ScreenContextProvider {
 
         let frame = CodableRect(axFrame(element) ?? .zero)
         let isEnabled = axBoolAttribute(element, kAXEnabledAttribute) ?? true
+        var actions = axActionNames(element).sorted()
+        if axIsAttributeSettable(element, kAXValueAttribute), !actions.contains("AXSetValue") {
+            actions.append("AXSetValue")
+        }
+        let elementID: Int?
+        if !actions.isEmpty {
+            elementID = nextElementID
+            nextElementID += 1
+        } else {
+            elementID = nil
+        }
 
         // Get children if within depth limit
         let children: [AXNode]?
         if depth < options.maxDepth {
             if let childArray = axChildren(element) {
-                children = childArray.compactMap { child in
-                    buildAXNode(from: child, options: options, depth: depth + 1, nodeCount: &nodeCount)
+                children = childArray.enumerated().compactMap { index, child in
+                    buildAXNode(
+                        from: child,
+                        options: options,
+                        depth: depth + 1,
+                        path: path + [index],
+                        nodeCount: &nodeCount,
+                        nextElementID: &nextElementID
+                    )
                 }
             } else {
                 children = []
@@ -343,7 +473,10 @@ extension ScreenContextProvider {
             value: value,
             frame: frame,
             isEnabled: isEnabled,
-            children: children
+            children: children,
+            elementID: elementID,
+            path: path,
+            actions: actions
         )
     }
 }
@@ -369,6 +502,11 @@ extension ScreenContext {
             lines.append("Keyboard input source: \(inputSource.localizedName) (\(inputSource.id))")
         }
 
+        if let focusedElement {
+            let label = focusedElement.label.map { " \"\($0)\"" } ?? ""
+            lines.append("Focused element: \(focusedElement.role)\(label)")
+        }
+
         // Visible windows
         if !visibleWindows.isEmpty {
             lines.append("Visible windows:")
@@ -392,7 +530,11 @@ extension ScreenContext {
 extension AXNode {
     func appendFormatted(to lines: inout [String], indent: Int) {
         let prefix = String(repeating: "  ", count: indent)
-        var parts: [String] = [role]
+        var parts: [String] = []
+        if let elementID {
+            parts.append("[#\(elementID)]")
+        }
+        parts.append(role)
 
         if let label = label, !label.isEmpty {
             parts.append("\"\(label)\"")
@@ -411,6 +553,10 @@ extension AXNode {
             parts.append("disabled")
         }
 
+        if !actions.isEmpty {
+            parts.append("actions=[\(actions.joined(separator: ","))]")
+        }
+
         lines.append(prefix + parts.joined(separator: " "))
 
         if let children = children {
@@ -421,5 +567,85 @@ extension AXNode {
             // nil children means pruned
             lines.append(prefix + "  [...]")
         }
+    }
+
+
+    /// Returns the actionable node with the given step-local identifier.
+    public func node(withID id: Int) -> AXNode? {
+        if elementID == id { return self }
+        for child in children ?? [] {
+            if let match = child.node(withID: id) { return match }
+        }
+        return nil
+    }
+}
+
+extension ScreenContext {
+    /// A deterministic summary used to detect meaningful UI changes between actions.
+    public var stateFingerprint: String {
+        var lines: [String] = []
+        if let app = frontmostApp {
+            lines.append("app:\(app.pid):\(app.bundleIdentifier ?? app.name)")
+        }
+        focusedWindowAXTree?.appendFingerprint(to: &lines)
+        return lines.joined(separator: "\n")
+    }
+
+    /// Number of elements that can be targeted by an element-ID action.
+    public var actionableElementCount: Int {
+        focusedWindowAXTree?.actionableElementCount ?? 0
+    }
+}
+
+private extension AXNode {
+    var actionableElementCount: Int {
+        (elementID == nil ? 0 : 1) + (children ?? []).reduce(0) { $0 + $1.actionableElementCount }
+    }
+
+    func appendFingerprint(to lines: inout [String]) {
+        lines.append("\(path):\(role):\(label ?? ""):\(value ?? ""):\(isEnabled):\(Int(frame.x)),\(Int(frame.y)),\(Int(frame.width)),\(Int(frame.height))")
+        for child in children ?? [] { child.appendFingerprint(to: &lines) }
+    }
+}
+
+extension ScreenContextProvider {
+    /// Resolves a step-local element ID against the current live AX hierarchy.
+    /// Returns `nil` if the hierarchy changed or the resolved element no longer
+    /// matches the observed role and label.
+    @MainActor
+    public static func resolveElement(id: Int, in context: ScreenContext) -> AXUIElement? {
+        guard let observed = context.focusedWindowAXTree?.node(withID: id),
+              let pid = context.frontmostApp?.pid,
+              NSWorkspace.shared.frontmostApplication?.processIdentifier == pid else { return nil }
+
+        let app = AXUIElementCreateApplication(pid)
+        var windowValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            app,
+            kAXFocusedWindowAttribute as CFString,
+            &windowValue
+        ) == .success, let windowValue else { return nil }
+
+        var current = windowValue as! AXUIElement
+        for index in observed.path {
+            guard let children = axChildren(current), children.indices.contains(index) else { return nil }
+            current = children[index]
+        }
+
+        let currentRole = axStringAttribute(current, kAXRoleAttribute) ?? "AXUnknown"
+        let currentLabel = axStringAttribute(current, kAXTitleAttribute)
+            ?? axStringAttribute(current, kAXDescriptionAttribute)
+        guard currentRole == observed.role, currentLabel == observed.label else { return nil }
+
+        if observed.frame.width > 0 || observed.frame.height > 0 {
+            guard let currentFrame = axFrame(current),
+                  abs(currentFrame.minX - observed.frame.cgRect.minX) <= 2,
+                  abs(currentFrame.minY - observed.frame.cgRect.minY) <= 2,
+                  abs(currentFrame.width - observed.frame.cgRect.width) <= 2,
+                  abs(currentFrame.height - observed.frame.cgRect.height) <= 2 else {
+                return nil
+            }
+        }
+        return current
     }
 }

--- a/Sources/SwiftAutoGUI/AI/VisionActionGenerating.swift
+++ b/Sources/SwiftAutoGUI/AI/VisionActionGenerating.swift
@@ -76,6 +76,39 @@ extension VisionActionGenerating {
             history: history
         )
     }
+
+    /// Generates actions when a screenshot may be omitted. Backends that can
+    /// operate from structured context alone should override this overload.
+    public func generateActions(
+        goal: String,
+        screenshot: Data?,
+        screenSize: CGSize,
+        history: [AgentStep],
+        screenContext: ScreenContext?
+    ) async throws -> AgentResponse {
+        guard let screenshot else {
+            throw ActionGeneratorError.invalidResponse(
+                detail: "This vision backend requires a screenshot. Use AgentVisionMode.always."
+            )
+        }
+        return try await generateActions(
+            goal: goal,
+            screenshot: screenshot,
+            screenSize: screenSize,
+            history: history,
+            screenContext: screenContext
+        )
+    }
+}
+
+/// Controls when ``Agent`` includes a screenshot in an observation.
+public enum AgentVisionMode: String, Sendable, Codable, CaseIterable {
+    /// Always capture a screenshot. This preserves the original Agent behavior.
+    case always
+    /// Omit the screenshot when actionable AX elements are available.
+    case automatic
+    /// Use structured screen context without a screenshot.
+    case never
 }
 
 // MARK: - Agent Types
@@ -88,12 +121,21 @@ public struct AgentStep: Sendable {
     /// The LLM's reasoning about what it observed and decided.
     public let reasoning: String
 
+    /// Structured outcomes for the actions that were actually executed.
+    public let executionResults: [ActionExecutionResult]
+
     /// When this step occurred.
     public let timestamp: Date
 
-    public init(actions: [BasicAction], reasoning: String, timestamp: Date = Date()) {
+    public init(
+        actions: [BasicAction],
+        reasoning: String,
+        executionResults: [ActionExecutionResult] = [],
+        timestamp: Date = Date()
+    ) {
         self.actions = actions
         self.reasoning = reasoning
+        self.executionResults = executionResults
         self.timestamp = timestamp
     }
 }

--- a/Sources/SwiftAutoGUI/Accessibility/AXAttributes.swift
+++ b/Sources/SwiftAutoGUI/Accessibility/AXAttributes.swift
@@ -79,3 +79,9 @@ internal func axActionNames(_ element: AXUIElement) -> [String] {
     guard result == .success, let names = namesRef as? [String] else { return [] }
     return names
 }
+
+internal func axIsAttributeSettable(_ element: AXUIElement, _ attribute: String) -> Bool {
+    var settable = DarwinBoolean(false)
+    let result = AXUIElementIsAttributeSettable(element, attribute as CFString, &settable)
+    return result == .success && settable.boolValue
+}

--- a/Sources/SwiftAutoGUI/Actions/Agent.swift
+++ b/Sources/SwiftAutoGUI/Actions/Agent.swift
@@ -43,6 +43,9 @@ public struct Agent: Sendable {
     /// Set to `nil` to disable screen context gathering entirely.
     public let screenContextOptions: ScreenContextProvider.Options?
 
+    /// Controls whether screenshots accompany structured screen context.
+    public let visionMode: AgentVisionMode
+
     /// Creates an agent with the specified configuration.
     ///
     /// - Parameters:
@@ -51,16 +54,19 @@ public struct Agent: Sendable {
     ///   - delayBetweenSteps: Seconds to wait between steps (default: 1.0).
     ///   - screenContextOptions: Options for screen context gathering (default: enabled with defaults).
     ///     Pass `nil` to disable.
+    ///   - visionMode: Controls when screenshots are included (default: ``AgentVisionMode/always``).
     public init(
         backend: any VisionActionGenerating,
         maxIterations: Int = 20,
         delayBetweenSteps: TimeInterval = 1.0,
-        screenContextOptions: ScreenContextProvider.Options? = ScreenContextProvider.Options()
+        screenContextOptions: ScreenContextProvider.Options? = ScreenContextProvider.Options(),
+        visionMode: AgentVisionMode = .always
     ) {
         self.backend = backend
         self.maxIterations = maxIterations
         self.delayBetweenSteps = delayBetweenSteps
         self.screenContextOptions = screenContextOptions
+        self.visionMode = visionMode
     }
 
     /// Runs the agent loop to achieve the given goal.
@@ -86,19 +92,34 @@ public struct Agent: Sendable {
         for _ in 0..<maxIterations {
             try Task.checkCancellation()
 
-            // 1. Observe: take screenshot
-            guard let screenshot = try await SwiftAutoGUI.screenshot(),
-                  let jpegData = screenshot.jpegData(compressionFactor: 0.5) else {
-                throw ActionGeneratorError.invalidResponse(detail: "Failed to capture screenshot")
+            // 1. Observe structured screen state first.
+            let screenContext: ScreenContext? = screenContextOptions.map { options in
+                ScreenContextProvider.gather(options: options)
+            }
+
+            let includeScreenshot: Bool
+            switch visionMode {
+            case .always:
+                includeScreenshot = true
+            case .automatic:
+                includeScreenshot = screenContext?.actionableElementCount == 0
+            case .never:
+                includeScreenshot = false
+            }
+
+            let jpegData: Data?
+            if includeScreenshot {
+                guard let screenshot = try await SwiftAutoGUI.screenshot(),
+                      let data = screenshot.jpegData(compressionFactor: 0.5) else {
+                    throw ActionGeneratorError.invalidResponse(detail: "Failed to capture screenshot")
+                }
+                jpegData = data
+            } else {
+                jpegData = nil
             }
 
             let screenSize = SwiftAutoGUI.size()
             let screenCGSize = CGSize(width: screenSize.width, height: screenSize.height)
-
-            // 1b. Gather screen context (if enabled)
-            let screenContext: ScreenContext? = screenContextOptions.map { options in
-                ScreenContextProvider.gather(options: options)
-            }
 
             // 2. Think: send to backend
             let response = try await backend.generateActions(
@@ -109,14 +130,31 @@ public struct Agent: Sendable {
                 screenContext: screenContext
             )
 
-            // 3. Act: execute actions
-            let actions = response.actions.map { $0.toAction() }
-            await actions.execute()
+            // 3. Act: execute against the observation used by the model. Stop
+            // as soon as the UI changes or an action fails, then re-observe.
+            var currentContext = screenContext
+            var executedActions: [BasicAction] = []
+            var executionResults: [ActionExecutionResult] = []
+            for action in response.actions {
+                let execution = await AgentActionExecutor.execute(
+                    action,
+                    in: currentContext,
+                    screenContextOptions: screenContextOptions
+                )
+                executedActions.append(action)
+                executionResults.append(execution.result)
+                currentContext = execution.screenContext
+
+                if !execution.result.succeeded || execution.result.screenChanged {
+                    break
+                }
+            }
 
             // 4. Record step
             let step = AgentStep(
-                actions: response.actions,
-                reasoning: response.reasoning
+                actions: executedActions,
+                reasoning: response.reasoning,
+                executionResults: executionResults
             )
             steps.append(step)
             onStep?(step)

--- a/Sources/SwiftAutoGUI/Actions/AgentActionExecutor.swift
+++ b/Sources/SwiftAutoGUI/Actions/AgentActionExecutor.swift
@@ -1,0 +1,147 @@
+//
+//  AgentActionExecutor.swift
+//  SwiftAutoGUI
+//
+
+import ApplicationServices
+import Foundation
+
+/// How an agent action was executed.
+public enum AgentActionExecutionMethod: String, Sendable, Codable {
+    case accessibility
+    case cgEvent
+    case standardAction
+    case none
+}
+
+/// Structured result for a single action executed by ``Agent``.
+public struct ActionExecutionResult: Sendable, Codable {
+    public let action: BasicAction
+    public let succeeded: Bool
+    public let method: AgentActionExecutionMethod
+    public let failureReason: String?
+    public let screenChanged: Bool
+    public let focusedAppChanged: Bool
+    public let focusedElementChanged: Bool
+
+    public init(
+        action: BasicAction,
+        succeeded: Bool,
+        method: AgentActionExecutionMethod,
+        failureReason: String? = nil,
+        screenChanged: Bool = false,
+        focusedAppChanged: Bool = false,
+        focusedElementChanged: Bool = false
+    ) {
+        self.action = action
+        self.succeeded = succeeded
+        self.method = method
+        self.failureReason = failureReason
+        self.screenChanged = screenChanged
+        self.focusedAppChanged = focusedAppChanged
+        self.focusedElementChanged = focusedElementChanged
+    }
+}
+
+/// The action result together with the observation captured after execution.
+public struct AgentActionExecution: Sendable {
+    public let result: ActionExecutionResult
+    public let screenContext: ScreenContext?
+
+    public init(result: ActionExecutionResult, screenContext: ScreenContext?) {
+        self.result = result
+        self.screenContext = screenContext
+    }
+}
+
+/// Executes agent actions against the exact ``ScreenContext`` used to generate
+/// them. Element-ID actions are resolved just before execution so stale UI
+/// references fail safely instead of clicking an unrelated coordinate.
+public enum AgentActionExecutor {
+    @MainActor
+    public static func execute(
+        _ action: BasicAction,
+        in observation: ScreenContext?,
+        screenContextOptions: ScreenContextProvider.Options? = ScreenContextProvider.Options(),
+        observationDelay: TimeInterval = 0.15
+    ) async -> AgentActionExecution {
+        let execution = await perform(action, in: observation)
+
+        if observationDelay > 0 {
+            try? await Task.sleep(for: .seconds(observationDelay))
+        }
+
+        let updatedContext = screenContextOptions.map { ScreenContextProvider.gather(options: $0) }
+        let screenChanged = observation?.stateFingerprint != updatedContext?.stateFingerprint
+        let focusedAppChanged = observation?.frontmostApp?.pid != updatedContext?.frontmostApp?.pid
+        let focusedElementChanged = observation?.focusedElement != updatedContext?.focusedElement
+
+        return AgentActionExecution(
+            result: ActionExecutionResult(
+                action: action,
+                succeeded: execution.succeeded,
+                method: execution.method,
+                failureReason: execution.failureReason,
+                screenChanged: observation != nil && updatedContext != nil && screenChanged,
+                focusedAppChanged: observation != nil && updatedContext != nil && focusedAppChanged,
+                focusedElementChanged: observation != nil && updatedContext != nil && focusedElementChanged
+            ),
+            screenContext: updatedContext
+        )
+    }
+
+    @MainActor
+    private static func perform(
+        _ action: BasicAction,
+        in observation: ScreenContext?
+    ) async -> (succeeded: Bool, method: AgentActionExecutionMethod, failureReason: String?) {
+        switch action {
+        case .pressElement(let elementID):
+            guard elementID > 0,
+                  let observation,
+                  let node = observation.focusedWindowAXTree?.node(withID: elementID) else {
+                return (false, .none, "Element #\(elementID) is not present in the current observation.")
+            }
+            guard node.isEnabled else {
+                return (false, .none, "Element #\(elementID) is disabled.")
+            }
+            guard let element = ScreenContextProvider.resolveElement(id: elementID, in: observation) else {
+                return (false, .none, "Element #\(elementID) became stale; observe the screen again.")
+            }
+
+            if node.actions.contains(kAXPressAction), AXAction.press(element) {
+                return (true, .accessibility, nil)
+            }
+            let frame = AXAction.frame(of: element) ?? node.frame.cgRect
+            guard frame.width > 0, frame.height > 0 else {
+                return (false, .none, "Element #\(elementID) has no clickable frame and AXPress failed.")
+            }
+            SwiftAutoGUI.click(at: CGPoint(x: frame.midX, y: frame.midY))
+            return (true, .cgEvent, nil)
+
+        case .setElementValue(let elementID, let value):
+            guard elementID > 0,
+                  let observation,
+                  let node = observation.focusedWindowAXTree?.node(withID: elementID) else {
+                return (false, .none, "Element #\(elementID) is not present in the current observation.")
+            }
+            guard node.isEnabled else {
+                return (false, .none, "Element #\(elementID) is disabled.")
+            }
+            guard node.actions.contains("AXSetValue") else {
+                return (false, .none, "Element #\(elementID) does not expose a writable value.")
+            }
+            guard let element = ScreenContextProvider.resolveElement(id: elementID, in: observation) else {
+                return (false, .none, "Element #\(elementID) became stale; observe the screen again.")
+            }
+            guard AXAction.setValue(element, value: value) else {
+                return (false, .accessibility, "Setting the value of element #\(elementID) failed.")
+            }
+            return (true, .accessibility, nil)
+
+        default:
+            _ = await action.toAction().execute()
+            return (true, .standardAction, nil)
+        }
+    }
+}

--- a/Sources/SwiftAutoGUI/Documentation.docc/SwiftAutoGUI.md
+++ b/Sources/SwiftAutoGUI/Documentation.docc/SwiftAutoGUI.md
@@ -47,7 +47,7 @@ SwiftAutoGUI includes an ``Agent`` that can autonomously observe the screen, rea
 import SwiftAutoGUI
 
 let backend = OpenAIVisionBackend(apiKey: "sk-...", model: "gpt-5.6-sol")
-let agent = Agent(backend: backend, maxIterations: 15)
+let agent = Agent(backend: backend, maxIterations: 15, visionMode: .automatic)
 
 let result = try await agent.run(goal: "Open Safari and search for Swift")
 print("Completed: \(result.completed), Steps: \(result.iterationsUsed)")
@@ -92,6 +92,9 @@ sagui agent "Open Safari and search for Swift" --api-key sk-...
 # With options
 sagui agent "Click the trash icon" --model gpt-5.6-sol --reasoning-effort low --max-iterations 15 --delay 2.0
 
+# Use AX-only observation when actionable elements are available
+sagui agent "Press the Save button" --vision-mode automatic
+
 # Using environment variable for the API key
 export OPENAI_API_KEY=sk-...
 sagui agent "Open Terminal"
@@ -101,6 +104,16 @@ The command prints the effective reasoning effort at startup and a `Reasoning:`
 summary for each step. `--reasoning-effort` accepts `none`, `low`, `medium`,
 `high`, `xhigh`, or `max`, and defaults to `low` for GPT-5.6 models. The step
 summary explains the selected actions; it is not the model's hidden chain of thought.
+
+With screen context enabled, actionable AX elements are formatted with step-local
+identifiers such as `[#12]`. Element actions are resolved against the live hierarchy
+immediately before execution, so stale targets fail safely. ``AgentStep`` includes
+structured execution results, and the Agent re-observes as soon as an action changes
+the UI instead of continuing a batch generated for the old state.
+
+`--vision-mode` accepts `always`, `automatic`, or `never`. The `automatic` mode
+omits screenshots when actionable AX elements are available. The default is `always`
+for backward compatibility.
 
 ## Action Pattern
 

--- a/Sources/sagui/AgentCommand.swift
+++ b/Sources/sagui/AgentCommand.swift
@@ -23,6 +23,12 @@ struct AgentCommand: AsyncParsableCommand {
         case max
     }
 
+    enum VisionMode: String, CaseIterable, ExpressibleByArgument {
+        case always
+        case automatic
+        case never
+    }
+
     static let defaultModel = OpenAIVisionBackend.defaultModel
 
     static let configuration = CommandConfiguration(
@@ -51,6 +57,9 @@ struct AgentCommand: AsyncParsableCommand {
     @Flag(help: "Disable screen context (accessibility tree and window info).")
     var noScreenContext: Bool = false
 
+    @Option(help: "Screenshot mode: always, automatic, or never.")
+    var visionMode: VisionMode = .always
+
     @MainActor
     func run() async throws {
         let key = apiKey ?? ProcessInfo.processInfo.environment["OPENAI_API_KEY"]
@@ -68,13 +77,15 @@ struct AgentCommand: AsyncParsableCommand {
             backend: backend,
             maxIterations: maxIterations,
             delayBetweenSteps: delay,
-            screenContextOptions: contextOptions
+            screenContextOptions: contextOptions,
+            visionMode: AgentVisionMode(rawValue: visionMode.rawValue) ?? .always
         )
 
         print("Agent starting with goal: \"\(goal)\"")
         print("Model: \(model)")
         print("Reasoning effort: \(effectiveReasoningEffort)")
         print("Max iterations: \(maxIterations), Delay: \(delay)s, Screen context: \(!noScreenContext)")
+        print("Vision mode: \(visionMode.rawValue)")
         print("---")
 
         let result = try await agent.run(goal: goal) { step in
@@ -84,6 +95,12 @@ struct AgentCommand: AsyncParsableCommand {
             let actionSummary = step.actions.map { "\($0)" }.joined(separator: ", ")
             print("[\(timestamp)] Reasoning: \(step.reasoning)")
             print("  Actions: \(actionSummary)")
+            for result in step.executionResults {
+                let status = result.succeeded ? "succeeded" : "failed"
+                let change = result.screenChanged ? ", UI changed" : ""
+                let reason = result.failureReason.map { ", \($0)" } ?? ""
+                print("  Result: \(status) via \(result.method.rawValue)\(change)\(reason)")
+            }
             print("---")
         }
 

--- a/Tests/SaguiTests/SaguiCommandTests.swift
+++ b/Tests/SaguiTests/SaguiCommandTests.swift
@@ -88,4 +88,26 @@ struct SaguiCommandTests {
             ])
         }
     }
+
+    @Test(
+        "Agent accepts every vision mode",
+        arguments: AgentCommand.VisionMode.allCases
+    )
+    func agentVisionMode(mode: AgentCommand.VisionMode) throws {
+        let command = try AgentCommand.parse([
+            "Inspect the frontmost app",
+            "--vision-mode", mode.rawValue,
+        ])
+        #expect(command.visionMode == mode)
+    }
+
+    @Test("Agent rejects an unknown vision mode")
+    func agentRejectsUnknownVisionMode() {
+        #expect(throws: (any Error).self) {
+            try AgentCommand.parse([
+                "Inspect the frontmost app",
+                "--vision-mode", "sometimes",
+            ])
+        }
+    }
 }

--- a/Tests/SwiftAutoGUITests/ActionGeneratorTests.swift
+++ b/Tests/SwiftAutoGUITests/ActionGeneratorTests.swift
@@ -691,6 +691,56 @@ struct ActionGeneratorTests {
             #expect(actionTypes?.contains("quitApp") == true)
             #expect(actionTypes?.contains("getFrontmostApp") == true)
         }
+
+        @Test("semantic element actions round-trip and parse")
+        func semanticElementActions() throws {
+            let press = try roundTrip(.pressElement(elementID: 12))
+            let setValue = try roundTrip(.setElementValue(elementID: 13, value: "Swift"))
+
+            guard case .pressElement(let pressID) = press,
+                  case .setElementValue(let valueID, let value) = setValue else {
+                Issue.record("Expected semantic element actions")
+                return
+            }
+            #expect(pressID == 12)
+            #expect(valueID == 13)
+            #expect(value == "Swift")
+
+            let parsedPress = OpenAIVisionBackend.parseAction(["type": "pressElement", "elementID": 21])
+            guard case .pressElement(let parsedID) = parsedPress else {
+                Issue.record("Expected parsed pressElement")
+                return
+            }
+            #expect(parsedID == 21)
+        }
+
+        @Test("OpenAI schema exposes semantic element fields")
+        func schemaIncludesSemanticElements() {
+            let schema = OpenAIVisionBackend.actionItemSchemaDict
+            let properties = schema["properties"] as? [String: Any]
+            let required = schema["required"] as? [String]
+            let typeProperty = properties?["type"] as? [String: Any]
+            let actionTypes = typeProperty?["enum"] as? [String]
+
+            #expect(properties?["elementID"] != nil)
+            #expect(required?.contains("elementID") == true)
+            #expect(actionTypes?.contains("pressElement") == true)
+            #expect(actionTypes?.contains("setElementValue") == true)
+        }
+
+        @Test("semantic action without an observation fails safely")
+        @MainActor
+        func semanticActionRequiresObservation() async {
+            let execution = await AgentActionExecutor.execute(
+                .pressElement(elementID: 1),
+                in: nil,
+                screenContextOptions: nil,
+                observationDelay: 0
+            )
+            #expect(!execution.result.succeeded)
+            #expect(execution.result.method == .none)
+            #expect(execution.result.failureReason?.contains("not present") == true)
+        }
     }
 }
 

--- a/Tests/SwiftAutoGUITests/ScreenContextTests.swift
+++ b/Tests/SwiftAutoGUITests/ScreenContextTests.swift
@@ -64,6 +64,23 @@ struct ScreenContextTests {
     @Suite("ScreenContext Formatting")
     struct FormattingTests {
 
+        @Test("decodes AX nodes written before semantic identifiers existed")
+        func legacyAXNodeDecoding() throws {
+            let json = """
+            {
+              "role": "AXButton",
+              "label": "OK",
+              "frame": {"x": 1, "y": 2, "width": 3, "height": 4},
+              "isEnabled": true,
+              "children": []
+            }
+            """
+            let node = try JSONDecoder().decode(AXNode.self, from: Data(json.utf8))
+            #expect(node.elementID == nil)
+            #expect(node.path.isEmpty)
+            #expect(node.actions.isEmpty)
+        }
+
         @Test("formats frontmost app")
         func frontmostApp() {
             let context = ScreenContext(
@@ -190,6 +207,61 @@ struct ScreenContextTests {
             )
             let output = context.formatted()
             #expect(output.contains("AXTextField \"Search\" value=\"hello world\" {100,50 200x22}"))
+        }
+
+        @Test("formats and resolves actionable element identifiers")
+        func actionableElementIdentifiers() {
+            let button = AXNode(
+                role: "AXButton",
+                label: "Save",
+                value: nil,
+                frame: CodableRect(x: 10, y: 20, width: 80, height: 30),
+                isEnabled: true,
+                children: [],
+                elementID: 7,
+                path: [0, 2],
+                actions: ["AXPress"]
+            )
+            let tree = AXNode(
+                role: "AXWindow",
+                label: "Document",
+                value: nil,
+                frame: CodableRect(x: 0, y: 0, width: 500, height: 400),
+                isEnabled: true,
+                children: [button]
+            )
+            let context = ScreenContext(
+                frontmostApp: nil,
+                visibleWindows: [],
+                focusedWindowAXTree: tree
+            )
+
+            #expect(context.formatted().contains("[#7] AXButton \"Save\""))
+            #expect(context.formatted().contains("actions=[AXPress]"))
+            #expect(context.actionableElementCount == 1)
+            #expect(tree.node(withID: 7)?.path == [0, 2])
+            #expect(tree.node(withID: 999) == nil)
+        }
+
+        @Test("fingerprint changes with semantic UI state")
+        func semanticFingerprint() {
+            func context(value: String) -> ScreenContext {
+                ScreenContext(
+                    frontmostApp: AppInfo(name: "Example", bundleIdentifier: "com.example", pid: 1),
+                    visibleWindows: [],
+                    focusedWindowAXTree: AXNode(
+                        role: "AXTextField",
+                        label: "Name",
+                        value: value,
+                        frame: CodableRect(x: 0, y: 0, width: 100, height: 20),
+                        isEnabled: true,
+                        children: []
+                    )
+                )
+            }
+
+            #expect(context(value: "before").stateFingerprint != context(value: "after").stateFingerprint)
+            #expect(context(value: "same").stateFingerprint == context(value: "same").stateFingerprint)
         }
 
         @Test("formats pruned subtree with [...]")

--- a/plugins/swift-auto-gui/skills/macos-control/SKILL.md
+++ b/plugins/swift-auto-gui/skills/macos-control/SKILL.md
@@ -168,11 +168,12 @@ sagui screen locate-center button.png                      # Find image center (
 sagui agent "Open Safari and search for Swift"                    # Uses OPENAI_API_KEY and default model
 sagui agent "Click the submit button" --api-key sk-...            # Run with OpenAI
 sagui agent "Fill in the form" --model gpt-5.6-sol --reasoning-effort low --max-iterations 10
+sagui agent "Press the Save button" --vision-mode automatic       # Prefer semantic AX elements when available
 ```
 
 | Required | Optional |
 |---|---|
-| `<goal>` (string) | `--api-key <key>` (or `OPENAI_API_KEY` env), `--model <model>` (default: `gpt-5.6-sol`), `--reasoning-effort <none|low|medium|high|xhigh|max>` (default: `low` for GPT-5.6), `--max-iterations <n>` (default: 20), `--delay <seconds>` (default: 1.0), `--no-screen-context` |
+| `<goal>` (string) | `--api-key <key>` (or `OPENAI_API_KEY` env), `--model <model>` (default: `gpt-5.6-sol`), `--reasoning-effort <none|low|medium|high|xhigh|max>` (default: `low` for GPT-5.6), `--vision-mode <always|automatic|never>` (default: `always`), `--max-iterations <n>` (default: 20), `--delay <seconds>` (default: 1.0), `--no-screen-context` |
 
 The command prints the effective reasoning effort at startup and a concise
 `Reasoning:` summary for every step. This summary explains the selected actions;


### PR DESCRIPTION
## Summary

- assign step-local identifiers to actionable Accessibility elements
- add semantic pressElement and setElementValue agent actions
- resolve observed elements immediately before execution and reject stale targets
- return structured execution results and re-observe after semantic UI changes
- add always, automatic, and never screenshot modes to Agent and sagui
- add an Element Action Observer to the Sample app
- update README, DocC, CLI help, and the bundled macos-control skill

## Implementation details

Actionable AX nodes now include a numbered identifier, hierarchy path, and supported actions. The Agent prefers Accessibility actions, falls back to a positioned CGEvent click when AXPress fails, and validates the frontmost process, role, label, and frame before acting.

Each action produces an ActionExecutionResult with its success state, execution method, failure reason, screen change, focused app change, and focused element change. When an action fails or changes the semantic UI state, the remaining actions generated for the old observation are skipped.

The default vision mode remains always for backward compatibility. Automatic mode omits the screenshot when actionable AX context is available.

## Validation

- swift test: 159 tests passed
- swift build -c release
- Sample macOS build with code signing disabled
- swift package generate-documentation
- git diff --check

## Compatibility

Existing Agent initialization, BasicAction cases, and CLI behavior remain available. The default screenshot behavior is unchanged.

## Related

- #118 tracks a future optional CDP backend for Chromium automation.