### PR TITLE
Add dedicated Chromium CDP browser backend

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,6 +181,7 @@ jobs:
         run: |
           set -o pipefail
           swift package generate-documentation --target SwiftAutoGUI 2>&1 | xcbeautify
+          swift package generate-documentation --target SwiftAutoGUIBrowser 2>&1 | xcbeautify
 
   sample-app:
     name: Build Sample App

--- a/Documentation/BrowserAgent.md
+++ b/Documentation/BrowserAgent.md
@@ -1,0 +1,103 @@
+# SwiftAutoGUI Browser Agent
+
+Browser Agent controls web pages in a Chromium browser with remote debugging enabled. It uses the
+Chrome DevTools Protocol (CDP) and is intentionally browser-only: it does not control native macOS
+interfaces such as Finder or System Settings, and it never falls back to Accessibility or CGEvent.
+
+## 1. Start Chromium
+
+Use a dedicated profile and expose the debugging port only on the loopback interface:
+
+```bash
+"/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing" \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/swift-auto-gui-browser-profile
+```
+
+To use the standard Google Chrome installation instead, replace the executable path with:
+
+```text
+/Applications/Google Chrome.app/Contents/MacOS/Google Chrome
+```
+
+## 2. Try it in the Sample app
+
+1. Open `Sample/Sample.xcodeproj` in Xcode.
+2. Run the **Sample** scheme.
+3. Open the **Browser CDP** tab.
+4. Enter `http://127.0.0.1:9222` as the endpoint.
+5. Enter the page hosts that the Agent may access under **Domains**, such as `github.com`.
+6. Select **Connect**, then choose the target browser tab.
+7. Enter an OpenAI API key and a goal.
+8. Select **Run Agent**.
+
+The Sample app permits cross-origin navigation only when the destination is in the domain allowlist.
+It rejects navigation outside the allowlist and rejects all downloads. The API key is read from the
+text field or the `OPENAI_API_KEY` environment variable and is never stored in source code.
+
+## 3. Try it with sagui
+
+```bash
+export OPENAI_API_KEY="your-key-in-your-shell"
+
+sagui browser tabs
+
+sagui browser agent "Open issue 118" \
+  --domain github.com \
+  --allow-cross-origin
+```
+
+To start from a specific tab:
+
+```bash
+sagui browser agent "Open the Issues page" \
+  --domain github.com \
+  --tab-id TARGET_ID
+```
+
+- Repeat `--domain` to allow multiple hosts.
+- Without `--allow-cross-origin`, cross-origin navigation is rejected even when its destination is
+  in the allowlist.
+- Downloads are always rejected.
+- The default endpoint is `http://127.0.0.1:9222`.
+
+## 4. Use the Swift API
+
+```swift
+import Foundation
+import SwiftAutoGUI
+import SwiftAutoGUIBrowser
+
+struct Authorizer: BrowserActionAuthorizing {
+    func authorize(_ request: BrowserAuthorizationRequest) async -> Bool {
+        switch request {
+        case .crossOriginNavigation: true
+        case .download: false
+        }
+    }
+}
+
+let browser = try await BrowserSession.connect(
+    endpoint: URL(string: "http://127.0.0.1:9222")!,
+    securityPolicy: BrowserSecurityPolicy(
+        allowedDomains: ["github.com"]
+    ),
+    authorizer: Authorizer()
+)
+
+let apiKey = ProcessInfo.processInfo.environment["OPENAI_API_KEY"]!
+let llm = OpenAIVisionBackend(apiKey: apiKey)
+let agent = Agent(
+    backend: llm,
+    screenContextOptions: nil,
+    visionMode: .automatic,
+    automationBackend: browser
+)
+
+let result = try await agent.run(goal: "Open issue 118")
+print(result.completed)
+await browser.close()
+```
+
+For API details, security behavior, element lifetime, and error handling, see the
+**Using a Browser Agent** page in the `SwiftAutoGUIBrowser` DocC documentation.

