### PR TITLE
Fix tiled image recognition Metal crash

### DIFF
--- a/Sample/Sample/Features/ImageRecognition/ImageRecognitionView.swift
+++ b/Sample/Sample/Features/ImageRecognition/ImageRecognitionView.swift
@@ -18,6 +18,10 @@ struct ImageRecognitionView: View {
             Button("Create Test Image") {
                 viewModel.createTestImageForRecognition()
             }
+
+            Button("Create Tiled Matcher Test Image") {
+                viewModel.createTiledTestImageForRecognition()
+            }
             
             Button("Locate Test Image on Screen") {
                 viewModel.locateTestImage()

--- a/Sample/Sample/Features/ImageRecognition/ImageRecognitionViewModel.swift
+++ b/Sample/Sample/Features/ImageRecognition/ImageRecognitionViewModel.swift
@@ -13,6 +13,64 @@ import SwiftAutoGUI
 class ImageRecognitionViewModel {
     var imageRecognitionResult: String = ""
     var testImagePath: String = ""
+
+    func createTiledTestImageForRecognition() {
+        guard let bitmapImage = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: 64,
+            pixelsHigh: 64,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ), let context = NSGraphicsContext(bitmapImageRep: bitmapImage) else {
+            imageRecognitionResult = "Failed to create 64x64 test image bitmap"
+            return
+        }
+
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = context
+
+        NSColor.systemBlue.setFill()
+        NSRect(x: 0, y: 0, width: 64, height: 64).fill()
+
+        NSColor.white.setFill()
+        NSRect(x: 12, y: 12, width: 40, height: 40).fill()
+
+        NSColor.systemRed.setFill()
+        NSRect(x: 19, y: 19, width: 26, height: 26).fill()
+
+        NSColor.systemYellow.setFill()
+        NSBezierPath(ovalIn: NSRect(x: 26, y: 26, width: 12, height: 12)).fill()
+
+        context.flushGraphics()
+        NSGraphicsContext.restoreGraphicsState()
+
+        let documents = FileManager.default.urls(
+            for: .documentDirectory,
+            in: .userDomainMask
+        ).first!
+        let path = documents.appendingPathComponent(
+            "tiled_test_recognition_image.png"
+        ).path
+
+        if let pngData = bitmapImage.representation(using: .png, properties: [:]) {
+            do {
+                try pngData.write(to: URL(fileURLWithPath: path))
+                testImagePath = path
+                imageRecognitionResult = """
+                    Tiled matcher test image created at: \(path)
+                    Pixel size: \(bitmapImage.pixelsWide)x\(bitmapImage.pixelsHigh)
+                    Open this image in a separate Preview window, then try to locate it.
+                    """
+            } catch {
+                imageRecognitionResult = "Failed to create tiled test image: \(error)"
+            }
+        }
+    }
     
     func createTestImageForRecognition() {
         let size = NSSize(width: 100, height: 100)

--- a/Sample/Sample/Features/ImageRecognition/ImageRecognitionViewModel.swift
+++ b/Sample/Sample/Features/ImageRecognition/ImageRecognitionViewModel.swift
@@ -49,6 +49,11 @@ class ImageRecognitionViewModel {
         context.flushGraphics()
         NSGraphicsContext.restoreGraphicsState()
 
+        // Preserve the 64x64 pixel template while displaying it at 32 points.
+        // On a 2x Retina display, Preview then renders it as 64x64 screen pixels,
+        // matching the pixel dimensions used by template matching.
+        bitmapImage.size = NSSize(width: 32, height: 32)
+
         let documents = FileManager.default.urls(
             for: .documentDirectory,
             in: .userDomainMask
@@ -64,6 +69,7 @@ class ImageRecognitionViewModel {
                 imageRecognitionResult = """
                     Tiled matcher test image created at: \(path)
                     Pixel size: \(bitmapImage.pixelsWide)x\(bitmapImage.pixelsHigh)
+                    Display size: \(Int(bitmapImage.size.width))x\(Int(bitmapImage.size.height)) points
                     Open this image in a separate Preview window, then try to locate it.
                     """
             } catch {

--- a/Sources/ImageRecognition/TemplateMatcher.swift
+++ b/Sources/ImageRecognition/TemplateMatcher.swift
@@ -142,9 +142,10 @@ package final class TemplateMatcher: @unchecked Sendable {
         let tileWidth = needlePixels.width + threadgroupSize.width - 1
         let tileHeight = needlePixels.height + threadgroupSize.height - 1
         let tileByteCount = tileWidth * tileHeight
+        let threadgroupMemoryLength = Self.alignedThreadgroupMemoryLength(tileByteCount)
         let canUseTiledPipeline =
             needlePixels.width * needlePixels.height <= 4_096 &&
-            tileByteCount + tiledPipeline.staticThreadgroupMemoryLength
+            threadgroupMemoryLength + tiledPipeline.staticThreadgroupMemoryLength
                 <= device.maxThreadgroupMemoryLength
 
         encoder.setComputePipelineState(canUseTiledPipeline ? tiledPipeline : pipeline)
@@ -154,7 +155,7 @@ package final class TemplateMatcher: @unchecked Sendable {
         encoder.setBytes(&parameters, length: MemoryLayout<MatchParameters>.stride, index: 3)
 
         if canUseTiledPipeline {
-            encoder.setThreadgroupMemoryLength(tileByteCount, index: 0)
+            encoder.setThreadgroupMemoryLength(threadgroupMemoryLength, index: 0)
             encoder.dispatchThreadgroups(
                 MTLSize(
                     width: (outputWidth + threadgroupSize.width - 1) / threadgroupSize.width,
@@ -265,6 +266,12 @@ package final class TemplateMatcher: @unchecked Sendable {
             return matches.first.map { [$0] } ?? []
         }
         return NonMaximumSuppression.apply(to: matches)
+    }
+
+    static func alignedThreadgroupMemoryLength(_ byteCount: Int) -> Int {
+        let alignment = 16
+        let remainder = byteCount % alignment
+        return remainder == 0 ? byteCount : byteCount + alignment - remainder
     }
 }
 

--- a/Tests/ImageRecognitionTests/TemplateMatcherTests.swift
+++ b/Tests/ImageRecognitionTests/TemplateMatcherTests.swift
@@ -5,6 +5,18 @@ import Testing
 
 @Suite("Metal Template Matcher Tests")
 struct TemplateMatcherTests {
+    @Test(
+        "Aligns dynamic threadgroup memory to Metal's 16-byte requirement",
+        arguments: [0, 1, 15, 16, 17, 90, 5_041]
+    )
+    func threadgroupMemoryAlignment(byteCount: Int) {
+        let alignedLength = TemplateMatcher.alignedThreadgroupMemoryLength(byteCount)
+
+        #expect(alignedLength >= byteCount)
+        #expect(alignedLength % 16 == 0)
+        #expect(alignedLength - byteCount < 16)
+    }
+
     @Test("Finds an exact match at a known offset")
     func exactMatch() throws {
         let template = [

--- a/Tests/ImageRecognitionTests/TemplateMatcherTests.swift
+++ b/Tests/ImageRecognitionTests/TemplateMatcherTests.swift
@@ -88,6 +88,39 @@ struct TemplateMatcherTests {
         #expect(matches.first?.y == 1)
     }
 
+    @Test("Finds a match with a 64x64 template using the tiled pipeline")
+    func tiledPipelineBoundaryTemplateMatch() throws {
+        let templateWidth = 64
+        let templateHeight = 64
+        let template = (0..<(templateWidth * templateHeight)).map {
+            UInt8(truncatingIfNeeded: $0 &* 31)
+        }
+        var haystack = [UInt8](repeating: 17, count: 68 * 68)
+        insert(
+            template,
+            width: templateWidth,
+            height: templateHeight,
+            into: &haystack,
+            haystackWidth: 68,
+            x: 2,
+            y: 3
+        )
+
+        let matches = try makeMatcher().match(
+            needle: makeImage(
+                width: templateWidth,
+                height: templateHeight,
+                pixels: template
+            ),
+            in: makeImage(width: 68, height: 68, pixels: haystack),
+            threshold: 0.999,
+            findAll: false
+        )
+
+        #expect(matches.first?.x == 2)
+        #expect(matches.first?.y == 3)
+    }
+
     @Test("Finds a match with a template larger than the tiled-kernel limit")
     func largeTemplateMatch() throws {
         let templateWidth = 65


### PR DESCRIPTION
## Summary

- add a 64x64 tiled template-matching regression case and Sample workflow
- align dynamic Metal threadgroup memory length to the required 16-byte boundary
- preserve the tiled Sample image pixel size when Preview renders it on Retina displays

## Root cause

The tiled matcher requested 5,041 bytes of dynamic threadgroup memory for a 64x64 template. Metal requires the length passed to setThreadgroupMemoryLength to be a multiple of 16 bytes, so API validation aborted the process. The matcher now rounds the allocation up to 5,056 bytes and uses that aligned value for the device-limit check.

The Sample also records the 64x64 PNG as 32x32 logical points so that Preview displays it as 64x64 screen pixels on a 2x Retina display.

Closes #120

## Testing

- MTL_DEBUG_LAYER=1 swift test --filter TemplateMatcherTests (14 tests passed)
- swift test (161 tests passed)
- Sample macOS app build with code signing disabled
- manually reproduced the crash before the fix with Metal API Validation
- manually verified tiled image recognition after the fix