--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,9 @@ let package = Package(
         .library(
             name: "SwiftAutoGUI",
             targets: ["SwiftAutoGUI"]),
+        .library(
+            name: "SwiftAutoGUIBrowser",
+            targets: ["SwiftAutoGUIBrowser"]),
         .executable(
             name: "sagui",
             targets: ["sagui"]),
@@ -38,15 +41,22 @@ let package = Package(
             dependencies: [
                 "ImageRecognition"
             ]),
+        .target(
+            name: "SwiftAutoGUIBrowser",
+            dependencies: ["SwiftAutoGUI"]),
         .executableTarget(
             name: "sagui",
             dependencies: [
                 "SwiftAutoGUI",
+                "SwiftAutoGUIBrowser",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ]),
         .testTarget(
             name: "SwiftAutoGUITests",
             dependencies: ["SwiftAutoGUI"]),
+        .testTarget(
+            name: "SwiftAutoGUIBrowserTests",
+            dependencies: ["SwiftAutoGUIBrowser", "SwiftAutoGUI"]),
         .testTarget(
             name: "SaguiTests",
             dependencies: ["sagui"]),

--- a/README.md
+++ b/README.md
@@ -67,6 +67,71 @@ sagui mouse click --x 100 --y 200
 sagui mouse click --right --x 100 --y 200
 ```
 
+## Optional Chromium CDP backend
+
+> Quick start: [Browser Agent guide](Documentation/BrowserAgent.md)
+
+`SwiftAutoGUIBrowser` adds semantic automation for an existing Chrome, Edge,
+or other Chromium debugging session. It is a separate product, so applications
+that use only native macOS automation do not acquire browser-specific code.
+
+Add the optional product to the client target:
+
+```swift
+.target(
+    name: "MyProject",
+    dependencies: [
+        .product(name: "SwiftAutoGUI", package: "SwiftAutoGUI"),
+        .product(name: "SwiftAutoGUIBrowser", package: "SwiftAutoGUI")
+    ]
+)
+```
+
+Start Chromium with a dedicated profile and a loopback debugging port. Chrome
+136 and later do not honor remote debugging against the default profile.
+
+```bash
+"/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing" \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/swift-auto-gui-browser-profile
+```
+
+Connect with an explicit navigation allowlist:
+
+```swift
+import SwiftAutoGUI
+import SwiftAutoGUIBrowser
+
+let browser = try await BrowserSession.connect(
+    endpoint: URL(string: "http://127.0.0.1:9222")!,
+    securityPolicy: BrowserSecurityPolicy(
+        allowedDomains: ["example.com", "*.example.org"]
+    )
+)
+
+let observation = try await browser.observe()
+print(observation.formattedContext)
+
+let apiKey = ProcessInfo.processInfo.environment["OPENAI_API_KEY"]!
+let browserAgent = Agent(
+    backend: OpenAIVisionBackend(apiKey: apiKey),
+    automationBackend: browser
+)
+```
+
+The browser Agent is intentionally browser-only: native app, window, AX-label,
+and coordinate mouse actions fail as unsupported instead of falling back to
+Accessibility or CGEvent. Stale DOM elements also fail safely without clicking
+a saved coordinate. Cross-origin navigation and downloads require a
+`BrowserActionAuthorizing` implementation; without one they are denied.
+
+The `sagui` CLI can run the same browser-only Agent:
+
+```bash
+sagui browser tabs
+sagui browser agent "Open issue 118" --domain github.com --allow-cross-origin
+```
+
 
 # Example Usage
 

--- a/Sample/Sample.xcodeproj/project.pbxproj
+++ b/Sample/Sample.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		5C3CE0262973398400D9CE50 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5C3CE0252973398400D9CE50 /* Assets.xcassets */; };
 		5C3CE0292973398400D9CE50 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5C3CE0282973398400D9CE50 /* Preview Assets.xcassets */; };
 		5C3CE032297339AA00D9CE50 /* SwiftAutoGUI in Frameworks */ = {isa = PBXBuildFile; productRef = 5C3CE031297339AA00D9CE50 /* SwiftAutoGUI */; };
+		A1180001297339AA00D9CE50 /* SwiftAutoGUIBrowser in Frameworks */ = {isa = PBXBuildFile; productRef = A1180000297339AA00D9CE50 /* SwiftAutoGUIBrowser */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -21,7 +22,6 @@
 		5C3CE0252973398400D9CE50 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		5C3CE0282973398400D9CE50 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		5C3CE02A2973398400D9CE50 /* Sample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Sample.entitlements; sourceTree = "<group>"; };
-		5C3E344A2C3030D600BAD11F /* SwiftAutoGUI */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = SwiftAutoGUI; path = ../..; sourceTree = "<group>"; };
 		5CBA7E592E2B7D3700CBB992 /* SwiftAutoGUITestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = SwiftAutoGUITestPlan.xctestplan; path = Sample/SwiftAutoGUITestPlan.xctestplan; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -36,6 +36,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5C3CE032297339AA00D9CE50 /* SwiftAutoGUI in Frameworks */,
+				A1180001297339AA00D9CE50 /* SwiftAutoGUIBrowser in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -63,7 +64,6 @@
 		5C3CE0202973398300D9CE50 /* Sample */ = {
 			isa = PBXGroup;
 			children = (
-				5C3E344A2C3030D600BAD11F /* SwiftAutoGUI */,
 				5C3CE0212973398300D9CE50 /* SampleApp.swift */,
 				5C3CE0232973398300D9CE50 /* ContentView.swift */,
 				5CBA7D5E2E1FB87700CBB992 /* Common */,
@@ -112,6 +112,7 @@
 			name = Sample;
 			packageProductDependencies = (
 				5C3CE031297339AA00D9CE50 /* SwiftAutoGUI */,
+				A1180000297339AA00D9CE50 /* SwiftAutoGUIBrowser */,
 			);
 			productName = Sample;
 			productReference = 5C3CE01E2973398300D9CE50 /* Sample.app */;
@@ -141,6 +142,9 @@
 				Base,
 			);
 			mainGroup = 5C3CE0152973398300D9CE50;
+			packageReferences = (
+				5C3E344A2C3030D600BAD11F /* XCLocalSwiftPackageReference "SwiftAutoGUI" */,
+			);
 			productRefGroup = 5C3CE01F2973398300D9CE50 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -369,10 +373,23 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		5C3E344A2C3030D600BAD11F /* XCLocalSwiftPackageReference "SwiftAutoGUI" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ..;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		5C3CE031297339AA00D9CE50 /* SwiftAutoGUI */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = 5C3E344A2C3030D600BAD11F /* XCLocalSwiftPackageReference "SwiftAutoGUI" */;
 			productName = SwiftAutoGUI;
+		};
+		A1180000297339AA00D9CE50 /* SwiftAutoGUIBrowser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5C3E344A2C3030D600BAD11F /* XCLocalSwiftPackageReference "SwiftAutoGUI" */;
+			productName = SwiftAutoGUIBrowser;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Sample/Sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Sample/Sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,31 +1,13 @@
 {
-  "originHash" : "7f43dfee10b03e34f5f76551d7937a8d725136fe3ecabb38d8954528c4222c60",
+  "originHash" : "64f069b7c22787ac59104fba3fcc126a5dfc1eee6786b6cc68ca411bcb405236",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
-        "version" : "1.7.1"
-      }
-    },
-    {
-      "identity" : "swift-docc-plugin",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-plugin",
-      "state" : {
-        "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
-        "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-docc-symbolkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-symbolkit",
-      "state" : {
-        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
-        "version" : "1.0.0"
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     }
   ],

--- a/Sample/Sample/Common/DemoTab.swift
+++ b/Sample/Sample/Common/DemoTab.swift
@@ -22,6 +22,7 @@ enum DemoTab: String, CaseIterable {
     case actions
     case aiGeneration
     case screenContext
+    case browser
     case agent
 
     var title: String {
@@ -40,6 +41,7 @@ enum DemoTab: String, CaseIterable {
         case .actions: return "Actions"
         case .aiGeneration: return "AI Generation"
         case .screenContext: return "Screen Context"
+        case .browser: return "Browser CDP"
         case .agent: return "AI Agent"
         }
     }
@@ -60,6 +62,7 @@ enum DemoTab: String, CaseIterable {
         case .actions: return "play.circle"
         case .aiGeneration: return "sparkles"
         case .screenContext: return "accessibility"
+        case .browser: return "network"
         case .agent: return "brain"
         }
     }

--- a/Sample/Sample/ContentView.swift
+++ b/Sample/Sample/ContentView.swift
@@ -110,6 +110,8 @@ struct ContentView: View {
                             AIGenerationDemoView()
                         case .screenContext:
                             ScreenContextDemoView()
+                        case .browser:
+                            BrowserDemoView()
                         case .agent:
                             AgentDemoView()
                         }

--- a/Sample/Sample/Features/Agent/AgentDemoViewModel.swift
+++ b/Sample/Sample/Features/Agent/AgentDemoViewModel.swift
@@ -142,6 +142,8 @@ class AgentDemoViewModel {
             return "drag(\(Int(fromX)),\(Int(fromY))->\(Int(toX)),\(Int(toY)))"
         case .openURL(let url):
             return "openURL(\"\(url)\")"
+        case .activateTab(let tabID):
+            return "activateTab(\"\(tabID)\")"
         case .activateApp(let name):
             return "activateApp(\"\(name)\")"
         case .quitApp(let name):

--- a/Sample/Sample/Features/Browser/BrowserDemoView.swift
+++ b/Sample/Sample/Features/Browser/BrowserDemoView.swift
@@ -1,0 +1,328 @@
+import SwiftAutoGUIBrowser
+import SwiftUI
+
+struct BrowserDemoView: View {
+    @State private var viewModel = BrowserDemoViewModel()
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            header
+            setupNote
+            connectionControls
+
+            if viewModel.isConnected {
+                browserControls
+                agentControls
+                actionControls
+            }
+
+            status
+
+            if viewModel.formattedOutput.isEmpty {
+                emptyState
+            } else {
+                selectorMap
+            }
+        }
+        .onDisappear { viewModel.disconnect() }
+    }
+
+    private var header: some View {
+        HStack {
+            Image(systemName: "network")
+                .font(.title)
+                .foregroundColor(.indigo)
+            Text("Chromium CDP")
+                .font(.title2)
+                .fontWeight(.bold)
+            Spacer()
+            if viewModel.isConnected {
+                badge("Connected", icon: "checkmark.circle.fill", color: .green)
+                badge("\(viewModel.tabs.count) tabs", icon: "rectangle.on.rectangle", color: .indigo)
+                badge("\(viewModel.observation?.elements.count ?? 0) elements", icon: "scope", color: .orange)
+            }
+        }
+    }
+
+    private var setupNote: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Label("Browser-only demo", systemImage: "shield.lefthalf.filled")
+                .font(.headline)
+            Text("This tab controls Chromium pages through CDP. It never falls back to macOS Accessibility or CGEvent input.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            Text("/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --remote-debugging-port=9222 --user-data-dir=/tmp/swiftautogui-cdp-profile")
+                .font(.system(.caption, design: .monospaced))
+                .textSelection(.enabled)
+                .padding(8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(RoundedRectangle(cornerRadius: 6).fill(Color.primary.opacity(0.06)))
+            Text("Use a dedicated profile. Allowlisted cross-origin navigation is approved for this demo; navigation outside the list and all downloads are denied.")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 10).fill(Color.indigo.opacity(0.08)))
+    }
+
+    private var connectionControls: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Text("Endpoint")
+                    .font(.caption)
+                    .frame(width: 88, alignment: .leading)
+                TextField("http://127.0.0.1:9222", text: $viewModel.endpoint)
+                    .textFieldStyle(.roundedBorder)
+                    .disabled(viewModel.isConnected || viewModel.isAgentRunning)
+            }
+            HStack(spacing: 8) {
+                Text("Domains")
+                    .font(.caption)
+                    .frame(width: 88, alignment: .leading)
+                TextField("example.com, *.example.org", text: $viewModel.allowedDomains)
+                    .textFieldStyle(.roundedBorder)
+                    .disabled(viewModel.isConnected || viewModel.isAgentRunning)
+                if viewModel.isConnected {
+                    Button("Disconnect") { viewModel.disconnect() }
+                        .disabled(viewModel.isAgentRunning)
+                } else {
+                    Button("Connect") { viewModel.connect() }
+                        .buttonStyle(.borderedProminent)
+                        .tint(.indigo)
+                }
+            }
+        }
+    }
+
+    private var browserControls: some View {
+        HStack(spacing: 8) {
+            Text("Tab")
+                .font(.caption)
+            Picker("Tab", selection: Binding(
+                get: { viewModel.selectedTabID },
+                set: { viewModel.selectTab($0) }
+            )) {
+                ForEach(viewModel.tabs, id: \.id) { tab in
+                    Text(tabLabel(tab)).tag(tab.id)
+                }
+            }
+            .labelsHidden()
+            .frame(maxWidth: .infinity)
+
+            Button { viewModel.refreshTabs() } label: {
+                Label("Refresh Tabs", systemImage: "arrow.clockwise")
+            }
+            Button { viewModel.capture() } label: {
+                Label("Observe", systemImage: "eye")
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.indigo)
+        }
+        .disabled(viewModel.isWorking || viewModel.isAgentRunning)
+    }
+
+    private var agentControls: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Label("Browser AI Agent", systemImage: "brain.head.profile")
+                    .font(.headline)
+                Spacer()
+                if viewModel.isAgentRunning {
+                    ProgressView().controlSize(.small)
+                    Text("Step \(viewModel.agentSteps.count + 1)/\(viewModel.maxAgentIterations)")
+                        .font(.caption2)
+                } else if let completed = viewModel.agentCompleted {
+                    Label(completed ? "Done" : "Limit reached", systemImage: completed ? "checkmark.circle.fill" : "exclamationmark.circle.fill")
+                        .font(.caption2)
+                        .foregroundColor(completed ? .green : .orange)
+                }
+            }
+
+            Text("The Agent observes the selected page, asks the OpenAI model for semantic actions, and executes them only through this CDP session.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            HStack(spacing: 8) {
+                SecureField("OpenAI API Key or OPENAI_API_KEY", text: $viewModel.openAIKey)
+                    .textFieldStyle(.roundedBorder)
+                Picker("Model", selection: $viewModel.openAIModel) {
+                    ForEach(BrowserDemoViewModel.availableModels, id: \.self) { model in
+                        Text(model).tag(model)
+                    }
+                }
+                .labelsHidden()
+                .frame(width: 170)
+            }
+            .disabled(viewModel.isAgentRunning)
+
+            HStack(spacing: 8) {
+                TextEditor(text: $viewModel.agentGoal)
+                    .font(.body)
+                    .frame(height: 48)
+                    .padding(5)
+                    .background(RoundedRectangle(cornerRadius: 7).fill(Color.primary.opacity(0.045)))
+                    .overlay(RoundedRectangle(cornerRadius: 7).stroke(Color.primary.opacity(0.12)))
+                    .disabled(viewModel.isAgentRunning)
+
+                if viewModel.isAgentRunning {
+                    Button { viewModel.stopAgent() } label: {
+                        Label("Stop", systemImage: "stop.fill")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.red)
+                } else {
+                    Button { viewModel.startAgent() } label: {
+                        Label("Run Agent", systemImage: "play.fill")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.indigo)
+                    .disabled(viewModel.agentGoal.isEmpty || viewModel.openAIKey.isEmpty)
+                }
+            }
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    ForEach(viewModel.sampleAgentGoals, id: \.self) { goal in
+                        Button(goal) { viewModel.agentGoal = goal }
+                            .buttonStyle(.plain)
+                            .font(.caption2)
+                            .foregroundColor(.indigo)
+                            .padding(.horizontal, 9)
+                            .padding(.vertical, 4)
+                            .background(Capsule().fill(Color.indigo.opacity(0.1)))
+                    }
+                }
+            }
+            .disabled(viewModel.isAgentRunning)
+
+            if let error = viewModel.agentError {
+                Label(error, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundColor(.orange)
+                    .textSelection(.enabled)
+            }
+
+            if !viewModel.agentSteps.isEmpty {
+                HStack {
+                    Text("Agent steps")
+                        .font(.subheadline.weight(.semibold))
+                    Spacer()
+                    if !viewModel.isAgentRunning {
+                        Button("Clear") { viewModel.clearAgentResult() }
+                            .buttonStyle(.plain)
+                            .font(.caption)
+                            .foregroundColor(.red)
+                    }
+                }
+
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 8) {
+                        ForEach(viewModel.agentSteps) { step in
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Step \(step.number) · \(step.reasoning)")
+                                    .font(.caption)
+                                Text(step.actions)
+                                    .font(.system(.caption2, design: .monospaced))
+                                    .foregroundColor(.secondary)
+                                    .textSelection(.enabled)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            if step.id != viewModel.agentSteps.last?.id { Divider() }
+                        }
+                    }
+                    .padding(9)
+                }
+                .frame(maxHeight: 180)
+                .background(RoundedRectangle(cornerRadius: 8).fill(Color.primary.opacity(0.04)))
+            }
+        }
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 10).fill(Color.indigo.opacity(0.07)))
+    }
+
+    private var actionControls: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("Element actions", systemImage: "cursorarrow.click")
+                .font(.headline)
+            Text("Choose an ID from the latest selector map. If the DOM changes, stale IDs are rejected and the page is observed again.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            HStack(spacing: 8) {
+                Text("Element #")
+                    .font(.caption)
+                TextField("ID", value: $viewModel.selectedElementID, format: .number)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 60)
+                Button("Click") { viewModel.clickSelectedElement() }
+
+                Divider().frame(height: 20)
+
+                TextField("Replacement text", text: $viewModel.replacementText)
+                    .textFieldStyle(.roundedBorder)
+                Button("Replace Text") { viewModel.replaceSelectedElementText() }
+            }
+            .disabled(viewModel.isWorking || viewModel.isAgentRunning || viewModel.observation == nil)
+        }
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 10).fill(Color.primary.opacity(0.045)))
+    }
+
+    private var status: some View {
+        HStack(spacing: 8) {
+            if viewModel.isWorking {
+                ProgressView().controlSize(.small)
+            }
+            Text(viewModel.statusMessage)
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .textSelection(.enabled)
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "globe.desk")
+                .font(.largeTitle)
+                .foregroundColor(.secondary)
+            Text("Connect and observe a Chromium tab to show its selector map.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 28)
+    }
+
+    private var selectorMap: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("Latest selector map", systemImage: "list.number")
+                .font(.headline)
+            ScrollView([.horizontal, .vertical]) {
+                Text(viewModel.formattedOutput)
+                    .font(.system(.caption, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
+                    .padding(10)
+            }
+            .frame(minHeight: 180, maxHeight: 280)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(colorScheme == .dark ? Color.black.opacity(0.25) : Color.gray.opacity(0.08))
+            )
+        }
+    }
+
+    private func tabLabel(_ tab: BrowserTab) -> String {
+        let title = tab.title.isEmpty ? tab.url : tab.title
+        return "\(tab.state.rawValue.capitalized) · \(title)"
+    }
+
+    private func badge(_ text: String, icon: String, color: Color) -> some View {
+        Label(text, systemImage: icon)
+            .font(.caption2)
+            .foregroundColor(color)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(Capsule().fill(color.opacity(0.12)))
+    }
+}

--- a/Sample/Sample/Features/Browser/BrowserDemoViewModel.swift
+++ b/Sample/Sample/Features/Browser/BrowserDemoViewModel.swift
@@ -1,0 +1,310 @@
+import Foundation
+import SwiftAutoGUI
+import SwiftAutoGUIBrowser
+import SwiftUI
+
+@MainActor
+@Observable
+final class BrowserDemoViewModel {
+    var endpoint = "http://127.0.0.1:9222"
+    var allowedDomains = "example.com"
+    var selectedTabID = ""
+    var selectedElementID = 1
+    var replacementText = ""
+    var agentGoal = "Find the SwiftAutoGUI repository and open its Issues page"
+    var openAIKey = ProcessInfo.processInfo.environment["OPENAI_API_KEY"] ?? ""
+    var openAIModel = OpenAIVisionBackend.defaultModel
+    var maxAgentIterations = 12
+    var agentDelay = 0.8
+
+    private(set) var tabs: [BrowserTab] = []
+    private(set) var observation: BrowserObservation?
+    private(set) var statusMessage = "Start Chromium with remote debugging, then connect."
+    private(set) var isConnected = false
+    private(set) var isWorking = false
+    private(set) var isAgentRunning = false
+    private(set) var agentCompleted: Bool?
+    private(set) var agentError: String?
+    private(set) var agentSteps: [AgentStepDisplay] = []
+
+    @ObservationIgnored private var session: BrowserSession?
+    @ObservationIgnored private var agentTask: Task<Void, Never>?
+
+    struct AgentStepDisplay: Identifiable {
+        let id = UUID()
+        let number: Int
+        let reasoning: String
+        let actions: String
+    }
+
+    static let availableModels = [
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-4o",
+        "gpt-4o-mini",
+    ]
+
+    let sampleAgentGoals = [
+        "Open the Issues page for this repository",
+        "Find issue 118 and open it",
+        "Search this page for BrowserSession",
+    ]
+
+    var formattedOutput: String {
+        observation?.formattedContext ?? ""
+    }
+
+    func connect() {
+        guard !isWorking else { return }
+        guard let endpointURL = URL(string: endpoint), endpointURL.host != nil else {
+            statusMessage = "Enter a valid HTTP endpoint."
+            return
+        }
+
+        let domains = Set(
+            allowedDomains
+                .split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+                .filter { !$0.isEmpty }
+        )
+        guard !domains.isEmpty else {
+            statusMessage = "Enter at least one allowed page domain."
+            return
+        }
+
+        isWorking = true
+        statusMessage = "Connecting to Chromium…"
+        Task {
+            do {
+                if let currentSession = session {
+                    await currentSession.close()
+                }
+                let newSession = try await BrowserSession.connect(
+                    endpoint: endpointURL,
+                    securityPolicy: BrowserSecurityPolicy(allowedDomains: domains),
+                    authorizer: SampleBrowserAuthorizer()
+                )
+                session = newSession
+                isConnected = true
+                try await refresh(using: newSession)
+                try await observe(using: newSession)
+                statusMessage = "Connected. Element IDs are valid only for the latest observation."
+            } catch {
+                session = nil
+                isConnected = false
+                tabs = []
+                observation = nil
+                statusMessage = error.localizedDescription
+            }
+            isWorking = false
+        }
+    }
+
+    func disconnect() {
+        stopAgent()
+        let currentSession = session
+        session = nil
+        isConnected = false
+        isWorking = false
+        tabs = []
+        selectedTabID = ""
+        observation = nil
+        statusMessage = "Disconnected."
+        Task { await currentSession?.close() }
+    }
+
+    func startAgent() {
+        guard let session, isConnected else {
+            agentError = "Connect to Chromium first."
+            return
+        }
+        guard !agentGoal.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            agentError = "Enter a browser goal."
+            return
+        }
+        guard !openAIKey.isEmpty else {
+            agentError = "Enter an OpenAI API key or launch the app with OPENAI_API_KEY."
+            return
+        }
+        guard !isAgentRunning else { return }
+
+        isAgentRunning = true
+        agentCompleted = nil
+        agentError = nil
+        agentSteps = []
+        statusMessage = "Browser AI Agent is running…"
+
+        let goal = agentGoal
+        let backend = OpenAIVisionBackend(apiKey: openAIKey, model: openAIModel)
+        let agent = Agent(
+            backend: backend,
+            maxIterations: maxAgentIterations,
+            delayBetweenSteps: agentDelay,
+            screenContextOptions: nil,
+            visionMode: .automatic,
+            automationBackend: session
+        )
+
+        agentTask = Task {
+            do {
+                let result = try await agent.run(goal: goal) { [weak self] step in
+                    Task { @MainActor in
+                        guard let self else { return }
+                        let actions = step.actions.map(self.describeAction).joined(separator: ", ")
+                        let executions = step.executionResults.map { execution in
+                            let state = execution.succeeded ? "✓" : "✗"
+                            let detail = execution.failureReason.map { ": \($0)" } ?? ""
+                            return "\(state) \(execution.method.rawValue)\(detail)"
+                        }.joined(separator: ", ")
+                        self.agentSteps.append(
+                            AgentStepDisplay(
+                                number: self.agentSteps.count + 1,
+                                reasoning: step.reasoning,
+                                actions: actions + (executions.isEmpty ? "" : "\n\(executions)")
+                            )
+                        )
+                    }
+                }
+                agentCompleted = result.completed
+                statusMessage = result.completed
+                    ? "Browser AI Agent completed the goal."
+                    : "Browser AI Agent reached its iteration limit."
+                try await refresh(using: session)
+                try await observe(using: session)
+            } catch is CancellationError {
+                statusMessage = "Browser AI Agent stopped."
+            } catch {
+                agentError = error.localizedDescription
+                statusMessage = "Browser AI Agent failed."
+            }
+            isAgentRunning = false
+            agentTask = nil
+        }
+    }
+
+    func stopAgent() {
+        agentTask?.cancel()
+        statusMessage = "Stopping Browser AI Agent…"
+    }
+
+    func clearAgentResult() {
+        agentSteps = []
+        agentCompleted = nil
+        agentError = nil
+    }
+
+    func refreshTabs() {
+        guard let session, !isWorking, !isAgentRunning else { return }
+        run { try await self.refresh(using: session) }
+    }
+
+    func selectTab(_ tabID: String) {
+        guard let session, !isWorking, !isAgentRunning else { return }
+        selectedTabID = tabID
+        run {
+            try await session.activateTab(tabID)
+            try await self.refresh(using: session)
+            try await self.observe(using: session)
+            self.statusMessage = "Activated the selected tab and captured a new observation."
+        }
+    }
+
+    func capture() {
+        guard let session, !isWorking, !isAgentRunning else { return }
+        run {
+            try await self.observe(using: session)
+            self.statusMessage = "Captured \(self.observation?.elements.count ?? 0) actionable elements."
+        }
+    }
+
+    func clickSelectedElement() {
+        execute(.click(elementID: selectedElementID))
+    }
+
+    func replaceSelectedElementText() {
+        execute(.replaceText(elementID: selectedElementID, value: replacementText))
+    }
+
+    private func execute(_ action: BrowserAction) {
+        guard let session, let observation, !isWorking, !isAgentRunning else { return }
+        run {
+            let result = await session.execute(action, against: observation)
+            self.observation = result.observation
+            try await self.refresh(using: session)
+            if result.succeeded {
+                self.statusMessage = "Action completed. The page was observed again automatically."
+            } else {
+                self.statusMessage = result.failure?.localizedDescription ?? "The browser action failed."
+            }
+        }
+    }
+
+    private func run(_ operation: @escaping @MainActor () async throws -> Void) {
+        isWorking = true
+        Task {
+            do {
+                try await operation()
+            } catch {
+                statusMessage = error.localizedDescription
+            }
+            isWorking = false
+        }
+    }
+
+    private func refresh(using session: BrowserSession) async throws {
+        tabs = try await session.listTabs()
+        if !tabs.contains(where: { $0.id == selectedTabID }) {
+            selectedTabID = tabs.first(where: { $0.state == .active })?.id ?? tabs.first?.id ?? ""
+        }
+    }
+
+    private func observe(using session: BrowserSession) async throws {
+        observation = try await session.observe(
+            tabID: selectedTabID.isEmpty ? nil : selectedTabID,
+            includeScreenshot: false
+        )
+        selectedTabID = observation?.tab.id ?? selectedTabID
+    }
+
+    private func describeAction(_ action: BasicAction) -> String {
+        switch action {
+        case .write(let text): "write(\"\(text)\")"
+        case .move(let x, let y): "move(\(Int(x)), \(Int(y)))"
+        case .leftClick: "leftClick"
+        case .rightClick: "rightClick"
+        case .doubleClick: "doubleClick"
+        case .vscroll(let clicks): "vscroll(\(clicks))"
+        case .hscroll(let clicks): "hscroll(\(clicks))"
+        case .wait(let duration): "wait(\(duration)s)"
+        case .keyShortcut(let keys): "keyShortcut(\(keys.joined(separator: "+")))"
+        case .drag(let fromX, let fromY, let toX, let toY):
+            "drag(\(Int(fromX)),\(Int(fromY))->\(Int(toX)),\(Int(toY)))"
+        case .openURL(let url): "openURL(\"\(url)\")"
+        case .activateTab(let tabID): "activateTab(\"\(tabID)\")"
+        case .pressElement(let elementID): "pressElement(#\(elementID))"
+        case .setElementValue(let elementID, let value):
+            "setElementValue(#\(elementID), value:\"\(value)\")"
+        case .activateApp(let name): "activateApp(\"\(name)\")"
+        case .quitApp(let name): "quitApp(\"\(name)\")"
+        case .getFrontmostApp: "getFrontmostApp"
+        case .pressButton(let label, _): "pressButton(\"\(label)\")"
+        case .setTextField(let label, let value, _):
+            "setTextField(\"\(label)\", \"\(value)\")"
+        case .selectMenuItem(let path, _): "selectMenuItem(\(path.joined(separator: " > ")))"
+        case .raiseWindow(let title, _): "raiseWindow(\"\(title)\")"
+        }
+    }
+}
+
+/// The domain field is the user's explicit allowlist for this demo. Cross-origin
+/// navigation within that allowlist is approved; downloads remain denied.
+private struct SampleBrowserAuthorizer: BrowserActionAuthorizing {
+    func authorize(_ request: BrowserAuthorizationRequest) async -> Bool {
+        switch request {
+        case .crossOriginNavigation: true
+        case .download: false
+        }
+    }
+}

--- a/Sources/SwiftAutoGUI/AI/ActionGenerator.swift
+++ b/Sources/SwiftAutoGUI/AI/ActionGenerator.swift
@@ -77,6 +77,10 @@ public enum BasicAction: Sendable, Codable {
     /// Get the name of the frontmost application.
     case getFrontmostApp
 
+    /// Activate a browser tab by its CDP target identifier.
+    /// Native automation backends report this action as unsupported.
+    case activateTab(tabID: String)
+
     /// Convert to an executable ``Action``.
     public func toAction() -> Action {
         switch self {
@@ -131,6 +135,9 @@ public enum BasicAction: Sendable, Codable {
             return .quitApp(name: name)
         case .getFrontmostApp:
             return .getFrontmostApp
+        case .activateTab:
+            // Browser-only actions are executed by SwiftAutoGUIBrowser.
+            return .wait(0)
         }
     }
 
@@ -169,14 +176,14 @@ public enum BasicAction: Sendable, Codable {
         case text, x, y, clicks, duration, keys
         case fromX, fromY, toX, toY
         case label, value, path, title, bundleID, elementID
-        case url, name
+        case url, name, tabID
     }
 
     private enum ActionType: String, Codable {
         case write, move, leftClick, rightClick, doubleClick
         case vscroll, hscroll, wait, keyShortcut, drag
         case pressButton, pressElement, setTextField, setElementValue, selectMenuItem, raiseWindow
-        case openURL, activateApp, quitApp, getFrontmostApp
+        case openURL, activateApp, quitApp, getFrontmostApp, activateTab
     }
 
     public init(from decoder: Decoder) throws {
@@ -250,6 +257,9 @@ public enum BasicAction: Sendable, Codable {
             self = .quitApp(name: name)
         case .getFrontmostApp:
             self = .getFrontmostApp
+        case .activateTab:
+            let tabID = try container.decodeIfPresent(String.self, forKey: .tabID) ?? ""
+            self = .activateTab(tabID: tabID)
         }
     }
 
@@ -323,6 +333,9 @@ public enum BasicAction: Sendable, Codable {
             try container.encode(name, forKey: .name)
         case .getFrontmostApp:
             try container.encode(ActionType.getFrontmostApp, forKey: .type)
+        case .activateTab(let tabID):
+            try container.encode(ActionType.activateTab, forKey: .type)
+            try container.encode(tabID, forKey: .tabID)
         }
     }
 }

--- a/Sources/SwiftAutoGUI/AI/OpenAIVisionBackend.swift
+++ b/Sources/SwiftAutoGUI/AI/OpenAIVisionBackend.swift
@@ -102,20 +102,56 @@ public struct OpenAIVisionBackend: VisionActionGenerating, Sendable {
         history: [AgentStep],
         screenContext: ScreenContext?
     ) async throws -> AgentResponse {
+        try await generateActions(
+            goal: goal,
+            screenshot: screenshot,
+            screenSize: screenSize,
+            history: history,
+            formattedContext: screenContext?.formatted(),
+            observationKind: screenContext == nil ? nil : .native
+        )
+    }
+
+    public func generateActions(
+        goal: String,
+        screenshot: Data?,
+        screenSize: CGSize,
+        history: [AgentStep],
+        observation: AgentObservation
+    ) async throws -> AgentResponse {
+        try await generateActions(
+            goal: goal,
+            screenshot: screenshot,
+            screenSize: screenSize,
+            history: history,
+            formattedContext: observation.formattedContext,
+            observationKind: observation.kind
+        )
+    }
+
+    private func generateActions(
+        goal: String,
+        screenshot: Data?,
+        screenSize: CGSize,
+        history: [AgentStep],
+        formattedContext: String?,
+        observationKind: AgentObservationKind?
+    ) async throws -> AgentResponse {
         let input = buildInput(
             goal: goal,
             screenshot: screenshot,
             screenSize: screenSize,
             history: history,
-            screenContext: screenContext
+            formattedContext: formattedContext
         )
 
         var requestBody: [String: Any] = [
             "model": model,
             "instructions": Self.buildSystemPrompt(
                 screenSize: screenSize,
-                hasScreenContext: screenContext != nil,
-                hasScreenshot: screenshot != nil
+                hasScreenContext: !(formattedContext?.isEmpty ?? true),
+                hasScreenshot: screenshot != nil,
+                observationKind: observationKind
             ),
             "input": input,
             "text": [
@@ -180,7 +216,7 @@ extension OpenAIVisionBackend {
         screenshot: Data?,
         screenSize: CGSize,
         history: [AgentStep],
-        screenContext: ScreenContext? = nil
+        formattedContext: String? = nil
     ) -> [[String: Any]] {
         var input: [[String: Any]] = []
 
@@ -201,9 +237,9 @@ extension OpenAIVisionBackend {
         }
 
         var userText = "Goal: \(goal)\n"
-        if let context = screenContext {
+        if let formattedContext, !formattedContext.isEmpty {
             userText += "\n--- Screen Context ---\n"
-            userText += context.formatted()
+            userText += formattedContext
             userText += "\n--- End Screen Context ---\n"
         }
         userText += screenshot == nil
@@ -264,6 +300,8 @@ extension OpenAIVisionBackend {
             return "quitApp(\"\(name)\")"
         case .getFrontmostApp:
             return "getFrontmostApp"
+        case .activateTab(let tabID):
+            return "activateTab(\"\(tabID)\")"
         }
     }
 }
@@ -274,7 +312,8 @@ extension OpenAIVisionBackend {
     static func buildSystemPrompt(
         screenSize: CGSize,
         hasScreenContext: Bool = false,
-        hasScreenshot: Bool = true
+        hasScreenshot: Bool = true,
+        observationKind: AgentObservationKind? = nil
     ) -> String {
         var prompt = """
         You are an AI agent controlling a macOS computer to achieve a user's goal. \
@@ -312,6 +351,7 @@ extension OpenAIVisionBackend {
         - activateApp: Launch an app if needed and bring it to the front. Parameters: name (string)
         - quitApp: Gracefully quit an app. Parameters: name (string)
         - getFrontmostApp: Get the name of the frontmost application. No additional parameters needed.
+        - activateTab: Activate a browser tab. Parameters: tabID (string from the browser context).
 
         Prefer openURL/activateApp/quitApp and the AX-based actions \
         (pressElement, setElementValue, pressButton, setTextField, selectMenuItem, raiseWindow) when applicable. \
@@ -353,6 +393,17 @@ extension OpenAIVisionBackend {
             When the keyboard input source indicates a non-ASCII input mode (e.g., Japanese), \
             consider switching to an ASCII-capable source before using the 'write' action for English text. \
             Common shortcuts to toggle input source include Control+Space or Caps Lock, depending on user settings.
+            """
+        }
+
+        if observationKind == .browser {
+            prompt += """
+
+
+            This is a browser-only CDP observation. Use pressElement, setElementValue, openURL,
+            keyShortcut, scrolling, wait, and activateTab. Do not use native application,
+            window, menu, Accessibility-label, coordinate mouse, or drag actions. Browser
+            element identifiers are step-local and must never be reused in a later observation.
             """
         }
 
@@ -434,6 +485,9 @@ extension OpenAIVisionBackend {
             return .quitApp(name: name)
         case "getFrontmostApp":
             return .getFrontmostApp
+        case "activateTab":
+            let tabID = dict["tabID"] as? String ?? ""
+            return .activateTab(tabID: tabID)
         default:
             return nil
         }
@@ -518,7 +572,7 @@ extension OpenAIVisionBackend {
                 "enum": ["write", "move", "leftClick", "rightClick", "doubleClick",
                          "vscroll", "hscroll", "wait", "keyShortcut", "drag",
                          "pressButton", "pressElement", "setTextField", "setElementValue", "selectMenuItem", "raiseWindow",
-                         "openURL", "activateApp", "quitApp", "getFrontmostApp"]
+                         "openURL", "activateApp", "quitApp", "getFrontmostApp", "activateTab"]
             ] as [String: Any],
             "text": ["type": ["string", "null"], "description": "Text to type. Used with 'write' action."] as [String: Any],
             "x": ["type": ["number", "null"], "description": "X coordinate. Used with 'move' action."] as [String: Any],
@@ -538,10 +592,11 @@ extension OpenAIVisionBackend {
             "elementID": ["type": ["integer", "null"], "description": "Step-local [#N] element identifier. Used with element actions."] as [String: Any],
             "url": ["type": ["string", "null"], "description": "HTTP or HTTPS URL. Used with 'openURL'."] as [String: Any],
             "name": ["type": ["string", "null"], "description": "Application name. Used with 'activateApp' and 'quitApp'."] as [String: Any],
+            "tabID": ["type": ["string", "null"], "description": "CDP target identifier. Used with 'activateTab'."] as [String: Any],
         ] as [String: Any],
         "required": ["type", "text", "x", "y", "clicks", "duration", "keys",
                      "fromX", "fromY", "toX", "toY",
-                     "label", "value", "path", "title", "bundleID", "elementID", "url", "name"],
+                     "label", "value", "path", "title", "bundleID", "elementID", "url", "name", "tabID"],
         "additionalProperties": false
     ] as [String: Any]
 

--- a/Sources/SwiftAutoGUI/AI/VisionActionGenerating.swift
+++ b/Sources/SwiftAutoGUI/AI/VisionActionGenerating.swift
@@ -44,11 +44,42 @@ public protocol VisionActionGenerating: Sendable {
         screenSize: CGSize,
         history: [AgentStep]
     ) async throws -> AgentResponse
+
+    /// Generates actions from a backend-neutral automation observation.
+    /// Implementations may use structured native or browser context without a screenshot.
+    func generateActions(
+        goal: String,
+        screenshot: Data?,
+        screenSize: CGSize,
+        history: [AgentStep],
+        observation: AgentObservation
+    ) async throws -> AgentResponse
 }
 
 // MARK: - Default Implementation with Screen Context
 
 extension VisionActionGenerating {
+    /// Generates actions from a backend-neutral automation observation.
+    ///
+    /// Existing custom vision backends remain compatible: the default
+    /// implementation forwards native observations to the screen-context
+    /// overload and forwards browser observations as screenshot-only input.
+    public func generateActions(
+        goal: String,
+        screenshot: Data?,
+        screenSize: CGSize,
+        history: [AgentStep],
+        observation: AgentObservation
+    ) async throws -> AgentResponse {
+        try await generateActions(
+            goal: goal,
+            screenshot: screenshot,
+            screenSize: screenSize,
+            history: history,
+            screenContext: observation.nativeScreenContext
+        )
+    }
+
     /// Generates actions with additional screen context alongside the screenshot.
     ///
     /// The default implementation ignores the screen context and delegates to the

--- a/Sources/SwiftAutoGUI/Actions/Agent.swift
+++ b/Sources/SwiftAutoGUI/Actions/Agent.swift
@@ -46,6 +46,9 @@ public struct Agent: Sendable {
     /// Controls whether screenshots accompany structured screen context.
     public let visionMode: AgentVisionMode
 
+    /// The environment used to observe and execute actions.
+    public let automationBackend: any AgentAutomationBackend
+
     /// Creates an agent with the specified configuration.
     ///
     /// - Parameters:
@@ -55,18 +58,23 @@ public struct Agent: Sendable {
     ///   - screenContextOptions: Options for screen context gathering (default: enabled with defaults).
     ///     Pass `nil` to disable.
     ///   - visionMode: Controls when screenshots are included (default: ``AgentVisionMode/always``).
+    ///   - automationBackend: Optional observation/execution environment. `nil` preserves
+    ///     the native Accessibility and CGEvent backend.
     public init(
         backend: any VisionActionGenerating,
         maxIterations: Int = 20,
         delayBetweenSteps: TimeInterval = 1.0,
         screenContextOptions: ScreenContextProvider.Options? = ScreenContextProvider.Options(),
-        visionMode: AgentVisionMode = .always
+        visionMode: AgentVisionMode = .always,
+        automationBackend: (any AgentAutomationBackend)? = nil
     ) {
         self.backend = backend
         self.maxIterations = maxIterations
         self.delayBetweenSteps = delayBetweenSteps
         self.screenContextOptions = screenContextOptions
         self.visionMode = visionMode
+        self.automationBackend = automationBackend
+            ?? NativeAutomationBackend(screenContextOptions: screenContextOptions)
     }
 
     /// Runs the agent loop to achieve the given goal.
@@ -92,58 +100,31 @@ public struct Agent: Sendable {
         for _ in 0..<maxIterations {
             try Task.checkCancellation()
 
-            // 1. Observe structured screen state first.
-            let screenContext: ScreenContext? = screenContextOptions.map { options in
-                ScreenContextProvider.gather(options: options)
-            }
-
-            let includeScreenshot: Bool
-            switch visionMode {
-            case .always:
-                includeScreenshot = true
-            case .automatic:
-                includeScreenshot = screenContext?.actionableElementCount == 0
-            case .never:
-                includeScreenshot = false
-            }
-
-            let jpegData: Data?
-            if includeScreenshot {
-                guard let screenshot = try await SwiftAutoGUI.screenshot(),
-                      let data = screenshot.jpegData(compressionFactor: 0.5) else {
-                    throw ActionGeneratorError.invalidResponse(detail: "Failed to capture screenshot")
-                }
-                jpegData = data
-            } else {
-                jpegData = nil
-            }
-
-            let screenSize = SwiftAutoGUI.size()
-            let screenCGSize = CGSize(width: screenSize.width, height: screenSize.height)
+            // 1. Observe through the selected automation environment.
+            let observation = try await automationBackend.observe(visionMode: visionMode)
 
             // 2. Think: send to backend
             let response = try await backend.generateActions(
                 goal: goal,
-                screenshot: jpegData,
-                screenSize: screenCGSize,
+                screenshot: observation.screenshotJPEGData,
+                screenSize: observation.viewportSize,
                 history: steps,
-                screenContext: screenContext
+                observation: observation
             )
 
             // 3. Act: execute against the observation used by the model. Stop
             // as soon as the UI changes or an action fails, then re-observe.
-            var currentContext = screenContext
+            var currentObservation = observation
             var executedActions: [BasicAction] = []
             var executionResults: [ActionExecutionResult] = []
             for action in response.actions {
-                let execution = await AgentActionExecutor.execute(
+                let execution = await automationBackend.execute(
                     action,
-                    in: currentContext,
-                    screenContextOptions: screenContextOptions
+                    in: currentObservation
                 )
                 executedActions.append(action)
                 executionResults.append(execution.result)
-                currentContext = execution.screenContext
+                currentObservation = execution.observation
 
                 if !execution.result.succeeded || execution.result.screenChanged {
                     break

--- a/Sources/SwiftAutoGUI/Actions/AgentActionExecutor.swift
+++ b/Sources/SwiftAutoGUI/Actions/AgentActionExecutor.swift
@@ -10,8 +10,60 @@ import Foundation
 public enum AgentActionExecutionMethod: String, Sendable, Codable {
     case accessibility
     case cgEvent
+    case cdp
     case standardAction
     case none
+}
+
+/// A top-level browser navigation observed after an action.
+public struct AgentNavigationResult: Sendable, Codable, Equatable {
+    public let fromURL: String?
+    public let toURL: String
+
+    public init(fromURL: String?, toURL: String) {
+        self.fromURL = fromURL
+        self.toURL = toURL
+    }
+}
+
+/// A browser tab lifecycle change observed after an action.
+public struct AgentTabChange: Sendable, Codable, Equatable {
+    public enum Kind: String, Sendable, Codable { case opened, closed, activated }
+
+    public let kind: Kind
+    public let tabID: String
+    public let url: String?
+
+    public init(kind: Kind, tabID: String, url: String? = nil) {
+        self.kind = kind
+        self.tabID = tabID
+        self.url = url
+    }
+}
+
+/// A browser download lifecycle update observed after an action.
+public struct AgentDownloadResult: Sendable, Codable, Equatable {
+    public enum State: String, Sendable, Codable { case requested, inProgress, completed, canceled }
+
+    public let identifier: String
+    public let url: String?
+    public let suggestedFilename: String?
+    public let state: State
+    public let filePath: String?
+
+    public init(
+        identifier: String,
+        url: String? = nil,
+        suggestedFilename: String? = nil,
+        state: State,
+        filePath: String? = nil
+    ) {
+        self.identifier = identifier
+        self.url = url
+        self.suggestedFilename = suggestedFilename
+        self.state = state
+        self.filePath = filePath
+    }
 }
 
 /// Structured result for a single action executed by ``Agent``.
@@ -23,6 +75,9 @@ public struct ActionExecutionResult: Sendable, Codable {
     public let screenChanged: Bool
     public let focusedAppChanged: Bool
     public let focusedElementChanged: Bool
+    public let navigation: AgentNavigationResult?
+    public let tabChanges: [AgentTabChange]
+    public let downloads: [AgentDownloadResult]
 
     public init(
         action: BasicAction,
@@ -31,7 +86,10 @@ public struct ActionExecutionResult: Sendable, Codable {
         failureReason: String? = nil,
         screenChanged: Bool = false,
         focusedAppChanged: Bool = false,
-        focusedElementChanged: Bool = false
+        focusedElementChanged: Bool = false,
+        navigation: AgentNavigationResult? = nil,
+        tabChanges: [AgentTabChange] = [],
+        downloads: [AgentDownloadResult] = []
     ) {
         self.action = action
         self.succeeded = succeeded
@@ -40,6 +98,9 @@ public struct ActionExecutionResult: Sendable, Codable {
         self.screenChanged = screenChanged
         self.focusedAppChanged = focusedAppChanged
         self.focusedElementChanged = focusedElementChanged
+        self.navigation = navigation
+        self.tabChanges = tabChanges
+        self.downloads = downloads
     }
 }
 
@@ -96,6 +157,8 @@ public enum AgentActionExecutor {
         in observation: ScreenContext?
     ) async -> (succeeded: Bool, method: AgentActionExecutionMethod, failureReason: String?) {
         switch action {
+        case .activateTab:
+            return (false, .none, "Browser tab actions require SwiftAutoGUIBrowser.")
         case .pressElement(let elementID):
             guard elementID > 0,
                   let observation,

--- a/Sources/SwiftAutoGUI/Actions/AgentAutomationBackend.swift
+++ b/Sources/SwiftAutoGUI/Actions/AgentAutomationBackend.swift
@@ -1,0 +1,158 @@
+import AppKit
+import Foundation
+
+/// The kind of environment represented by an agent observation.
+public enum AgentObservationKind: String, Sendable, Codable {
+    case native
+    case browser
+}
+
+/// A backend-neutral observation consumed by ``Agent`` and vision backends.
+///
+/// `nativeScreenContext` is populated only by ``NativeAutomationBackend`` and
+/// keeps the existing screen-context API source-compatible. Browser backends
+/// provide their semantic state through `formattedContext` instead.
+public struct AgentObservation: Sendable {
+    public let id: UUID
+    public let kind: AgentObservationKind
+    public let formattedContext: String
+    public let stateFingerprint: String
+    public let actionableElementCount: Int
+    public let viewportSize: CGSize
+    public let screenshotJPEGData: Data?
+    public let nativeScreenContext: ScreenContext?
+
+    public init(
+        id: UUID = UUID(),
+        kind: AgentObservationKind,
+        formattedContext: String,
+        stateFingerprint: String,
+        actionableElementCount: Int,
+        viewportSize: CGSize,
+        screenshotJPEGData: Data? = nil,
+        nativeScreenContext: ScreenContext? = nil
+    ) {
+        self.id = id
+        self.kind = kind
+        self.formattedContext = formattedContext
+        self.stateFingerprint = stateFingerprint
+        self.actionableElementCount = actionableElementCount
+        self.viewportSize = viewportSize
+        self.screenshotJPEGData = screenshotJPEGData
+        self.nativeScreenContext = nativeScreenContext
+    }
+}
+
+/// An action result paired with the backend observation captured afterwards.
+public struct AgentAutomationExecution: Sendable {
+    public let result: ActionExecutionResult
+    public let observation: AgentObservation
+
+    public init(result: ActionExecutionResult, observation: AgentObservation) {
+        self.result = result
+        self.observation = observation
+    }
+}
+
+/// Supplies observations and executes actions for ``Agent``.
+///
+/// SwiftAutoGUI uses ``NativeAutomationBackend`` by default. Optional modules
+/// can implement this protocol without adding their dependencies to the core
+/// library.
+public protocol AgentAutomationBackend: Sendable {
+    func observe(visionMode: AgentVisionMode) async throws -> AgentObservation
+
+    func execute(
+        _ action: BasicAction,
+        in observation: AgentObservation
+    ) async -> AgentAutomationExecution
+}
+
+/// The existing Accessibility and CGEvent based Agent environment.
+public struct NativeAutomationBackend: AgentAutomationBackend, Sendable {
+    public let screenContextOptions: ScreenContextProvider.Options?
+    public let observationDelay: TimeInterval
+
+    public init(
+        screenContextOptions: ScreenContextProvider.Options? = ScreenContextProvider.Options(),
+        observationDelay: TimeInterval = 0.15
+    ) {
+        self.screenContextOptions = screenContextOptions
+        self.observationDelay = observationDelay
+    }
+
+    public func observe(visionMode: AgentVisionMode) async throws -> AgentObservation {
+        let context = await MainActor.run {
+            screenContextOptions.map { ScreenContextProvider.gather(options: $0) }
+        }
+        let includeScreenshot = switch visionMode {
+        case .always: true
+        case .automatic: context?.actionableElementCount == 0
+        case .never: false
+        }
+
+        let screenshotData: Data?
+        if includeScreenshot {
+            guard let screenshot = try await SwiftAutoGUI.screenshot(),
+                  let data = await MainActor.run(body: {
+                      screenshot.jpegData(compressionFactor: 0.5)
+                  }) else {
+                throw ActionGeneratorError.invalidResponse(detail: "Failed to capture screenshot")
+            }
+            screenshotData = data
+        } else {
+            screenshotData = nil
+        }
+
+        let size = await MainActor.run { SwiftAutoGUI.size() }
+        return Self.makeObservation(
+            context: context,
+            viewportSize: CGSize(width: size.width, height: size.height),
+            screenshotData: screenshotData
+        )
+    }
+
+    public func execute(
+        _ action: BasicAction,
+        in observation: AgentObservation
+    ) async -> AgentAutomationExecution {
+        guard observation.kind == .native else {
+            let result = ActionExecutionResult(
+                action: action,
+                succeeded: false,
+                method: .none,
+                failureReason: "NativeAutomationBackend cannot execute a non-native observation."
+            )
+            return AgentAutomationExecution(result: result, observation: observation)
+        }
+
+        let execution = await AgentActionExecutor.execute(
+            action,
+            in: observation.nativeScreenContext,
+            screenContextOptions: screenContextOptions,
+            observationDelay: observationDelay
+        )
+        let nextObservation = Self.makeObservation(
+            context: execution.screenContext,
+            viewportSize: observation.viewportSize,
+            screenshotData: nil
+        )
+        return AgentAutomationExecution(result: execution.result, observation: nextObservation)
+    }
+
+    private static func makeObservation(
+        context: ScreenContext?,
+        viewportSize: CGSize,
+        screenshotData: Data?
+    ) -> AgentObservation {
+        AgentObservation(
+            kind: .native,
+            formattedContext: context?.formatted() ?? "",
+            stateFingerprint: context?.stateFingerprint ?? "native:no-context",
+            actionableElementCount: context?.actionableElementCount ?? 0,
+            viewportSize: viewportSize,
+            screenshotJPEGData: screenshotData,
+            nativeScreenContext: context
+        )
+    }
+}

--- a/Sources/SwiftAutoGUI/Documentation.docc/SwiftAutoGUI.md
+++ b/Sources/SwiftAutoGUI/Documentation.docc/SwiftAutoGUI.md
@@ -53,6 +53,9 @@ let result = try await agent.run(goal: "Open Safari and search for Swift")
 print("Completed: \(result.completed), Steps: \(result.iterationsUsed)")
 ```
 
+`Agent` uses ``NativeAutomationBackend`` by default. Optional modules can supply
+another ``AgentAutomationBackend`` explicitly while preserving the native default.
+
 ### With Step Callback
 
 ```swift

--- a/Sources/SwiftAutoGUIBrowser/BrowserObservationBuilder.swift
+++ b/Sources/SwiftAutoGUIBrowser/BrowserObservationBuilder.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+struct BrowserAXCandidate: Sendable, Equatable {
+    let backendDOMNodeID: Int
+    let frameID: String?
+    let role: String
+    let name: String
+    let value: String?
+    let isEnabled: Bool
+    let isEditable: Bool
+}
+
+enum BrowserSelectorMapBuilder {
+    private static let actionableRoles: Set<String> = [
+        "button", "link", "textbox", "searchbox", "checkbox", "radio",
+        "combobox", "listbox", "menuitem", "option", "tab", "switch",
+        "slider", "spinbutton", "treeitem"
+    ]
+
+    static func candidates(from result: CDPJSONValue, limit: Int) -> [BrowserAXCandidate] {
+        let nodes = result["nodes"]?.arrayValue ?? []
+        var output: [BrowserAXCandidate] = []
+        output.reserveCapacity(min(nodes.count, limit))
+
+        for node in nodes {
+            guard output.count < limit,
+                  node["ignored"]?.boolValue != true,
+                  let backendID = node["backendDOMNodeId"]?.intValue,
+                  let role = nestedString(node["role"]),
+                  !role.isEmpty else { continue }
+
+            let properties = propertyMap(node["properties"]?.arrayValue ?? [])
+            let isHidden = properties["hidden"]?.boolValue == true
+            let isDisabled = properties["disabled"]?.boolValue == true
+            let isEditable = properties["editable"]?.boolValue == true
+                || properties["settable"]?.boolValue == true
+            let isFocusable = properties["focusable"]?.boolValue == true
+            guard !isHidden,
+                  actionableRoles.contains(role.lowercased()) || isEditable || isFocusable else { continue }
+
+            output.append(
+                BrowserAXCandidate(
+                    backendDOMNodeID: backendID,
+                    frameID: node["frameId"]?.stringValue,
+                    role: role,
+                    name: nestedString(node["name"]) ?? "",
+                    value: nestedString(node["value"]),
+                    isEnabled: !isDisabled,
+                    isEditable: isEditable || ["textbox", "searchbox"].contains(role.lowercased())
+                )
+            )
+        }
+        return output
+    }
+
+    static func elements(
+        candidates: [BrowserAXCandidate],
+        bounds: [Int: BrowserRect],
+        destinationURLs: [Int: String]
+    ) -> [BrowserElement] {
+        var nextID = 1
+        return candidates.compactMap { candidate in
+            guard candidate.isEnabled,
+                  let rect = bounds[candidate.backendDOMNodeID],
+                  rect.width > 0,
+                  rect.height > 0 else { return nil }
+            defer { nextID += 1 }
+            return BrowserElement(
+                elementID: nextID,
+                backendDOMNodeID: candidate.backendDOMNodeID,
+                frameID: candidate.frameID,
+                role: candidate.role,
+                name: candidate.name,
+                value: candidate.value,
+                bounds: rect,
+                isEnabled: candidate.isEnabled,
+                isEditable: candidate.isEditable,
+                destinationURL: destinationURLs[candidate.backendDOMNodeID]
+            )
+        }
+    }
+
+    static func format(tabs: [BrowserTab], activeTabID: String, elements: [BrowserElement]) -> String {
+        var lines = ["Browser tabs:"]
+        for tab in tabs {
+            let active = tab.id == activeTabID ? " active" : ""
+            lines.append("  [tab:\(tab.id)] \"\(tab.title)\" \(tab.url) state=\(tab.state.rawValue)\(active)")
+        }
+        lines.append("Actionable page elements:")
+        if elements.isEmpty { lines.append("  (none)") }
+        for element in elements {
+            var line = "  [#\(element.elementID)] \(element.role)"
+            if !element.name.isEmpty { line += " \"\(element.name)\"" }
+            if let value = element.value, !value.isEmpty { line += " value=\"\(value.prefix(120))\"" }
+            let rect = element.bounds
+            line += " {\(Int(rect.x)),\(Int(rect.y)) \(Int(rect.width))x\(Int(rect.height))}"
+            if element.isEditable { line += " editable" }
+            if let url = element.destinationURL { line += " url=\"\(url)\"" }
+            lines.append(line)
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    static func fingerprint(
+        tab: BrowserTab,
+        loaderID: String,
+        elements: [BrowserElement]
+    ) -> String {
+        var lines = ["tab:\(tab.id):\(tab.url):\(loaderID)"]
+        for element in elements {
+            lines.append(
+                "\(element.backendDOMNodeID):\(element.role):\(element.name):\(element.value ?? ""):" +
+                "\(Int(element.bounds.x)),\(Int(element.bounds.y)),\(Int(element.bounds.width)),\(Int(element.bounds.height))"
+            )
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    static func bounds(from boxModelResult: CDPJSONValue) -> BrowserRect? {
+        guard let quad = boxModelResult["model"]?["border"]?.arrayValue?.compactMap(\.doubleValue),
+              quad.count >= 8 else { return nil }
+        let xs = stride(from: 0, to: quad.count, by: 2).map { quad[$0] }
+        let ys = stride(from: 1, to: quad.count, by: 2).map { quad[$0] }
+        guard let minX = xs.min(), let maxX = xs.max(),
+              let minY = ys.min(), let maxY = ys.max() else { return nil }
+        return BrowserRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
+    }
+
+    static func destinationURL(from describeNodeResult: CDPJSONValue) -> String? {
+        guard let attributes = describeNodeResult["node"]?["attributes"]?.arrayValue?.compactMap(\.stringValue) else {
+            return nil
+        }
+        var index = 0
+        while index + 1 < attributes.count {
+            if attributes[index].lowercased() == "href" { return attributes[index + 1] }
+            index += 2
+        }
+        return nil
+    }
+
+    private static func propertyMap(_ properties: [CDPJSONValue]) -> [String: CDPJSONValue] {
+        Dictionary(uniqueKeysWithValues: properties.compactMap { property in
+            guard let name = property["name"]?.stringValue,
+                  let value = property["value"]?["value"] else { return nil }
+            return (name, value)
+        })
+    }
+
+    private static func nestedString(_ value: CDPJSONValue?) -> String? {
+        if let string = value?["value"]?.stringValue { return string }
+        if let number = value?["value"]?.doubleValue { return String(number) }
+        if let bool = value?["value"]?.boolValue { return String(bool) }
+        return nil
+    }
+}

--- a/Sources/SwiftAutoGUIBrowser/BrowserSession.swift
+++ b/Sources/SwiftAutoGUIBrowser/BrowserSession.swift
@@ -1,0 +1,833 @@
+import Foundation
+import SwiftAutoGUI
+
+/// A browser-only Agent backend connected to a Chromium debugging endpoint.
+public actor BrowserSession: AgentAutomationBackend {
+    public struct Options: Sendable {
+        public var maxElements: Int
+        public var actionObservationDelay: Duration
+
+        public init(maxElements: Int = 100, actionObservationDelay: Duration = .milliseconds(200)) {
+            self.maxElements = maxElements
+            self.actionObservationDelay = actionObservationDelay
+        }
+    }
+
+    private struct Discovery: Decodable {
+        let webSocketDebuggerUrl: String
+    }
+
+    private let transport: any CDPTransporting
+    private let securityPolicy: BrowserSecurityPolicy
+    private let authorizer: (any BrowserActionAuthorizing)?
+    private let options: Options
+    private var eventTask: Task<Void, Never>?
+    private var tabsByID: [String: BrowserTab] = [:]
+    private var sessionIDByTabID: [String: String] = [:]
+    private var activeTabID: String?
+    private var observations: [UUID: BrowserObservation] = [:]
+    private var pendingNavigation: AgentNavigationResult?
+    private var pendingTabChanges: [AgentTabChange] = []
+    private var pendingDownloads: [AgentDownloadResult] = []
+    private var preauthorizedNavigationURLs: Set<String> = []
+
+    init(
+        transport: any CDPTransporting,
+        securityPolicy: BrowserSecurityPolicy,
+        authorizer: (any BrowserActionAuthorizing)?,
+        options: Options
+    ) {
+        self.transport = transport
+        self.securityPolicy = securityPolicy
+        self.authorizer = authorizer
+        self.options = options
+    }
+
+    /// Connects to an existing Chromium browser debugging endpoint.
+    public static func connect(
+        endpoint: URL,
+        securityPolicy: BrowserSecurityPolicy = BrowserSecurityPolicy(),
+        authorizer: (any BrowserActionAuthorizing)? = nil,
+        options: Options = Options()
+    ) async throws -> BrowserSession {
+        try securityPolicy.validateEndpoint(endpoint)
+        let discoveryURL = discoveryURL(for: endpoint)
+        let delegate = DiscoverySessionDelegate(policy: securityPolicy)
+        let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+        let (data, response) = try await session.data(from: discoveryURL)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            throw BrowserError.discoveryFailed("GET \(discoveryURL.absoluteString) did not return HTTP 200.")
+        }
+        if let finalURL = response.url { try securityPolicy.validateEndpoint(finalURL) }
+        let discovery: Discovery
+        do { discovery = try JSONDecoder().decode(Discovery.self, from: data) }
+        catch { throw BrowserError.discoveryFailed(error.localizedDescription) }
+        guard let webSocketURL = URL(string: discovery.webSocketDebuggerUrl) else {
+            throw BrowserError.invalidWebSocketURL(discovery.webSocketDebuggerUrl)
+        }
+        try securityPolicy.validateWebSocket(webSocketURL)
+
+        let backend = BrowserSession(
+            transport: WebSocketCDPTransport(webSocketURL: webSocketURL),
+            securityPolicy: securityPolicy,
+            authorizer: authorizer,
+            options: options
+        )
+        try await backend.start()
+        return backend
+    }
+
+    /// Closes the CDP connection.
+    public func close() async {
+        eventTask?.cancel()
+        eventTask = nil
+        await transport.close()
+    }
+
+    /// Returns all current page tabs.
+    public func listTabs() async throws -> [BrowserTab] {
+        try await refreshTabs()
+        return sortedTabs()
+    }
+
+    /// Activates a page tab and makes it the target of subsequent observations.
+    public func activateTab(_ tabID: String) async throws {
+        try await refreshTabs()
+        guard tabsByID[tabID] != nil else { throw BrowserError.tabNotFound(tabID) }
+        _ = try await transport.send(
+            method: "Target.activateTarget",
+            params: .object(["targetId": .string(tabID)]),
+            sessionID: nil
+        )
+        activeTabID = tabID
+        try await ensureAttached(to: tabID)
+        markActiveTab(tabID)
+        pendingTabChanges.append(AgentTabChange(kind: .activated, tabID: tabID, url: tabsByID[tabID]?.url))
+    }
+
+    /// Observes the selected browser tab and builds a numbered semantic element map.
+    public func observe(
+        tabID requestedTabID: String? = nil,
+        includeScreenshot: Bool = false
+    ) async throws -> BrowserObservation {
+        try await refreshTabs()
+        guard let tabID = requestedTabID ?? activeTabID ?? sortedTabs().first?.id else {
+            throw BrowserError.noPageTabs
+        }
+        if activeTabID != tabID { try await activateTab(tabID) }
+        try await ensureAttached(to: tabID)
+        guard let sessionID = sessionIDByTabID[tabID], var tab = tabsByID[tabID] else {
+            throw BrowserError.tabNotFound(tabID)
+        }
+
+        _ = try await transport.send(
+            method: "DOM.getDocument",
+            params: .object(["depth": .number(3), "pierce": .bool(true)]),
+            sessionID: sessionID
+        )
+        let frameTree = try await transport.send(
+            method: "Page.getFrameTree",
+            params: .object([:]),
+            sessionID: sessionID
+        )
+        guard let frame = frameTree["frameTree"]?["frame"],
+              let frameID = frame["id"]?.stringValue else {
+            throw BrowserError.malformedResponse("Page.getFrameTree omitted the main frame.")
+        }
+        let loaderID = frame["loaderId"]?.stringValue ?? "same-document"
+        let observedURL = frame["url"]?.stringValue ?? tab.url
+        tab = BrowserTab(id: tab.id, url: observedURL, title: tab.title, state: tab.state)
+        tabsByID[tabID] = tab
+
+        var candidates: [BrowserAXCandidate] = []
+        for observedFrameID in frameIDs(from: frameTree["frameTree"]) where candidates.count < options.maxElements {
+            let axTree = try await transport.send(
+                method: "Accessibility.getFullAXTree",
+                params: .object(["frameId": .string(observedFrameID)]),
+                sessionID: sessionID
+            )
+            candidates.append(
+                contentsOf: BrowserSelectorMapBuilder.candidates(
+                    from: axTree,
+                    limit: options.maxElements - candidates.count
+                )
+            )
+        }
+        var bounds: [Int: BrowserRect] = [:]
+        var destinationURLs: [Int: String] = [:]
+        for candidate in candidates {
+            let params = CDPJSONValue.object(
+                ("backendNodeId", .number(Double(candidate.backendDOMNodeID)))
+            )
+            if let box = try? await transport.send(method: "DOM.getBoxModel", params: params, sessionID: sessionID),
+               let rect = BrowserSelectorMapBuilder.bounds(from: box) {
+                bounds[candidate.backendDOMNodeID] = rect
+            }
+            if let description = try? await transport.send(
+                method: "DOM.describeNode",
+                params: .object(["backendNodeId": .number(Double(candidate.backendDOMNodeID)), "depth": .number(0)]),
+                sessionID: sessionID
+            ), let url = BrowserSelectorMapBuilder.destinationURL(from: description) {
+                destinationURLs[candidate.backendDOMNodeID] = url
+            }
+        }
+        let elements = BrowserSelectorMapBuilder.elements(
+            candidates: candidates,
+            bounds: bounds,
+            destinationURLs: destinationURLs
+        )
+        let viewport = try await viewportSize(sessionID: sessionID)
+        let screenshot = includeScreenshot ? try await captureScreenshot(sessionID: sessionID) : nil
+        let allTabs = sortedTabs()
+        let formatted = BrowserSelectorMapBuilder.format(tabs: allTabs, activeTabID: tabID, elements: elements)
+        let fingerprint = BrowserSelectorMapBuilder.fingerprint(tab: tab, loaderID: loaderID, elements: elements)
+        let observation = BrowserObservation(
+            tab: tab,
+            frameID: frameID,
+            loaderID: loaderID,
+            viewportSize: viewport,
+            elements: elements,
+            formattedContext: formatted,
+            stateFingerprint: fingerprint,
+            screenshotJPEGData: screenshot
+        )
+        observations[observation.id] = observation
+        trimObservations()
+        return observation
+    }
+
+    /// Executes a browser action against the exact observation that produced it.
+    public func execute(
+        _ action: BrowserAction,
+        against observation: BrowserObservation
+    ) async -> BrowserActionResult {
+        pendingNavigation = nil
+        pendingTabChanges.removeAll()
+        pendingDownloads.removeAll()
+        do {
+            try await perform(action, against: observation)
+            if options.actionObservationDelay > .zero {
+                try await Task.sleep(for: options.actionObservationDelay)
+            }
+            let next = try await observe(tabID: activeTabID, includeScreenshot: false)
+            return BrowserActionResult(
+                action: action,
+                succeeded: true,
+                observation: next,
+                navigation: pendingNavigation,
+                tabChanges: pendingTabChanges,
+                downloads: pendingDownloads
+            )
+        } catch {
+            let failure = (error as? BrowserError) ?? .malformedResponse(error.localizedDescription)
+            let next = (try? await observe(tabID: activeTabID, includeScreenshot: false)) ?? observation
+            return BrowserActionResult(
+                action: action,
+                succeeded: false,
+                failure: failure,
+                observation: next,
+                navigation: pendingNavigation,
+                tabChanges: pendingTabChanges,
+                downloads: pendingDownloads
+            )
+        }
+    }
+
+    // MARK: AgentAutomationBackend
+
+    public func observe(visionMode: AgentVisionMode) async throws -> AgentObservation {
+        var browserObservation = try await observe(tabID: activeTabID, includeScreenshot: visionMode == .always)
+        if visionMode == .automatic, browserObservation.elements.isEmpty {
+            browserObservation = try await observe(tabID: browserObservation.tab.id, includeScreenshot: true)
+        }
+        return makeAgentObservation(browserObservation)
+    }
+
+    public func execute(
+        _ action: BasicAction,
+        in observation: AgentObservation
+    ) async -> AgentAutomationExecution {
+        guard observation.kind == .browser,
+              let browserObservation = observations[observation.id] else {
+            let result = ActionExecutionResult(
+                action: action,
+                succeeded: false,
+                method: .none,
+                failureReason: BrowserError.observationNotFound.localizedDescription
+            )
+            return AgentAutomationExecution(result: result, observation: observation)
+        }
+
+        guard let browserAction = browserAction(from: action) else {
+            let error = BrowserError.unsupportedAction(String(describing: action))
+            let result = ActionExecutionResult(
+                action: action,
+                succeeded: false,
+                method: .none,
+                failureReason: error.localizedDescription
+            )
+            return AgentAutomationExecution(result: result, observation: observation)
+        }
+
+        let browserResult = await execute(browserAction, against: browserObservation)
+        let changed = browserObservation.stateFingerprint != browserResult.observation.stateFingerprint
+            || browserResult.navigation != nil
+            || !browserResult.tabChanges.isEmpty
+            || !browserResult.downloads.isEmpty
+        let result = ActionExecutionResult(
+            action: action,
+            succeeded: browserResult.succeeded,
+            method: .cdp,
+            failureReason: browserResult.failure?.localizedDescription,
+            screenChanged: changed,
+            navigation: browserResult.navigation,
+            tabChanges: browserResult.tabChanges,
+            downloads: browserResult.downloads
+        )
+        return AgentAutomationExecution(
+            result: result,
+            observation: makeAgentObservation(browserResult.observation)
+        )
+    }
+
+    // MARK: Connection and events
+
+    func start() async throws {
+        try await transport.connect()
+        let stream = await transport.events()
+        eventTask = Task { [weak self] in
+            for await event in stream {
+                await self?.handle(event)
+            }
+        }
+        _ = try await transport.send(method: "Browser.getVersion", params: .object([:]), sessionID: nil)
+        _ = try await transport.send(
+            method: "Target.setDiscoverTargets",
+            params: .object(["discover": .bool(true)]),
+            sessionID: nil
+        )
+        _ = try? await transport.send(
+            method: "Browser.setDownloadBehavior",
+            params: .object(["behavior": .string("default"), "eventsEnabled": .bool(true)]),
+            sessionID: nil
+        )
+        try await refreshTabs()
+        guard let first = sortedTabs().first else { throw BrowserError.noPageTabs }
+        activeTabID = first.id
+        try await ensureAttached(to: first.id)
+        markActiveTab(first.id)
+    }
+
+    private func refreshTabs() async throws {
+        let result = try await transport.send(method: "Target.getTargets", params: .object([:]), sessionID: nil)
+        let infos = result["targetInfos"]?.arrayValue ?? []
+        var refreshed: [String: BrowserTab] = [:]
+        for info in infos where info["type"]?.stringValue == "page" {
+            guard let id = info["targetId"]?.stringValue else { continue }
+            let existing = tabsByID[id]
+            let state: BrowserTabState = id == activeTabID ? .active : (existing?.state ?? .ready)
+            refreshed[id] = BrowserTab(
+                id: id,
+                url: info["url"]?.stringValue ?? "",
+                title: info["title"]?.stringValue ?? "",
+                state: state
+            )
+        }
+        tabsByID = refreshed
+        if let activeTabID, tabsByID[activeTabID] == nil { self.activeTabID = sortedTabs().first?.id }
+    }
+
+    private func ensureAttached(to tabID: String) async throws {
+        if sessionIDByTabID[tabID] != nil { return }
+        let result = try await transport.send(
+            method: "Target.attachToTarget",
+            params: .object(["targetId": .string(tabID), "flatten": .bool(true)]),
+            sessionID: nil
+        )
+        guard let sessionID = result["sessionId"]?.stringValue else {
+            throw BrowserError.malformedResponse("Target.attachToTarget omitted sessionId.")
+        }
+        sessionIDByTabID[tabID] = sessionID
+        for method in ["Page.enable", "DOM.enable", "Accessibility.enable"] {
+            _ = try await transport.send(method: method, params: .object([:]), sessionID: sessionID)
+        }
+        _ = try await transport.send(
+            method: "Page.setLifecycleEventsEnabled",
+            params: .object(["enabled": .bool(true)]),
+            sessionID: sessionID
+        )
+        _ = try await transport.send(
+            method: "Fetch.enable",
+            params: .object([
+                "patterns": .array([
+                    .object([
+                        "urlPattern": .string("*"),
+                        "resourceType": .string("Document"),
+                        "requestStage": .string("Request")
+                    ])
+                ])
+            ]),
+            sessionID: sessionID
+        )
+    }
+
+    private func handle(_ event: CDPEvent) async {
+        switch event.method {
+        case "Target.targetCreated":
+            guard let info = event.params["targetInfo"], info["type"]?.stringValue == "page",
+                  let id = info["targetId"]?.stringValue else { return }
+            let tab = BrowserTab(
+                id: id,
+                url: info["url"]?.stringValue ?? "",
+                title: info["title"]?.stringValue ?? "",
+                state: .ready
+            )
+            tabsByID[id] = tab
+            pendingTabChanges.append(.init(kind: .opened, tabID: id, url: tab.url))
+
+        case "Target.targetDestroyed":
+            guard let id = event.params["targetId"]?.stringValue else { return }
+            let url = tabsByID[id]?.url
+            tabsByID[id] = nil
+            sessionIDByTabID[id] = nil
+            pendingTabChanges.append(.init(kind: .closed, tabID: id, url: url))
+
+        case "Target.targetInfoChanged":
+            guard let info = event.params["targetInfo"], info["type"]?.stringValue == "page",
+                  let id = info["targetId"]?.stringValue else { return }
+            let old = tabsByID[id]
+            tabsByID[id] = BrowserTab(
+                id: id,
+                url: info["url"]?.stringValue ?? old?.url ?? "",
+                title: info["title"]?.stringValue ?? old?.title ?? "",
+                state: old?.state ?? .ready
+            )
+
+        case "Page.frameStartedLoading":
+            updateTabState(for: event.sessionID, state: .loading)
+
+        case "Page.frameStoppedLoading", "Page.loadEventFired":
+            updateTabState(for: event.sessionID, state: .ready)
+
+        case "Page.frameNavigated":
+            guard let frame = event.params["frame"], frame["parentId"] == nil,
+                  let url = frame["url"]?.stringValue,
+                  let tabID = tabID(for: event.sessionID), let old = tabsByID[tabID] else { return }
+            tabsByID[tabID] = BrowserTab(id: old.id, url: url, title: old.title, state: .ready)
+            if old.url != url { pendingNavigation = .init(fromURL: old.url, toURL: url) }
+
+        case "Fetch.requestPaused":
+            await handlePausedRequest(event)
+
+        case "Browser.downloadWillBegin":
+            await handleDownloadWillBegin(event.params)
+
+        case "Browser.downloadProgress":
+            handleDownloadProgress(event.params)
+
+        default:
+            break
+        }
+    }
+
+    private func handlePausedRequest(_ event: CDPEvent) async {
+        guard let requestID = event.params["requestId"]?.stringValue,
+              let value = event.params["request"]?["url"]?.stringValue,
+              let url = URL(string: value) else { return }
+        let allowed = securityPolicy.allowsNavigation(to: url)
+        var authorized = allowed
+        if allowed, preauthorizedNavigationURLs.remove(url.absoluteString) == nil {
+            let currentURL = tabID(for: event.sessionID)
+                .flatMap { tabsByID[$0] }
+                .flatMap { URL(string: $0.url) }
+            if isCrossOrigin(from: currentURL, to: url) {
+                authorized = await authorizer?.authorize(.crossOriginNavigation(from: currentURL, to: url)) ?? false
+            }
+        }
+        let method = authorized ? "Fetch.continueRequest" : "Fetch.failRequest"
+        var params: [String: CDPJSONValue] = ["requestId": .string(requestID)]
+        if !authorized { params["errorReason"] = .string("BlockedByClient") }
+        _ = try? await transport.send(method: method, params: .object(params), sessionID: event.sessionID)
+    }
+
+    private func handleDownloadWillBegin(_ params: CDPJSONValue) async {
+        guard let guid = params["guid"]?.stringValue else { return }
+        let url = params["url"]?.stringValue.flatMap(URL.init(string:))
+        let filename = params["suggestedFilename"]?.stringValue
+        let allowed = await authorizer?.authorize(.download(url: url, suggestedFilename: filename)) ?? false
+        pendingDownloads.append(
+            .init(
+                identifier: guid,
+                url: url?.absoluteString,
+                suggestedFilename: filename,
+                state: allowed ? .requested : .canceled
+            )
+        )
+        if !allowed {
+            _ = try? await transport.send(
+                method: "Browser.cancelDownload",
+                params: .object(["guid": .string(guid)]),
+                sessionID: nil
+            )
+        }
+    }
+
+    private func handleDownloadProgress(_ params: CDPJSONValue) {
+        guard let guid = params["guid"]?.stringValue,
+              let stateValue = params["state"]?.stringValue else { return }
+        let state: AgentDownloadResult.State = switch stateValue {
+        case "completed": .completed
+        case "canceled": .canceled
+        default: .inProgress
+        }
+        pendingDownloads.append(
+            .init(identifier: guid, state: state, filePath: params["filePath"]?.stringValue)
+        )
+    }
+
+    // MARK: Action execution
+
+    private func perform(_ action: BrowserAction, against observation: BrowserObservation) async throws {
+        switch action {
+        case .navigate(let url):
+            try await authorizeNavigation(from: URL(string: observation.tab.url), to: url)
+            preauthorizedNavigationURLs.insert(url.absoluteString)
+            guard let sessionID = sessionIDByTabID[observation.tab.id] else {
+                throw BrowserError.tabNotFound(observation.tab.id)
+            }
+            let result = try await transport.send(
+                method: "Page.navigate",
+                params: .object(["url": .string(url.absoluteString)]),
+                sessionID: sessionID
+            )
+            if let errorText = result["errorText"]?.stringValue, !errorText.isEmpty {
+                throw BrowserError.malformedResponse(errorText)
+            }
+
+        case .click(let elementID):
+            let element = try await resolveElement(elementID, in: observation)
+            if let destination = resolvedDestination(element.destinationURL, base: observation.tab.url) {
+                try await authorizeNavigation(from: URL(string: observation.tab.url), to: destination)
+                preauthorizedNavigationURLs.insert(destination.absoluteString)
+            }
+            guard let sessionID = sessionIDByTabID[observation.tab.id] else {
+                throw BrowserError.tabNotFound(observation.tab.id)
+            }
+            _ = try? await transport.send(
+                method: "DOM.scrollIntoViewIfNeeded",
+                params: .object(["backendNodeId": .number(Double(element.backendDOMNodeID))]),
+                sessionID: sessionID
+            )
+            let live = try await resolveElement(elementID, in: observation)
+            for (type, button) in [("mouseMoved", "none"), ("mousePressed", "left"), ("mouseReleased", "left")] {
+                _ = try await transport.send(
+                    method: "Input.dispatchMouseEvent",
+                    params: .object([
+                        "type": .string(type),
+                        "x": .number(live.bounds.midX),
+                        "y": .number(live.bounds.midY),
+                        "button": .string(button),
+                        "clickCount": .number(type == "mouseMoved" ? 0 : 1)
+                    ]),
+                    sessionID: sessionID
+                )
+            }
+
+        case .replaceText(let elementID, let value):
+            let element = try await resolveElement(elementID, in: observation)
+            guard element.isEditable else { throw BrowserError.unsupportedAction("text replacement for #\(elementID)") }
+            guard let sessionID = sessionIDByTabID[observation.tab.id] else {
+                throw BrowserError.tabNotFound(observation.tab.id)
+            }
+            _ = try await transport.send(
+                method: "DOM.focus",
+                params: .object(["backendNodeId": .number(Double(element.backendDOMNodeID))]),
+                sessionID: sessionID
+            )
+            try await dispatchShortcut(["command", "a"], sessionID: sessionID)
+            _ = try await transport.send(
+                method: "Input.insertText",
+                params: .object(["text": .string(value)]),
+                sessionID: sessionID
+            )
+
+        case .insertText(let text):
+            guard let sessionID = activeSessionID else { throw BrowserError.noPageTabs }
+            _ = try await transport.send(
+                method: "Input.insertText",
+                params: .object(["text": .string(text)]),
+                sessionID: sessionID
+            )
+
+        case .keyShortcut(let keys):
+            guard let sessionID = activeSessionID else { throw BrowserError.noPageTabs }
+            try await dispatchShortcut(keys, sessionID: sessionID)
+
+        case .scroll(let horizontal, let vertical):
+            guard let sessionID = activeSessionID else { throw BrowserError.noPageTabs }
+            _ = try await transport.send(
+                method: "Input.dispatchMouseEvent",
+                params: .object([
+                    "type": .string("mouseWheel"),
+                    "x": .number(observation.viewportSize.width / 2),
+                    "y": .number(observation.viewportSize.height / 2),
+                    "deltaX": .number(Double(horizontal) * 100),
+                    "deltaY": .number(Double(-vertical) * 100)
+                ]),
+                sessionID: sessionID
+            )
+
+        case .activateTab(let tabID):
+            try await activateTab(tabID)
+
+        case .wait(let duration):
+            guard duration >= 0 else { throw BrowserError.unsupportedAction("negative wait") }
+            try await Task.sleep(for: .seconds(duration))
+        }
+    }
+
+    private func resolveElement(_ elementID: Int, in observation: BrowserObservation) async throws -> BrowserElement {
+        guard activeTabID == observation.tab.id,
+              let observed = observation.element(withID: elementID),
+              let sessionID = sessionIDByTabID[observation.tab.id] else {
+            throw BrowserError.staleElement(elementID)
+        }
+        let frameTree = try await transport.send(method: "Page.getFrameTree", params: .object([:]), sessionID: sessionID)
+        let currentLoader = frameTree["frameTree"]?["frame"]?["loaderId"]?.stringValue ?? "same-document"
+        guard currentLoader == observation.loaderID else { throw BrowserError.staleElement(elementID) }
+
+        let partial = try await transport.send(
+            method: "Accessibility.getPartialAXTree",
+            params: .object([
+                "backendNodeId": .number(Double(observed.backendDOMNodeID)),
+                "fetchRelatives": .bool(false)
+            ]),
+            sessionID: sessionID
+        )
+        guard let candidate = BrowserSelectorMapBuilder.candidates(from: partial, limit: 1).first,
+              candidate.role == observed.role,
+              candidate.name == observed.name,
+              candidate.isEnabled else { throw BrowserError.staleElement(elementID) }
+        let box = try await transport.send(
+            method: "DOM.getBoxModel",
+            params: .object(["backendNodeId": .number(Double(observed.backendDOMNodeID))]),
+            sessionID: sessionID
+        )
+        guard let bounds = BrowserSelectorMapBuilder.bounds(from: box), bounds.width > 0, bounds.height > 0 else {
+            throw BrowserError.staleElement(elementID)
+        }
+        return BrowserElement(
+            elementID: observed.elementID,
+            backendDOMNodeID: observed.backendDOMNodeID,
+            frameID: candidate.frameID,
+            role: candidate.role,
+            name: candidate.name,
+            value: candidate.value,
+            bounds: bounds,
+            isEnabled: candidate.isEnabled,
+            isEditable: candidate.isEditable,
+            destinationURL: observed.destinationURL
+        )
+    }
+
+    private func dispatchShortcut(_ keys: [String], sessionID: String) async throws {
+        let normalized = keys.map { $0.lowercased() }
+        let modifiers = normalized.reduce(0) { result, key in
+            let bit = switch key {
+            case "option", "alt": 1
+            case "control", "ctrl": 2
+            case "command", "cmd", "meta": 4
+            case "shift": 8
+            default: 0
+            }
+            return result | bit
+        }
+        let modifierNames: Set<String> = ["option", "alt", "control", "ctrl", "command", "cmd", "meta", "shift"]
+        guard let keyName = normalized.last(where: { !modifierNames.contains($0) }) else {
+            throw BrowserError.unsupportedAction("key shortcut with no non-modifier key")
+        }
+        let mapped = mapKey(keyName)
+        let common: [String: CDPJSONValue] = [
+            "modifiers": .number(Double(modifiers)),
+            "key": .string(mapped.key),
+            "code": .string(mapped.code),
+            "windowsVirtualKeyCode": .number(Double(mapped.virtualKeyCode))
+        ]
+        for type in ["rawKeyDown", "keyUp"] {
+            var params = common
+            params["type"] = .string(type)
+            _ = try await transport.send(
+                method: "Input.dispatchKeyEvent",
+                params: .object(params),
+                sessionID: sessionID
+            )
+        }
+    }
+
+    // MARK: Helpers
+
+    private func browserAction(from action: BasicAction) -> BrowserAction? {
+        switch action {
+        case .pressElement(let id): .click(elementID: id)
+        case .setElementValue(let id, let value): .replaceText(elementID: id, value: value)
+        case .write(let text): .insertText(text)
+        case .keyShortcut(let keys): .keyShortcut(keys)
+        case .vscroll(let clicks): .scroll(horizontal: 0, vertical: clicks)
+        case .hscroll(let clicks): .scroll(horizontal: clicks, vertical: 0)
+        case .wait(let duration): .wait(duration)
+        case .openURL(let value): URL(string: value).map(BrowserAction.navigate)
+        case .activateTab(let tabID): .activateTab(tabID)
+        default: nil
+        }
+    }
+
+    private func makeAgentObservation(_ observation: BrowserObservation) -> AgentObservation {
+        observations[observation.id] = observation
+        return AgentObservation(
+            id: observation.id,
+            kind: .browser,
+            formattedContext: observation.formattedContext,
+            stateFingerprint: observation.stateFingerprint,
+            actionableElementCount: observation.elements.count,
+            viewportSize: observation.viewportSize,
+            screenshotJPEGData: observation.screenshotJPEGData
+        )
+    }
+
+    private func authorizeNavigation(from: URL?, to: URL) async throws {
+        guard securityPolicy.allowsNavigation(to: to) else {
+            throw BrowserError.navigationNotAllowed(to.absoluteString)
+        }
+        if isCrossOrigin(from: from, to: to) {
+            let allowed = await authorizer?.authorize(.crossOriginNavigation(from: from, to: to)) ?? false
+            guard allowed else { throw BrowserError.authorizationDenied("navigation to \(to.absoluteString)") }
+        }
+    }
+
+    private func isCrossOrigin(from: URL?, to: URL) -> Bool {
+        guard let from else { return true }
+        return origin(of: from) != origin(of: to)
+    }
+
+    private func origin(of url: URL) -> String {
+        "\(url.scheme?.lowercased() ?? "")://\(url.host?.lowercased() ?? ""):\(url.port ?? defaultPort(for: url))"
+    }
+
+    private func defaultPort(for url: URL) -> Int { url.scheme?.lowercased() == "https" ? 443 : 80 }
+
+    private func resolvedDestination(_ value: String?, base: String) -> URL? {
+        guard let value else { return nil }
+        return URL(string: value, relativeTo: URL(string: base))?.absoluteURL
+    }
+
+    private func viewportSize(sessionID: String) async throws -> CGSize {
+        let result = try await transport.send(method: "Page.getLayoutMetrics", params: .object([:]), sessionID: sessionID)
+        let viewport = result["cssVisualViewport"] ?? result["visualViewport"]
+        let width = viewport?["clientWidth"]?.doubleValue ?? 1024
+        let height = viewport?["clientHeight"]?.doubleValue ?? 768
+        return CGSize(width: width, height: height)
+    }
+
+    private func captureScreenshot(sessionID: String) async throws -> Data {
+        let result = try await transport.send(
+            method: "Page.captureScreenshot",
+            params: .object(["format": .string("jpeg"), "quality": .number(50), "fromSurface": .bool(true)]),
+            sessionID: sessionID
+        )
+        guard let encoded = result["data"]?.stringValue,
+              let data = Data(base64Encoded: encoded) else {
+            throw BrowserError.malformedResponse("Page.captureScreenshot omitted image data.")
+        }
+        return data
+    }
+
+    private func sortedTabs() -> [BrowserTab] {
+        tabsByID.values.sorted { lhs, rhs in
+            if lhs.id == activeTabID { return true }
+            if rhs.id == activeTabID { return false }
+            return lhs.id < rhs.id
+        }
+    }
+
+    private func markActiveTab(_ id: String) {
+        for (tabID, tab) in tabsByID {
+            let state: BrowserTabState = tabID == id ? .active : (tab.state == .loading ? .loading : .ready)
+            tabsByID[tabID] = BrowserTab(id: tab.id, url: tab.url, title: tab.title, state: state)
+        }
+    }
+
+    private func updateTabState(for sessionID: String?, state: BrowserTabState) {
+        guard let tabID = tabID(for: sessionID), let tab = tabsByID[tabID] else { return }
+        let effectiveState: BrowserTabState = state == .ready && tabID == activeTabID ? .active : state
+        tabsByID[tabID] = BrowserTab(id: tab.id, url: tab.url, title: tab.title, state: effectiveState)
+    }
+
+    private func tabID(for sessionID: String?) -> String? {
+        guard let sessionID else { return nil }
+        return sessionIDByTabID.first { $0.value == sessionID }?.key
+    }
+
+    private var activeSessionID: String? {
+        activeTabID.flatMap { sessionIDByTabID[$0] }
+    }
+
+    private func trimObservations() {
+        guard observations.count > 20 else { return }
+        let keep = Set(observations.keys.suffix(20))
+        observations = observations.filter { keep.contains($0.key) }
+    }
+
+    private func frameIDs(from frameTree: CDPJSONValue?) -> [String] {
+        guard let frameTree else { return [] }
+        var ids: [String] = []
+        if let id = frameTree["frame"]?["id"]?.stringValue { ids.append(id) }
+        for child in frameTree["childFrames"]?.arrayValue ?? [] {
+            ids.append(contentsOf: frameIDs(from: child))
+        }
+        return ids
+    }
+
+    private func mapKey(_ name: String) -> (key: String, code: String, virtualKeyCode: Int) {
+        if name.count == 1, let scalar = name.uppercased().unicodeScalars.first {
+            let upper = name.uppercased()
+            return (upper.lowercased(), "Key\(upper)", Int(scalar.value))
+        }
+        return switch name {
+        case "returnkey", "return", "enter": ("Enter", "Enter", 13)
+        case "space": (" ", "Space", 32)
+        case "tab": ("Tab", "Tab", 9)
+        case "escape": ("Escape", "Escape", 27)
+        case "delete", "backspace": ("Backspace", "Backspace", 8)
+        case "uparrow": ("ArrowUp", "ArrowUp", 38)
+        case "downarrow": ("ArrowDown", "ArrowDown", 40)
+        case "leftarrow": ("ArrowLeft", "ArrowLeft", 37)
+        case "rightarrow": ("ArrowRight", "ArrowRight", 39)
+        default: (name, name, 0)
+        }
+    }
+
+    private static func discoveryURL(for endpoint: URL) -> URL {
+        if endpoint.path.hasSuffix("/json/version") { return endpoint }
+        return endpoint.appending(path: "json/version")
+    }
+}
+
+private final class DiscoverySessionDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    private let policy: BrowserSecurityPolicy
+
+    init(policy: BrowserSecurityPolicy) { self.policy = policy }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping @Sendable (URLRequest?) -> Void
+    ) {
+        guard let url = request.url, (try? policy.validateEndpoint(url)) != nil else {
+            completionHandler(nil)
+            return
+        }
+        completionHandler(request)
+    }
+}

--- a/Sources/SwiftAutoGUIBrowser/CDPTransport.swift
+++ b/Sources/SwiftAutoGUIBrowser/CDPTransport.swift
@@ -1,0 +1,193 @@
+import Foundation
+
+struct CDPEvent: Sendable, Equatable {
+    let method: String
+    let params: CDPJSONValue
+    let sessionID: String?
+}
+
+protocol CDPTransporting: Sendable {
+    func connect() async throws
+    func send(
+        method: String,
+        params: CDPJSONValue,
+        sessionID: String?
+    ) async throws -> CDPJSONValue
+    func events() async -> AsyncStream<CDPEvent>
+    func close() async
+}
+
+actor WebSocketCDPTransport: CDPTransporting {
+    private struct Command: Encodable {
+        let id: Int
+        let method: String
+        let params: CDPJSONValue
+        let sessionId: String?
+    }
+
+    private struct ErrorPayload: Decodable {
+        let code: Int
+        let message: String
+    }
+
+    private struct Incoming: Decodable {
+        let id: Int?
+        let method: String?
+        let params: CDPJSONValue?
+        let result: CDPJSONValue?
+        let error: ErrorPayload?
+        let sessionId: String?
+    }
+
+    private struct Pending {
+        let method: String
+        let continuation: CheckedContinuation<CDPJSONValue, Error>
+    }
+
+    private let webSocketURL: URL
+    private let commandTimeout: Duration
+    private let session: URLSession
+    private var task: URLSessionWebSocketTask?
+    private var receiveTask: Task<Void, Never>?
+    private var nextID = 1
+    private var pending: [Int: Pending] = [:]
+    private var eventContinuations: [UUID: AsyncStream<CDPEvent>.Continuation] = [:]
+    private var isClosed = false
+
+    init(
+        webSocketURL: URL,
+        commandTimeout: Duration = .seconds(10),
+        session: URLSession = .shared
+    ) {
+        self.webSocketURL = webSocketURL
+        self.commandTimeout = commandTimeout
+        self.session = session
+    }
+
+    func connect() async throws {
+        guard task == nil else { return }
+        isClosed = false
+        let task = session.webSocketTask(with: webSocketURL)
+        self.task = task
+        task.resume()
+        receiveTask = Task { [weak self] in
+            await self?.receiveLoop()
+        }
+    }
+
+    func send(
+        method: String,
+        params: CDPJSONValue = .object([:]),
+        sessionID: String? = nil
+    ) async throws -> CDPJSONValue {
+        guard let task, !isClosed else { throw BrowserError.disconnected }
+        let id = nextID
+        nextID += 1
+        let command = Command(id: id, method: method, params: params, sessionId: sessionID)
+        let data = try JSONEncoder().encode(command)
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw BrowserError.malformedResponse("Could not encode command \(method).")
+        }
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                pending[id] = Pending(method: method, continuation: continuation)
+                Task { [weak self] in
+                    do {
+                        try await task.send(.string(text))
+                    } catch {
+                        await self?.failRequest(id: id, error: error)
+                    }
+                }
+                Task { [weak self, commandTimeout] in
+                    try? await Task.sleep(for: commandTimeout)
+                    await self?.timeOutRequest(id: id)
+                }
+            }
+        } onCancel: {
+            Task { [weak self] in
+                await self?.failRequest(id: id, error: CancellationError())
+            }
+        }
+    }
+
+    func events() -> AsyncStream<CDPEvent> {
+        let id = UUID()
+        return AsyncStream { continuation in
+            eventContinuations[id] = continuation
+            continuation.onTermination = { [weak self] _ in
+                Task { await self?.removeEventContinuation(id) }
+            }
+        }
+    }
+
+    func close() {
+        guard !isClosed else { return }
+        isClosed = true
+        receiveTask?.cancel()
+        receiveTask = nil
+        task?.cancel(with: .goingAway, reason: nil)
+        task = nil
+        let requests = pending.values
+        pending.removeAll()
+        for request in requests {
+            request.continuation.resume(throwing: BrowserError.disconnected)
+        }
+        for continuation in eventContinuations.values { continuation.finish() }
+        eventContinuations.removeAll()
+    }
+
+    private func receiveLoop() async {
+        guard let task else { return }
+        do {
+            while !Task.isCancelled {
+                let message = try await task.receive()
+                let data: Data
+                switch message {
+                case .data(let value): data = value
+                case .string(let value): data = Data(value.utf8)
+                @unknown default: continue
+                }
+                let incoming = try JSONDecoder().decode(Incoming.self, from: data)
+                handle(incoming)
+            }
+        } catch is CancellationError {
+            return
+        } catch {
+            close()
+        }
+    }
+
+    private func handle(_ incoming: Incoming) {
+        if let id = incoming.id, let request = pending.removeValue(forKey: id) {
+            if let error = incoming.error {
+                request.continuation.resume(
+                    throwing: BrowserError.protocolError(code: error.code, message: error.message)
+                )
+            } else {
+                request.continuation.resume(returning: incoming.result ?? .object([:]))
+            }
+            return
+        }
+        guard let method = incoming.method else { return }
+        let event = CDPEvent(
+            method: method,
+            params: incoming.params ?? .object([:]),
+            sessionID: incoming.sessionId
+        )
+        for continuation in eventContinuations.values { continuation.yield(event) }
+    }
+
+    private func failRequest(id: Int, error: Error) {
+        pending.removeValue(forKey: id)?.continuation.resume(throwing: error)
+    }
+
+    private func timeOutRequest(id: Int) {
+        guard let request = pending.removeValue(forKey: id) else { return }
+        request.continuation.resume(throwing: BrowserError.timeout(method: request.method))
+    }
+
+    private func removeEventContinuation(_ id: UUID) {
+        eventContinuations.removeValue(forKey: id)
+    }
+}

--- a/Sources/SwiftAutoGUIBrowser/CDPTypes.swift
+++ b/Sources/SwiftAutoGUIBrowser/CDPTypes.swift
@@ -1,0 +1,318 @@
+import Foundation
+import SwiftAutoGUI
+
+/// A JSON value used by the lightweight CDP client.
+public enum CDPJSONValue: Sendable, Codable, Equatable {
+    case null
+    case bool(Bool)
+    case number(Double)
+    case string(String)
+    case array([CDPJSONValue])
+    case object([String: CDPJSONValue])
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() { self = .null }
+        else if let value = try? container.decode(Bool.self) { self = .bool(value) }
+        else if let value = try? container.decode(Double.self) { self = .number(value) }
+        else if let value = try? container.decode(String.self) { self = .string(value) }
+        else if let value = try? container.decode([CDPJSONValue].self) { self = .array(value) }
+        else { self = .object(try container.decode([String: CDPJSONValue].self)) }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .null: try container.encodeNil()
+        case .bool(let value): try container.encode(value)
+        case .number(let value): try container.encode(value)
+        case .string(let value): try container.encode(value)
+        case .array(let value): try container.encode(value)
+        case .object(let value): try container.encode(value)
+        }
+    }
+
+    public var objectValue: [String: CDPJSONValue]? {
+        guard case .object(let value) = self else { return nil }
+        return value
+    }
+
+    public var arrayValue: [CDPJSONValue]? {
+        guard case .array(let value) = self else { return nil }
+        return value
+    }
+
+    public var stringValue: String? {
+        guard case .string(let value) = self else { return nil }
+        return value
+    }
+
+    public var boolValue: Bool? {
+        guard case .bool(let value) = self else { return nil }
+        return value
+    }
+
+    public var doubleValue: Double? {
+        guard case .number(let value) = self else { return nil }
+        return value
+    }
+
+    public var intValue: Int? { doubleValue.map(Int.init) }
+
+    public subscript(key: String) -> CDPJSONValue? { objectValue?[key] }
+}
+
+extension CDPJSONValue {
+    static func object(_ pairs: (String, CDPJSONValue?)...) -> CDPJSONValue {
+        .object(Dictionary(uniqueKeysWithValues: pairs.compactMap { key, value in
+            value.map { (key, $0) }
+        }))
+    }
+}
+
+public enum BrowserError: Error, Sendable, LocalizedError, Equatable {
+    case invalidEndpoint(String)
+    case endpointNotAllowed(String)
+    case discoveryFailed(String)
+    case invalidWebSocketURL(String)
+    case disconnected
+    case timeout(method: String)
+    case protocolError(code: Int, message: String)
+    case noPageTabs
+    case tabNotFound(String)
+    case observationNotFound
+    case staleElement(Int)
+    case unsupportedAction(String)
+    case navigationNotAllowed(String)
+    case authorizationDenied(String)
+    case malformedResponse(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidEndpoint(let value): "Invalid browser debugging endpoint: \(value)"
+        case .endpointNotAllowed(let value): "Browser debugging endpoint is not allowed: \(value)"
+        case .discoveryFailed(let value): "Browser discovery failed: \(value)"
+        case .invalidWebSocketURL(let value): "Invalid browser WebSocket URL: \(value)"
+        case .disconnected: "The browser debugging connection closed."
+        case .timeout(let method): "CDP command timed out: \(method)"
+        case .protocolError(let code, let message): "CDP error \(code): \(message)"
+        case .noPageTabs: "The browser has no page tabs."
+        case .tabNotFound(let id): "Browser tab not found: \(id)"
+        case .observationNotFound: "The browser observation is no longer available."
+        case .staleElement(let id): "Browser element #\(id) became stale; observe the page again."
+        case .unsupportedAction(let action): "The browser-only backend does not support \(action)."
+        case .navigationNotAllowed(let url): "Navigation is not allowed by the domain policy: \(url)"
+        case .authorizationDenied(let action): "Browser action was not authorized: \(action)"
+        case .malformedResponse(let detail): "Malformed CDP response: \(detail)"
+        }
+    }
+}
+
+public struct BrowserSecurityPolicy: Sendable, Equatable {
+    public var allowedEndpointHosts: Set<String>
+    public var allowedDomains: Set<String>
+
+    public init(
+        allowedEndpointHosts: Set<String> = ["127.0.0.1", "localhost", "::1"],
+        allowedDomains: Set<String> = []
+    ) {
+        self.allowedEndpointHosts = Set(allowedEndpointHosts.map { $0.lowercased() })
+        self.allowedDomains = Set(allowedDomains.map { $0.lowercased() })
+    }
+
+    public func validateEndpoint(_ url: URL) throws {
+        guard let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              let host = url.host?.lowercased() else {
+            throw BrowserError.invalidEndpoint(url.absoluteString)
+        }
+        guard allowedEndpointHosts.contains(host) else {
+            throw BrowserError.endpointNotAllowed(url.absoluteString)
+        }
+    }
+
+    public func validateWebSocket(_ url: URL) throws {
+        guard let scheme = url.scheme?.lowercased(),
+              scheme == "ws" || scheme == "wss",
+              let host = url.host?.lowercased() else {
+            throw BrowserError.invalidWebSocketURL(url.absoluteString)
+        }
+        guard allowedEndpointHosts.contains(host) else {
+            throw BrowserError.endpointNotAllowed(url.absoluteString)
+        }
+    }
+
+    public func allowsNavigation(to url: URL) -> Bool {
+        guard let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              let host = url.host?.lowercased() else { return false }
+        return allowedDomains.contains { rule in
+            if rule.hasPrefix("*.") {
+                let suffix = String(rule.dropFirst(2))
+                return host != suffix && host.hasSuffix("." + suffix)
+            }
+            return host == rule
+        }
+    }
+}
+
+public enum BrowserAuthorizationRequest: Sendable, Equatable {
+    case crossOriginNavigation(from: URL?, to: URL)
+    case download(url: URL?, suggestedFilename: String?)
+}
+
+public protocol BrowserActionAuthorizing: Sendable {
+    func authorize(_ request: BrowserAuthorizationRequest) async -> Bool
+}
+
+public enum BrowserTabState: String, Sendable, Codable {
+    case active
+    case loading
+    case ready
+    case closed
+}
+
+public struct BrowserTab: Sendable, Codable, Equatable {
+    public let id: String
+    public let url: String
+    public let title: String
+    public let state: BrowserTabState
+
+    public init(id: String, url: String, title: String, state: BrowserTabState) {
+        self.id = id
+        self.url = url
+        self.title = title
+        self.state = state
+    }
+}
+
+public struct BrowserRect: Sendable, Codable, Equatable {
+    public let x: Double
+    public let y: Double
+    public let width: Double
+    public let height: Double
+
+    public init(x: Double, y: Double, width: Double, height: Double) {
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+    }
+
+    public var midX: Double { x + width / 2 }
+    public var midY: Double { y + height / 2 }
+}
+
+public struct BrowserElement: Sendable, Codable, Equatable {
+    public let elementID: Int
+    public let backendDOMNodeID: Int
+    public let frameID: String?
+    public let role: String
+    public let name: String
+    public let value: String?
+    public let bounds: BrowserRect
+    public let isEnabled: Bool
+    public let isEditable: Bool
+    public let destinationURL: String?
+
+    public init(
+        elementID: Int,
+        backendDOMNodeID: Int,
+        frameID: String?,
+        role: String,
+        name: String,
+        value: String?,
+        bounds: BrowserRect,
+        isEnabled: Bool,
+        isEditable: Bool,
+        destinationURL: String? = nil
+    ) {
+        self.elementID = elementID
+        self.backendDOMNodeID = backendDOMNodeID
+        self.frameID = frameID
+        self.role = role
+        self.name = name
+        self.value = value
+        self.bounds = bounds
+        self.isEnabled = isEnabled
+        self.isEditable = isEditable
+        self.destinationURL = destinationURL
+    }
+}
+
+public struct BrowserObservation: Sendable {
+    public let id: UUID
+    public let tab: BrowserTab
+    public let frameID: String
+    public let loaderID: String
+    public let viewportSize: CGSize
+    public let elements: [BrowserElement]
+    public let formattedContext: String
+    public let stateFingerprint: String
+    public let screenshotJPEGData: Data?
+
+    public init(
+        id: UUID = UUID(),
+        tab: BrowserTab,
+        frameID: String,
+        loaderID: String,
+        viewportSize: CGSize,
+        elements: [BrowserElement],
+        formattedContext: String,
+        stateFingerprint: String,
+        screenshotJPEGData: Data? = nil
+    ) {
+        self.id = id
+        self.tab = tab
+        self.frameID = frameID
+        self.loaderID = loaderID
+        self.viewportSize = viewportSize
+        self.elements = elements
+        self.formattedContext = formattedContext
+        self.stateFingerprint = stateFingerprint
+        self.screenshotJPEGData = screenshotJPEGData
+    }
+
+    public func element(withID id: Int) -> BrowserElement? {
+        elements.first { $0.elementID == id }
+    }
+}
+
+public enum BrowserAction: Sendable, Equatable {
+    case navigate(URL)
+    case click(elementID: Int)
+    case replaceText(elementID: Int, value: String)
+    case insertText(String)
+    case keyShortcut([String])
+    case scroll(horizontal: Int, vertical: Int)
+    case activateTab(String)
+    case wait(TimeInterval)
+}
+
+public struct BrowserActionResult: Sendable {
+    public let action: BrowserAction
+    public let succeeded: Bool
+    public let failure: BrowserError?
+    public let observation: BrowserObservation
+    public let navigation: AgentNavigationResult?
+    public let tabChanges: [AgentTabChange]
+    public let downloads: [AgentDownloadResult]
+
+    public init(
+        action: BrowserAction,
+        succeeded: Bool,
+        failure: BrowserError? = nil,
+        observation: BrowserObservation,
+        navigation: AgentNavigationResult? = nil,
+        tabChanges: [AgentTabChange] = [],
+        downloads: [AgentDownloadResult] = []
+    ) {
+        self.action = action
+        self.succeeded = succeeded
+        self.failure = failure
+        self.observation = observation
+        self.navigation = navigation
+        self.tabChanges = tabChanges
+        self.downloads = downloads
+    }
+}

--- a/Sources/SwiftAutoGUIBrowser/Documentation.docc/BrowserAgent.md
+++ b/Sources/SwiftAutoGUIBrowser/Documentation.docc/BrowserAgent.md
@@ -1,0 +1,174 @@
+# Using a Browser Agent
+
+Build an AI Agent that observes and controls only pages in an existing Chromium session.
+
+## Overview
+
+A browser Agent uses two independent backends:
+
+1. A `VisionActionGenerating` backend decides what to do next.
+2. A ``BrowserSession`` observes the current page and executes the selected action through CDP.
+
+Passing a ``BrowserSession`` as `automationBackend` makes the Agent browser-only. It does not
+switch to Accessibility or CGEvent when an action is unavailable. Element identifiers such as
+`[#12]` are valid for one observation only and are verified again before execution.
+
+## 1. Start a dedicated Chromium session
+
+Quit any previous process using port 9222, then start Chromium with a dedicated profile:
+
+```bash
+"/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing" \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/swift-auto-gui-browser-profile
+```
+
+Keep the debugging endpoint on loopback. A CDP client attached to this profile can inspect and
+control its pages.
+
+## 2. Create a domain policy
+
+`allowedDomains` contains page hosts, not the debugging endpoint:
+
+```swift
+let policy = BrowserSecurityPolicy(
+    allowedDomains: ["github.com", "*.github.com"]
+)
+```
+
+`github.com` permits the exact host. `*.github.com` permits subdomains but does not include the
+parent host. Navigation outside the set is always rejected.
+
+## 3. Decide how cross-origin navigation is authorized
+
+An allowlist entry makes a destination eligible, but cross-origin navigation still requires an
+authorizer. The following authorizer approves allowlisted cross-origin navigation and rejects all
+downloads:
+
+```swift
+import SwiftAutoGUIBrowser
+
+struct NavigationAuthorizer: BrowserActionAuthorizing {
+    func authorize(_ request: BrowserAuthorizationRequest) async -> Bool {
+        switch request {
+        case .crossOriginNavigation:
+            true
+        case .download:
+            false
+        }
+    }
+}
+```
+
+For an interactive application, ask the user before returning `true`. Omit the authorizer when
+cross-origin navigation must remain disabled.
+
+## 4. Connect and select a tab
+
+```swift
+import Foundation
+import SwiftAutoGUIBrowser
+
+let browser = try await BrowserSession.connect(
+    endpoint: URL(string: "http://127.0.0.1:9222")!,
+    securityPolicy: policy,
+    authorizer: NavigationAuthorizer()
+)
+
+let tabs = try await browser.listTabs()
+for tab in tabs {
+    print(tab.id, tab.title, tab.url)
+}
+
+if let githubTab = tabs.first(where: { $0.url.contains("github.com") }) {
+    try await browser.activateTab(githubTab.id)
+}
+```
+
+Use `defer` in synchronous wrappers or explicitly call `await browser.close()` when the session is
+no longer needed.
+
+## 5. Run the Agent
+
+Keep API keys outside source control. This example reads `OPENAI_API_KEY` from the process
+environment:
+
+```swift
+import SwiftAutoGUI
+
+guard let apiKey = ProcessInfo.processInfo.environment["OPENAI_API_KEY"] else {
+    fatalError("Set OPENAI_API_KEY before starting the app")
+}
+
+let llm = OpenAIVisionBackend(apiKey: apiKey)
+let agent = Agent(
+    backend: llm,
+    maxIterations: 20,
+    delayBetweenSteps: 1,
+    screenContextOptions: nil,
+    visionMode: .automatic,
+    automationBackend: browser
+)
+
+let result = try await agent.run(
+    goal: "Open issue 118 in the SwiftAutoGUI repository"
+) { step in
+    print(step.reasoning)
+    for execution in step.executionResults {
+        print(execution.method, execution.succeeded)
+    }
+}
+
+print("Completed:", result.completed)
+await browser.close()
+```
+
+The browser observation tells the model to use semantic actions such as `pressElement`,
+`setElementValue`, `openURL`, `activateTab`, and scrolling. Native app, window, coordinate mouse,
+and drag actions return `unsupportedAction`.
+
+## Use the Sample app
+
+Open `Sample/Sample.xcodeproj`, run the Sample scheme, and select **Browser CDP**:
+
+1. Enter the loopback endpoint and page domains.
+2. Select **Connect** and choose a tab.
+3. Enter an API key or launch the app with `OPENAI_API_KEY`.
+4. Enter a goal and select **Run Agent**.
+5. Inspect each reasoning, action, and CDP execution result in **Agent steps**.
+
+The Sample approves cross-origin navigation within its explicit domain list and denies downloads.
+
+## Use sagui
+
+List available tabs:
+
+```bash
+sagui browser tabs --endpoint http://127.0.0.1:9222
+```
+
+Run a browser-only Agent:
+
+```bash
+export OPENAI_API_KEY="your-key-in-your-shell"
+
+sagui browser agent "Open issue 118" \
+  --domain github.com \
+  --allow-cross-origin \
+  --vision-mode automatic
+```
+
+Use repeated `--domain` options for multiple hosts. Use `--tab-id` with an ID printed by
+`sagui browser tabs` to choose the initial tab. Without `--allow-cross-origin`, cross-origin
+navigation is denied even when its destination is allowlisted. Downloads are always denied.
+
+## Understand failures
+
+- `navigationNotAllowed`: The destination host is not in `allowedDomains`.
+- `authorizationDenied`: Cross-origin navigation was not approved by the authorizer.
+- `staleElement`: The target, frame, loader, DOM node, or semantic element changed; observe again.
+- `unsupportedAction`: The model requested a native-only action in a browser-only session.
+- `disconnected`: Chromium exited or the debugging connection closed.
+
+An action failure or page change stops the remaining action batch. The Agent then observes the
+new page before deciding what to do next.

--- a/Sources/SwiftAutoGUIBrowser/Documentation.docc/SwiftAutoGUIBrowser.md
+++ b/Sources/SwiftAutoGUIBrowser/Documentation.docc/SwiftAutoGUIBrowser.md
@@ -1,0 +1,90 @@
+# ``SwiftAutoGUIBrowser``
+
+Control an existing Chromium page through the Chrome DevTools Protocol (CDP).
+
+## Overview
+
+SwiftAutoGUIBrowser is an optional, browser-only automation backend. It observes
+tabs and page accessibility information, assigns step-local identifiers to
+actionable elements, and resolves each identifier again immediately before
+execution.
+
+It does not replace SwiftAutoGUI's native Accessibility and CGEvent automation.
+An Agent configured with ``BrowserSession`` operates only inside the connected
+Chromium browser and reports native-only actions as unsupported.
+
+## Starting Chromium
+
+Start Chrome for Testing, Chrome, Edge, or another compatible Chromium browser
+with remote debugging and a dedicated profile. Chrome 136 and later require a
+non-default user data directory for this workflow.
+
+```bash
+"/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing" \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/swift-auto-gui-browser-profile
+```
+
+Do not expose the debugging port to a network interface. A CDP connection has
+powerful access to the attached browser profile.
+
+## Connecting
+
+```swift
+import SwiftAutoGUI
+import SwiftAutoGUIBrowser
+
+let browser = try await BrowserSession.connect(
+    endpoint: URL(string: "http://127.0.0.1:9222")!,
+    securityPolicy: BrowserSecurityPolicy(
+        allowedDomains: ["example.com", "*.example.org"]
+    )
+)
+
+let tabs = try await browser.listTabs()
+let observation = try await browser.observe()
+print(observation.formattedContext)
+
+if let button = observation.elements.first {
+    let result = await browser.execute(
+        .click(elementID: button.elementID),
+        against: observation
+    )
+    print(result.succeeded)
+}
+```
+
+Pass the session explicitly to use it as an Agent environment:
+
+```swift
+let agent = Agent(backend: llm, automationBackend: browser)
+```
+
+## Security behavior
+
+- Debugging endpoints are limited to `127.0.0.1`, `localhost`, and `::1` by default.
+- Top-level navigation and redirects are restricted to `allowedDomains`.
+- A wildcard such as `*.example.com` permits subdomains, but not `example.com` itself.
+- Cross-origin navigation and downloads require a ``BrowserActionAuthorizing`` implementation.
+- Without an authorizer, those sensitive operations are denied.
+- Arbitrary JavaScript evaluation is not exposed.
+- A stale page element never falls back to a saved CGEvent coordinate.
+
+## Topics
+
+### Getting started
+
+- <doc:BrowserAgent>
+
+### Browser connection
+
+- ``BrowserSession``
+- ``BrowserSecurityPolicy``
+- ``BrowserActionAuthorizing``
+
+### Observation and actions
+
+- ``BrowserObservation``
+- ``BrowserElement``
+- ``BrowserAction``
+- ``BrowserActionResult``

--- a/Sources/sagui/BrowserCommand.swift
+++ b/Sources/sagui/BrowserCommand.swift
@@ -1,0 +1,165 @@
+import ArgumentParser
+import Foundation
+import SwiftAutoGUI
+import SwiftAutoGUIBrowser
+
+/// Inspect and automate an existing Chromium remote-debugging session.
+struct BrowserCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "browser",
+        abstract: "Control Chromium pages through the Chrome DevTools Protocol.",
+        subcommands: [BrowserTabsCommand.self, BrowserAgentCommand.self]
+    )
+}
+
+struct BrowserTabsCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "tabs",
+        abstract: "List page tabs exposed by a Chromium debugging endpoint."
+    )
+
+    @Option(help: "Loopback Chromium debugging endpoint.")
+    var endpoint: String = "http://127.0.0.1:9222"
+
+    func run() async throws {
+        let endpointURL = try validatedEndpoint(endpoint)
+        let browser = try await BrowserSession.connect(endpoint: endpointURL)
+        do {
+            let tabs = try await browser.listTabs()
+            for tab in tabs {
+                print("\(tab.state.rawValue)\t\(tab.id)\t\(tab.title)\t\(tab.url)")
+            }
+            await browser.close()
+        } catch {
+            await browser.close()
+            throw error
+        }
+    }
+}
+
+struct BrowserAgentCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "agent",
+        abstract: "Run an AI Agent that is restricted to Chromium page actions."
+    )
+
+    @Argument(help: "The browser goal for the Agent to accomplish.")
+    var goal: String
+
+    @Option(help: "Loopback Chromium debugging endpoint.")
+    var endpoint: String = "http://127.0.0.1:9222"
+
+    @Option(
+        name: .customLong("domain"),
+        help: "Allowed page domain. Repeat for multiple domains, for example --domain example.com --domain '*.example.org'."
+    )
+    var domains: [String] = []
+
+    @Option(help: "Optional CDP target ID to activate before starting.")
+    var tabID: String?
+
+    @Flag(help: "Approve cross-origin navigation when its destination is also in --domain. Downloads remain denied.")
+    var allowCrossOrigin = false
+
+    @Option(help: "OpenAI API key. Prefer the OPENAI_API_KEY environment variable.")
+    var apiKey: String?
+
+    @Option(help: "OpenAI model to use.")
+    var model: String = OpenAIVisionBackend.defaultModel
+
+    @Option(help: "Reasoning effort: none, low, medium, high, xhigh, or max.")
+    var reasoningEffort: AgentCommand.ReasoningEffort?
+
+    @Option(help: "Maximum number of observe-think-act iterations.")
+    var maxIterations = 20
+
+    @Option(help: "Delay between Agent steps in seconds.")
+    var delay = 1.0
+
+    @Option(help: "Screenshot mode: always, automatic, or never.")
+    var visionMode: AgentCommand.VisionMode = .automatic
+
+    @MainActor
+    func run() async throws {
+        guard !domains.isEmpty else {
+            throw ValidationError("Provide at least one --domain allowlist entry.")
+        }
+        let key = apiKey ?? ProcessInfo.processInfo.environment["OPENAI_API_KEY"]
+        guard let key, !key.isEmpty else {
+            throw ValidationError("Set OPENAI_API_KEY or provide --api-key.")
+        }
+
+        let endpointURL = try validatedEndpoint(endpoint)
+        let domainSet = Set(domains.map { $0.lowercased() })
+        let authorizer: (any BrowserActionAuthorizing)? = allowCrossOrigin
+            ? SaguiBrowserAuthorizer()
+            : nil
+        let browser = try await BrowserSession.connect(
+            endpoint: endpointURL,
+            securityPolicy: BrowserSecurityPolicy(allowedDomains: domainSet),
+            authorizer: authorizer
+        )
+
+        do {
+            if let tabID { try await browser.activateTab(tabID) }
+
+            let backend = OpenAIVisionBackend(
+                apiKey: key,
+                model: model,
+                reasoningEffort: reasoningEffort?.rawValue
+            )
+            let agent = Agent(
+                backend: backend,
+                maxIterations: maxIterations,
+                delayBetweenSteps: delay,
+                screenContextOptions: nil,
+                visionMode: AgentVisionMode(rawValue: visionMode.rawValue) ?? .automatic,
+                automationBackend: browser
+            )
+
+            print("Browser Agent starting with goal: \"\(goal)\"")
+            print("Endpoint: \(endpoint)")
+            print("Domains: \(domains.joined(separator: ", "))")
+            print("Model: \(model), Vision mode: \(visionMode.rawValue)")
+            print("Cross-origin: \(allowCrossOrigin ? "allowlisted" : "denied"), Downloads: denied")
+            print("---")
+
+            let result = try await agent.run(goal: goal) { step in
+                let actionSummary = step.actions.map { String(describing: $0) }.joined(separator: ", ")
+                print("Reasoning: \(step.reasoning)")
+                print("  Actions: \(actionSummary)")
+                for execution in step.executionResults {
+                    let status = execution.succeeded ? "succeeded" : "failed"
+                    let change = execution.screenChanged ? ", page changed" : ""
+                    let reason = execution.failureReason.map { ", \($0)" } ?? ""
+                    print("  Result: \(status) via \(execution.method.rawValue)\(change)\(reason)")
+                }
+                print("---")
+            }
+
+            print("Browser Agent finished.")
+            print("Completed: \(result.completed)")
+            print("Iterations used: \(result.iterationsUsed)")
+            await browser.close()
+        } catch {
+            await browser.close()
+            throw error
+        }
+    }
+}
+
+private struct SaguiBrowserAuthorizer: BrowserActionAuthorizing {
+    func authorize(_ request: BrowserAuthorizationRequest) async -> Bool {
+        switch request {
+        case .crossOriginNavigation: true
+        case .download: false
+        }
+    }
+}
+
+private func validatedEndpoint(_ value: String) throws -> URL {
+    guard let url = URL(string: value), url.host != nil else {
+        throw ValidationError("Invalid --endpoint value: \(value)")
+    }
+    return url
+}

--- a/Sources/sagui/SaguiCLI.swift
+++ b/Sources/sagui/SaguiCLI.swift
@@ -35,6 +35,13 @@ struct SaguiCLI: AsyncParsableCommand {
         abstract: "Control mouse and keyboard on macOS from the command line.",
         discussion: "Requires accessibility permissions in System Settings > Privacy & Security > Accessibility.",
         version: SaguiVersion.current,
-        subcommands: [KeyCommand.self, MouseCommand.self, ScreenCommand.self, AXCommand.self, AgentCommand.self]
+        subcommands: [
+            KeyCommand.self,
+            MouseCommand.self,
+            ScreenCommand.self,
+            AXCommand.self,
+            AgentCommand.self,
+            BrowserCommand.self,
+        ]
     )
 }

--- a/Tests/SaguiTests/SaguiCommandTests.swift
+++ b/Tests/SaguiTests/SaguiCommandTests.swift
@@ -110,4 +110,33 @@ struct SaguiCommandTests {
             ])
         }
     }
+
+    @Test("Browser Agent requires no implicit domains at parse time")
+    func browserAgentDefaults() throws {
+        let command = try BrowserAgentCommand.parse(["Open the Issues page"])
+        #expect(command.endpoint == "http://127.0.0.1:9222")
+        #expect(command.domains.isEmpty)
+        #expect(command.visionMode == .automatic)
+        #expect(!command.allowCrossOrigin)
+    }
+
+    @Test("Browser Agent accepts repeated domain entries and a tab ID")
+    func browserAgentOptions() throws {
+        let command = try BrowserAgentCommand.parse([
+            "Open issue 118",
+            "--domain", "github.com",
+            "--domain", "*.github.com",
+            "--tab-id", "target-123",
+            "--allow-cross-origin",
+        ])
+        #expect(command.domains == ["github.com", "*.github.com"])
+        #expect(command.tabID == "target-123")
+        #expect(command.allowCrossOrigin)
+    }
+
+    @Test("Browser tabs defaults to the loopback endpoint")
+    func browserTabsDefaults() throws {
+        let command = try BrowserTabsCommand.parse([])
+        #expect(command.endpoint == "http://127.0.0.1:9222")
+    }
 }

--- a/Tests/SwiftAutoGUIBrowserTests/BrowserIntegrationTests.swift
+++ b/Tests/SwiftAutoGUIBrowserTests/BrowserIntegrationTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Testing
+@testable import SwiftAutoGUIBrowser
+
+@Suite("Browser integration")
+struct BrowserIntegrationTests {
+    @Test("connects to an explicitly enabled Chromium endpoint")
+    func optInConnection() async throws {
+        guard ProcessInfo.processInfo.environment["SWIFTAUTOGUI_RUN_CDP_TESTS"] == "1" else { return }
+        let endpointValue = ProcessInfo.processInfo.environment["SWIFTAUTOGUI_CDP_ENDPOINT"]
+            ?? "http://127.0.0.1:9222"
+        let domain = ProcessInfo.processInfo.environment["SWIFTAUTOGUI_CDP_DOMAIN"] ?? "example.com"
+        let endpoint = try #require(URL(string: endpointValue))
+        let browser = try await BrowserSession.connect(
+            endpoint: endpoint,
+            securityPolicy: BrowserSecurityPolicy(allowedDomains: [domain])
+        )
+        let tabs = try await browser.listTabs()
+        #expect(!tabs.isEmpty)
+        let observation = try await browser.observe()
+        #expect(!observation.tab.id.isEmpty)
+        await browser.close()
+    }
+}

--- a/Tests/SwiftAutoGUIBrowserTests/BrowserSecurityPolicyTests.swift
+++ b/Tests/SwiftAutoGUIBrowserTests/BrowserSecurityPolicyTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+@testable import SwiftAutoGUIBrowser
+
+@Suite("Browser security policy")
+struct BrowserSecurityPolicyTests {
+    @Test("loopback endpoints are allowed by default")
+    func loopbackEndpoint() throws {
+        let policy = BrowserSecurityPolicy()
+        try policy.validateEndpoint(#require(URL(string: "http://127.0.0.1:9222")))
+        try policy.validateWebSocket(#require(URL(string: "ws://localhost:9222/devtools/browser/1")))
+    }
+
+    @Test("remote debugging endpoints are rejected by default")
+    func remoteEndpoint() throws {
+        let policy = BrowserSecurityPolicy()
+        #expect(throws: BrowserError.self) {
+            try policy.validateEndpoint(#require(URL(string: "http://example.com:9222")))
+        }
+    }
+
+    @Test("domain wildcards do not include the parent domain")
+    func wildcardDomain() throws {
+        let policy = BrowserSecurityPolicy(allowedDomains: ["example.com", "*.example.org"])
+        let exact = try #require(URL(string: "https://example.com/path"))
+        let subdomain = try #require(URL(string: "https://a.example.org/path"))
+        let parent = try #require(URL(string: "https://example.org/path"))
+        let suffixOnly = try #require(URL(string: "https://badexample.com/path"))
+        #expect(policy.allowsNavigation(to: exact))
+        #expect(policy.allowsNavigation(to: subdomain))
+        #expect(!policy.allowsNavigation(to: parent))
+        #expect(!policy.allowsNavigation(to: suffixOnly))
+    }
+}

--- a/Tests/SwiftAutoGUIBrowserTests/BrowserSelectorMapTests.swift
+++ b/Tests/SwiftAutoGUIBrowserTests/BrowserSelectorMapTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+@testable import SwiftAutoGUIBrowser
+
+@Suite("Browser selector map")
+struct BrowserSelectorMapTests {
+    @Test("filters AX nodes and numbers visible actionable elements")
+    func actionableElements() throws {
+        let tree: CDPJSONValue = .object([
+            "nodes": .array([
+                axNode(backendID: 10, role: "button", name: "Submit"),
+                axNode(backendID: 11, role: "StaticText", name: "Description"),
+                axNode(backendID: 12, role: "textbox", name: "Email", editable: true),
+                axNode(backendID: 13, role: "button", name: "Disabled", disabled: true)
+            ])
+        ])
+        let candidates = BrowserSelectorMapBuilder.candidates(from: tree, limit: 20)
+        #expect(candidates.map(\.backendDOMNodeID) == [10, 12, 13])
+
+        let elements = BrowserSelectorMapBuilder.elements(
+            candidates: candidates,
+            bounds: [
+                10: BrowserRect(x: 10, y: 20, width: 80, height: 30),
+                12: BrowserRect(x: 20, y: 60, width: 200, height: 24),
+                13: BrowserRect(x: 10, y: 90, width: 80, height: 30)
+            ],
+            destinationURLs: [10: "https://example.com/next"]
+        )
+        #expect(elements.count == 2)
+        #expect(elements[0].elementID == 1)
+        #expect(elements[0].name == "Submit")
+        #expect(elements[1].elementID == 2)
+        #expect(elements[1].isEditable)
+
+        let tab = BrowserTab(id: "tab-1", url: "https://example.com", title: "Example", state: .active)
+        let formatted = BrowserSelectorMapBuilder.format(tabs: [tab], activeTabID: tab.id, elements: elements)
+        #expect(formatted.contains("[#1] button \"Submit\""))
+        #expect(formatted.contains("[#2] textbox \"Email\""))
+    }
+
+    @Test("extracts bounds from a CDP box model")
+    func boxBounds() throws {
+        let result: CDPJSONValue = .object([
+            "model": .object([
+                "border": .array([10, 20, 90, 20, 90, 50, 10, 50].map { .number(Double($0)) })
+            ])
+        ])
+        let bounds = try #require(BrowserSelectorMapBuilder.bounds(from: result))
+        #expect(bounds == BrowserRect(x: 10, y: 20, width: 80, height: 30))
+    }
+
+    @Test("CDP JSON values tolerate nested and unknown data")
+    func jsonRoundTrip() throws {
+        let value: CDPJSONValue = .object([
+            "known": .string("value"),
+            "futureField": .array([.bool(true), .number(2), .null])
+        ])
+        let data = try JSONEncoder().encode(value)
+        #expect(try JSONDecoder().decode(CDPJSONValue.self, from: data) == value)
+    }
+
+    private func axNode(
+        backendID: Int,
+        role: String,
+        name: String,
+        editable: Bool = false,
+        disabled: Bool = false
+    ) -> CDPJSONValue {
+        var properties: [CDPJSONValue] = []
+        if editable { properties.append(property("editable", .bool(true))) }
+        if disabled { properties.append(property("disabled", .bool(true))) }
+        return .object([
+            "ignored": .bool(false),
+            "backendDOMNodeId": .number(Double(backendID)),
+            "frameId": .string("frame-1"),
+            "role": axValue(.string(role)),
+            "name": axValue(.string(name)),
+            "properties": .array(properties)
+        ])
+    }
+
+    private func property(_ name: String, _ value: CDPJSONValue) -> CDPJSONValue {
+        .object(["name": .string(name), "value": axValue(value)])
+    }
+
+    private func axValue(_ value: CDPJSONValue) -> CDPJSONValue {
+        .object(["type": .string("string"), "value": value])
+    }
+}

--- a/Tests/SwiftAutoGUIBrowserTests/BrowserSessionTests.swift
+++ b/Tests/SwiftAutoGUIBrowserTests/BrowserSessionTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import SwiftAutoGUI
+import Testing
+@testable import SwiftAutoGUIBrowser
+
+@Suite("Browser session")
+struct BrowserSessionTests {
+    @Test("observes numbered semantic elements through CDP")
+    func observesElements() async throws {
+        let transport = MockCDPTransport()
+        let session = makeSession(transport: transport)
+        try await session.start()
+
+        let observation = try await session.observe(visionMode: .never)
+        #expect(observation.kind == .browser)
+        #expect(observation.actionableElementCount == 1)
+        #expect(observation.formattedContext.contains("[#1] button \"Submit\""))
+        #expect(await transport.didSend("Accessibility.getFullAXTree"))
+        #expect(await transport.didSend("DOM.getBoxModel"))
+    }
+
+    @Test("native-only actions fail without AX or CGEvent fallback")
+    func rejectsNativeAction() async throws {
+        let transport = MockCDPTransport()
+        let session = makeSession(transport: transport)
+        try await session.start()
+        let observation = try await session.observe(visionMode: .never)
+
+        let execution = await session.execute(.activateApp(name: "Notes"), in: observation)
+        #expect(!execution.result.succeeded)
+        #expect(execution.result.method == .none)
+        #expect(execution.result.failureReason?.contains("does not support") == true)
+        #expect(!(await transport.didSend("Input.dispatchMouseEvent")))
+    }
+
+    @Test("stale elements never fall back to a saved coordinate")
+    func staleElement() async throws {
+        let transport = MockCDPTransport()
+        let session = makeSession(transport: transport)
+        try await session.start()
+        let observation = try await session.observe(visionMode: .never)
+        await transport.setLoaderID("loader-2")
+
+        let execution = await session.execute(.pressElement(elementID: 1), in: observation)
+        #expect(!execution.result.succeeded)
+        #expect(execution.result.method == .cdp)
+        #expect(execution.result.failureReason?.contains("stale") == true)
+        #expect(!(await transport.didSend("Input.dispatchMouseEvent")))
+    }
+
+    @Test("semantic click dispatches CDP mouse events")
+    func clicksElement() async throws {
+        let transport = MockCDPTransport()
+        let session = makeSession(transport: transport)
+        try await session.start()
+        let observation = try await session.observe(visionMode: .never)
+
+        let execution = await session.execute(.pressElement(elementID: 1), in: observation)
+        #expect(execution.result.succeeded)
+        #expect(execution.result.method == .cdp)
+        #expect(await transport.count("Input.dispatchMouseEvent") == 3)
+    }
+
+    @Test("cross-origin navigation is denied without an authorizer")
+    func deniesCrossOriginNavigation() async throws {
+        let transport = MockCDPTransport()
+        let session = makeSession(
+            transport: transport,
+            policy: BrowserSecurityPolicy(allowedDomains: ["example.com", "other.example"])
+        )
+        try await session.start()
+        let observation = try await session.observe(visionMode: .never)
+
+        let execution = await session.execute(.openURL(url: "https://other.example/path"), in: observation)
+        #expect(!execution.result.succeeded)
+        #expect(execution.result.failureReason?.contains("not authorized") == true)
+        #expect(!(await transport.didSend("Page.navigate")))
+    }
+
+    @Test("an authorizer can approve allowlisted cross-origin navigation")
+    func authorizesCrossOriginNavigation() async throws {
+        let transport = MockCDPTransport()
+        let session = makeSession(
+            transport: transport,
+            policy: BrowserSecurityPolicy(allowedDomains: ["example.com", "other.example"]),
+            authorizer: AllowingAuthorizer()
+        )
+        try await session.start()
+        let observation = try await session.observe(visionMode: .never)
+
+        let execution = await session.execute(.openURL(url: "https://other.example/path"), in: observation)
+        #expect(execution.result.succeeded)
+        #expect(await transport.didSend("Page.navigate"))
+    }
+
+    private func makeSession(
+        transport: MockCDPTransport,
+        policy: BrowserSecurityPolicy = BrowserSecurityPolicy(allowedDomains: ["example.com"]),
+        authorizer: (any BrowserActionAuthorizing)? = nil
+    ) -> BrowserSession {
+        BrowserSession(
+            transport: transport,
+            securityPolicy: policy,
+            authorizer: authorizer,
+            options: .init(maxElements: 20, actionObservationDelay: .zero)
+        )
+    }
+}
+
+private struct AllowingAuthorizer: BrowserActionAuthorizing {
+    func authorize(_ request: BrowserAuthorizationRequest) async -> Bool { true }
+}
+
+private actor MockCDPTransport: CDPTransporting {
+    private var methods: [String] = []
+    private var loaderID = "loader-1"
+
+    func connect() async throws {}
+
+    func send(method: String, params: CDPJSONValue, sessionID: String?) async throws -> CDPJSONValue {
+        methods.append(method)
+        switch method {
+        case "Browser.getVersion":
+            return .object(["protocolVersion": .string("1.3"), "product": .string("Chrome/140")])
+        case "Target.getTargets":
+            return .object([
+                "targetInfos": .array([
+                    .object([
+                        "targetId": .string("tab-1"),
+                        "type": .string("page"),
+                        "url": .string("https://example.com"),
+                        "title": .string("Example")
+                    ])
+                ])
+            ])
+        case "Target.attachToTarget":
+            return .object(["sessionId": .string("session-1")])
+        case "Page.getFrameTree":
+            return .object([
+                "frameTree": .object([
+                    "frame": .object([
+                        "id": .string("frame-1"),
+                        "loaderId": .string(loaderID),
+                        "url": .string("https://example.com")
+                    ])
+                ])
+            ])
+        case "Accessibility.getFullAXTree", "Accessibility.getPartialAXTree":
+            return .object(["nodes": .array([buttonNode])])
+        case "DOM.getBoxModel":
+            return boxModel
+        case "DOM.describeNode":
+            return .object(["node": .object(["attributes": .array([])])])
+        case "Page.getLayoutMetrics":
+            return .object([
+                "cssVisualViewport": .object([
+                    "clientWidth": .number(1024),
+                    "clientHeight": .number(768)
+                ])
+            ])
+        default:
+            return .object([:])
+        }
+    }
+
+    func events() async -> AsyncStream<CDPEvent> { AsyncStream { _ in } }
+    func close() async {}
+
+    func setLoaderID(_ value: String) { loaderID = value }
+    func didSend(_ method: String) -> Bool { methods.contains(method) }
+    func count(_ method: String) -> Int { methods.filter { $0 == method }.count }
+
+    private var buttonNode: CDPJSONValue {
+        .object([
+            "ignored": .bool(false),
+            "backendDOMNodeId": .number(42),
+            "frameId": .string("frame-1"),
+            "role": .object(["type": .string("role"), "value": .string("button")]),
+            "name": .object(["type": .string("computedString"), "value": .string("Submit")]),
+            "properties": .array([])
+        ])
+    }
+
+    private var boxModel: CDPJSONValue {
+        .object([
+            "model": .object([
+                "border": .array([10, 20, 90, 20, 90, 50, 10, 50].map { .number(Double($0)) })
+            ])
+        ])
+    }
+}

--- a/Tests/SwiftAutoGUITests/ActionGeneratorTests.swift
+++ b/Tests/SwiftAutoGUITests/ActionGeneratorTests.swift
@@ -210,6 +210,16 @@ struct ActionGeneratorTests {
                 return
             }
         }
+
+        @Test("activateTab round-trip")
+        func activateTabRoundTrip() throws {
+            let roundTripped = try roundTrip(.activateTab(tabID: "target-123"))
+            guard case .activateTab(let tabID) = roundTripped else {
+                Issue.record("Expected .activateTab, got \(roundTripped)")
+                return
+            }
+            #expect(tabID == "target-123")
+        }
     }
 
     // MARK: - OpenAI JSON Response Parsing Tests

--- a/Tests/SwiftAutoGUITests/AgentAutomationBackendTests.swift
+++ b/Tests/SwiftAutoGUITests/AgentAutomationBackendTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+@testable import SwiftAutoGUI
+
+@Suite("Agent automation backend")
+struct AgentAutomationBackendTests {
+    @Test("Agent defaults to native automation")
+    func nativeDefault() {
+        let agent = Agent(backend: DoneVisionBackend())
+        #expect(agent.automationBackend is NativeAutomationBackend)
+    }
+
+    @Test("Agent observes through an explicitly supplied backend")
+    @MainActor
+    func explicitBackend() async throws {
+        let automation = FakeAutomationBackend()
+        let agent = Agent(
+            backend: DoneVisionBackend(),
+            maxIterations: 1,
+            delayBetweenSteps: 0,
+            visionMode: .always,
+            automationBackend: automation
+        )
+        let result = try await agent.run(goal: "Done")
+        #expect(result.completed)
+        #expect(await automation.observationCount == 1)
+    }
+}
+
+private struct DoneVisionBackend: VisionActionGenerating {
+    var isAvailable: Bool { true }
+    var unavailableReason: String? { nil }
+
+    func generateActions(
+        goal: String,
+        screenshot: Data,
+        screenSize: CGSize,
+        history: [AgentStep]
+    ) async throws -> AgentResponse {
+        AgentResponse(actions: [], reasoning: "Already complete", isDone: true)
+    }
+}
+
+private actor FakeAutomationBackend: AgentAutomationBackend {
+    private(set) var observationCount = 0
+
+    func observe(visionMode: AgentVisionMode) async throws -> AgentObservation {
+        observationCount += 1
+        return AgentObservation(
+            kind: .browser,
+            formattedContext: "Browser tab: test",
+            stateFingerprint: "test",
+            actionableElementCount: 0,
+            viewportSize: CGSize(width: 100, height: 100),
+            screenshotJPEGData: Data([0x01])
+        )
+    }
+
+    func execute(
+        _ action: BasicAction,
+        in observation: AgentObservation
+    ) async -> AgentAutomationExecution {
+        AgentAutomationExecution(
+            result: ActionExecutionResult(action: action, succeeded: true, method: .none),
+            observation: observation
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- add a pluggable Agent automation backend while preserving native macOS automation as the default
- add SwiftAutoGUIBrowser, a dedicated Chromium CDP backend for tab management, semantic observation, navigation, element actions, keyboard input, and scrolling
- add browser security policies for loopback endpoints, domain allowlists, cross-origin authorization, redirects, and downloads
- add browser commands to sagui and an interactive Browser CDP workflow to the Sample app
- add DocC documentation, an English quick-start guide, CI coverage, and mock-based browser tests

## Behavior

A BrowserSession passed to Agent is intentionally browser-only. Native-only actions return an unsupported result and never fall back to Accessibility or CGEvent. Stale DOM elements also fail safely and trigger a new observation instead of clicking stored coordinates.

The backend connects to an existing Chromium instance through a loopback remote-debugging endpoint. Navigation is restricted to explicitly allowed domains, while allowlisted cross-origin navigation and downloads require an injected authorizer.

Hybrid browser and native macOS automation remains out of scope and is tracked in #122.

## Validation

- swift test: 180 tests passed across 24 suites
- swift build -c release
- Sample app Debug build with code signing disabled
- git diff --check

Closes #118
