### PR TITLE
Add deterministic browser commands and Claude Code Skill

### DIFF
--- a/Documentation/BrowserAgent.md
+++ b/Documentation/BrowserAgent.md
@@ -37,10 +37,33 @@ text field or the `OPENAI_API_KEY` environment variable and is never stored in s
 
 ## 3. Try it with sagui
 
+Direct commands do not use the OpenAI API. List tabs, observe a semantic element map, and perform
+known actions with an explicit tab target:
+
+```bash
+sagui browser tabs
+sagui browser observe --tab-id TARGET_ID
+
+sagui browser click \
+  --tab-id TARGET_ID \
+  --role link \
+  --name "Issues" \
+  --domain github.com
+
+sagui browser set-value "SwiftAutoGUI" \
+  --tab-id TARGET_ID \
+  --role searchbox \
+  --name "Search"
+```
+
+Other direct commands include `activate-tab`, `open`, `type`, `key`, and `scroll`. Element actions
+always require the exact semantic role and accessible name from a fresh observation. Add
+`--element-id` only to disambiguate duplicate role/name pairs.
+
+To run the AI Agent:
+
 ```bash
 export OPENAI_API_KEY="your-key-in-your-shell"
-
-sagui browser tabs
 
 sagui browser agent "Open issue 118" \
   --domain github.com \

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ await actions.execute()
 
 # Claude Code Plugin
 
-SwiftAutoGUI ships as a [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugin so Claude can control macOS GUI applications via the `sagui` CLI — taking screenshots, clicking buttons, typing text, scrolling, and more.
+SwiftAutoGUI ships as a [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugin so Claude can control native macOS applications and Chromium pages through the `sagui` CLI.
 
 ## Install from the marketplace
 
@@ -212,7 +212,12 @@ Inside Claude Code:
 /plugin install swift-auto-gui@swift-auto-gui
 ```
 
-This installs the `macos-control` skill, which is invoked as `/swift-auto-gui:macos-control`. The skill walks Claude through installing the `sagui` binary the first time it's needed (Swift 6.2+ toolchain required).
+This installs two skills:
+
+- `macos-control`, invoked as `/swift-auto-gui:macos-control`, controls native macOS UI.
+- `browser-control`, invoked as `/swift-auto-gui:browser-control`, controls Chromium pages through CDP without native input fallback.
+
+The skills walk Claude through installing or updating the `sagui` binary when needed.
 
 ## Permissions
 
@@ -221,7 +226,9 @@ Grant the application running Claude Code (Terminal.app, iTerm, etc.) both:
 - **Accessibility** — System Settings → Privacy & Security → Accessibility
 - **Screen Recording** — System Settings → Privacy & Security → Screen Recording
 
-For full skill details, see [`plugins/swift-auto-gui/skills/macos-control/SKILL.md`](plugins/swift-auto-gui/skills/macos-control/SKILL.md).
+These permissions are required for `macos-control`; browser-only CDP actions do not require them.
+
+For full details, see the [`macos-control`](plugins/swift-auto-gui/skills/macos-control/SKILL.md) and [`browser-control`](plugins/swift-auto-gui/skills/browser-control/SKILL.md) skill definitions.
 
 # Contributors
 

--- a/README.md
+++ b/README.md
@@ -125,10 +125,12 @@ Accessibility or CGEvent. Stale DOM elements also fail safely without clicking
 a saved coordinate. Cross-origin navigation and downloads require a
 `BrowserActionAuthorizing` implementation; without one they are denied.
 
-The `sagui` CLI can run the same browser-only Agent:
+The `sagui` CLI supports deterministic CDP commands as well as the browser-only Agent:
 
 ```bash
 sagui browser tabs
+sagui browser observe --tab-id TARGET_ID
+sagui browser click --tab-id TARGET_ID --role link --name "Issues" --domain github.com
 sagui browser agent "Open issue 118" --domain github.com --allow-cross-origin
 ```
 

--- a/Sources/SwiftAutoGUIBrowser/Documentation.docc/BrowserAgent.md
+++ b/Sources/SwiftAutoGUIBrowser/Documentation.docc/BrowserAgent.md
@@ -147,6 +147,31 @@ List available tabs:
 sagui browser tabs --endpoint http://127.0.0.1:9222
 ```
 
+Use deterministic commands when the desired action is already known. These commands do not call
+the OpenAI API:
+
+```bash
+sagui browser observe --tab-id TARGET_ID
+
+sagui browser click \
+  --tab-id TARGET_ID \
+  --role link \
+  --name "Issues" \
+  --domain github.com
+
+sagui browser set-value "SwiftAutoGUI" \
+  --tab-id TARGET_ID \
+  --role searchbox \
+  --name "Search"
+
+sagui browser key return --tab-id TARGET_ID
+sagui browser scroll --vertical -5 --tab-id TARGET_ID
+```
+
+The direct command set also includes `activate-tab`, `open`, and `type`. Element actions resolve
+the exact role and accessible name against a fresh observation. Use `--element-id` in addition to
+`--role` and `--name` only when multiple current elements have the same semantic identity.
+
 Run a browser-only Agent:
 
 ```bash

--- a/Sources/sagui/BrowserCommand.swift
+++ b/Sources/sagui/BrowserCommand.swift
@@ -8,7 +8,18 @@ struct BrowserCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "browser",
         abstract: "Control Chromium pages through the Chrome DevTools Protocol.",
-        subcommands: [BrowserTabsCommand.self, BrowserAgentCommand.self]
+        subcommands: [
+            BrowserTabsCommand.self,
+            BrowserObserveCommand.self,
+            BrowserActivateTabCommand.self,
+            BrowserOpenCommand.self,
+            BrowserClickCommand.self,
+            BrowserSetValueCommand.self,
+            BrowserTypeCommand.self,
+            BrowserKeyCommand.self,
+            BrowserScrollCommand.self,
+            BrowserAgentCommand.self,
+        ]
     )
 }
 
@@ -33,6 +44,167 @@ struct BrowserTabsCommand: AsyncParsableCommand {
         } catch {
             await browser.close()
             throw error
+        }
+    }
+}
+
+struct BrowserObserveCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "observe",
+        abstract: "Print numbered semantic elements from a Chromium page."
+    )
+
+    @OptionGroup var target: BrowserTargetOptions
+
+    @Option(help: "Optional path for a JPEG screenshot of the page.")
+    var screenshot: String?
+
+    func run() async throws {
+        try await withBrowserSession(connection: target.connection, tabID: target.tabID) { browser in
+            let observation = try await browser.observe(
+                tabID: target.tabID,
+                includeScreenshot: screenshot != nil
+            )
+            print(observation.formattedContext)
+            if let screenshot, let data = observation.screenshotJPEGData {
+                try data.write(to: URL(fileURLWithPath: screenshot), options: .atomic)
+                print("Screenshot: \(screenshot)")
+            }
+        }
+    }
+}
+
+struct BrowserActivateTabCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "activate-tab",
+        abstract: "Activate a Chromium page tab by target ID."
+    )
+
+    @Argument(help: "CDP target ID printed by browser tabs.")
+    var tabID: String
+
+    @OptionGroup var connection: BrowserConnectionOptions
+
+    func run() async throws {
+        try await withBrowserSession(connection: connection, tabID: tabID) { browser in
+            let tabs = try await browser.listTabs()
+            printTabs(tabs)
+        }
+    }
+}
+
+struct BrowserOpenCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "open",
+        abstract: "Navigate the selected Chromium tab to an allowed URL."
+    )
+
+    @Argument(help: "HTTP or HTTPS URL to open.")
+    var url: String
+
+    @OptionGroup var target: BrowserTargetOptions
+
+    func run() async throws {
+        guard let destination = URL(string: url),
+              let scheme = destination.scheme?.lowercased(),
+              ["http", "https"].contains(scheme),
+              destination.host != nil else {
+            throw ValidationError("Provide an absolute HTTP or HTTPS URL.")
+        }
+        try await performBrowserAction(target: target) { _ in .navigate(destination) }
+    }
+}
+
+struct BrowserClickCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "click",
+        abstract: "Click a semantic element in the selected Chromium tab."
+    )
+
+    @OptionGroup var target: BrowserTargetOptions
+    @OptionGroup var selector: BrowserElementSelector
+
+    func run() async throws {
+        try await performBrowserAction(target: target) { observation in
+            .click(elementID: try selector.resolve(in: observation).elementID)
+        }
+    }
+}
+
+struct BrowserSetValueCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "set-value",
+        abstract: "Replace the value of an editable semantic element."
+    )
+
+    @Argument(help: "Replacement text.")
+    var value: String
+
+    @OptionGroup var target: BrowserTargetOptions
+    @OptionGroup var selector: BrowserElementSelector
+
+    func run() async throws {
+        try await performBrowserAction(target: target) { observation in
+            .replaceText(elementID: try selector.resolve(in: observation).elementID, value: value)
+        }
+    }
+}
+
+struct BrowserTypeCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "type",
+        abstract: "Insert text into the currently focused page element."
+    )
+
+    @Argument(help: "Text to insert.")
+    var text: String
+
+    @OptionGroup var target: BrowserTargetOptions
+
+    func run() async throws {
+        try await performBrowserAction(target: target) { _ in .insertText(text) }
+    }
+}
+
+struct BrowserKeyCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "key",
+        abstract: "Send a key or key shortcut to the selected Chromium tab."
+    )
+
+    @Argument(help: "Key names, for example command a or return.")
+    var keys: [String]
+
+    @OptionGroup var target: BrowserTargetOptions
+
+    func run() async throws {
+        try await performBrowserAction(target: target) { _ in .keyShortcut(keys) }
+    }
+}
+
+struct BrowserScrollCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "scroll",
+        abstract: "Scroll the selected Chromium page."
+    )
+
+    @Option(parsing: .unconditional, help: "Vertical scroll clicks; positive scrolls up and negative scrolls down.")
+    var vertical = 0
+
+    @Option(parsing: .unconditional, help: "Horizontal scroll clicks; positive scrolls left and negative scrolls right.")
+    var horizontal = 0
+
+    @OptionGroup var target: BrowserTargetOptions
+
+    mutating func validate() throws {
+        guard vertical != 0 || horizontal != 0 else {
+            throw ValidationError("Provide a non-zero --vertical or --horizontal value.")
+        }
+    }
+
+    func run() async throws {
+        try await performBrowserAction(target: target) { _ in
+            .scroll(horizontal: horizontal, vertical: vertical)
         }
     }
 }
@@ -154,6 +326,125 @@ private struct SaguiBrowserAuthorizer: BrowserActionAuthorizing {
         case .crossOriginNavigation: true
         case .download: false
         }
+    }
+}
+
+struct BrowserConnectionOptions: ParsableArguments {
+    @Option(help: "Loopback Chromium debugging endpoint.")
+    var endpoint: String = "http://127.0.0.1:9222"
+
+    @Option(
+        name: .customLong("domain"),
+        help: "Allowed page domain. Repeat for multiple domains."
+    )
+    var domains: [String] = []
+
+    @Flag(help: "Approve cross-origin navigation when its destination is also in --domain.")
+    var allowCrossOrigin = false
+}
+
+struct BrowserTargetOptions: ParsableArguments {
+    @OptionGroup var connection: BrowserConnectionOptions
+
+    @Option(help: "CDP target ID printed by browser tabs.")
+    var tabID: String
+}
+
+struct BrowserElementSelector: ParsableArguments {
+    @Option(help: "Optional step-local element ID used to disambiguate matching role and name values.")
+    var elementID: Int?
+
+    @Option(help: "Exact semantic role printed by browser observe.")
+    var role: String
+
+    @Option(help: "Exact accessible name printed by browser observe.")
+    var name: String
+
+    mutating func validate() throws {
+        if let elementID, elementID <= 0 {
+            throw ValidationError("--element-id must be greater than zero.")
+        }
+    }
+
+    func resolve(in observation: BrowserObservation) throws -> BrowserElement {
+        if let elementID {
+            guard let element = observation.element(withID: elementID),
+                  element.role.compare(role, options: .caseInsensitive) == .orderedSame,
+                  element.name == name else {
+                throw ValidationError(
+                    "Element #\(elementID) does not match role \(role) and name \(name) in the current observation."
+                )
+            }
+            return element
+        }
+
+        let matches = observation.elements.filter {
+            $0.role.compare(role, options: .caseInsensitive) == .orderedSame
+                && $0.name == name
+        }
+        guard matches.count == 1, let element = matches.first else {
+            if matches.isEmpty {
+                throw ValidationError("No current element matches role \(role) and name \(name).")
+            }
+            throw ValidationError("Multiple current elements match role \(role) and name \(name); use --element-id.")
+        }
+        return element
+    }
+}
+
+private func withBrowserSession<Result>(
+    connection: BrowserConnectionOptions,
+    tabID: String? = nil,
+    operation: (BrowserSession) async throws -> Result
+) async throws -> Result {
+    let endpointURL = try validatedEndpoint(connection.endpoint)
+    let domainSet = Set(connection.domains.map { $0.lowercased() })
+    let authorizer: (any BrowserActionAuthorizing)? = connection.allowCrossOrigin
+        ? SaguiBrowserAuthorizer()
+        : nil
+    let browser = try await BrowserSession.connect(
+        endpoint: endpointURL,
+        securityPolicy: BrowserSecurityPolicy(allowedDomains: domainSet),
+        authorizer: authorizer
+    )
+    do {
+        if let tabID { try await browser.activateTab(tabID) }
+        let result = try await operation(browser)
+        await browser.close()
+        return result
+    } catch {
+        await browser.close()
+        throw error
+    }
+}
+
+private func performBrowserAction(
+    target: BrowserTargetOptions,
+    action: (BrowserObservation) throws -> BrowserAction
+) async throws {
+    try await withBrowserSession(connection: target.connection, tabID: target.tabID) { browser in
+        let observation = try await browser.observe(tabID: target.tabID)
+        let result = await browser.execute(try action(observation), against: observation)
+        guard result.succeeded else {
+            throw result.failure ?? BrowserError.unsupportedAction("the requested command")
+        }
+        print("Result: succeeded via cdp")
+        if let navigation = result.navigation {
+            print("Navigation: \(navigation.fromURL ?? "(none)") -> \(navigation.toURL)")
+        }
+        for change in result.tabChanges {
+            print("Tab: \(change.kind.rawValue) \(change.tabID) \(change.url ?? "")")
+        }
+        for download in result.downloads {
+            print("Download: \(download.state.rawValue) \(download.suggestedFilename ?? download.identifier)")
+        }
+        print(result.observation.formattedContext)
+    }
+}
+
+private func printTabs(_ tabs: [BrowserTab]) {
+    for tab in tabs {
+        print("\(tab.state.rawValue)\t\(tab.id)\t\(tab.title)\t\(tab.url)")
     }
 }
 

--- a/Tests/SaguiTests/SaguiCommandTests.swift
+++ b/Tests/SaguiTests/SaguiCommandTests.swift
@@ -139,4 +139,91 @@ struct SaguiCommandTests {
         let command = try BrowserTabsCommand.parse([])
         #expect(command.endpoint == "http://127.0.0.1:9222")
     }
+
+    @Test("Browser observe requires and accepts a tab ID")
+    func browserObserveOptions() throws {
+        let command = try BrowserObserveCommand.parse([
+            "--tab-id", "target-123",
+            "--screenshot", "/tmp/page.jpg",
+        ])
+        #expect(command.target.tabID == "target-123")
+        #expect(command.target.connection.endpoint == "http://127.0.0.1:9222")
+        #expect(command.screenshot == "/tmp/page.jpg")
+    }
+
+    @Test("Browser open accepts a narrow navigation policy")
+    func browserOpenOptions() throws {
+        let command = try BrowserOpenCommand.parse([
+            "https://github.com/NakaokaRei/SwiftAutoGUI",
+            "--tab-id", "target-123",
+            "--domain", "github.com",
+            "--domain", "*.github.com",
+            "--allow-cross-origin",
+        ])
+        #expect(command.target.tabID == "target-123")
+        #expect(command.target.connection.domains == ["github.com", "*.github.com"])
+        #expect(command.target.connection.allowCrossOrigin)
+    }
+
+    @Test("Browser click accepts semantic selectors with optional disambiguation")
+    func browserClickOptions() throws {
+        let semantic = try BrowserClickCommand.parse([
+            "--tab-id", "target-123",
+            "--role", "button",
+            "--name", "Save",
+        ])
+        #expect(semantic.selector.elementID == nil)
+        #expect(semantic.selector.role == "button")
+        #expect(semantic.selector.name == "Save")
+
+        let disambiguated = try BrowserClickCommand.parse([
+            "--tab-id", "target-123",
+            "--role", "button",
+            "--name", "Save",
+            "--element-id", "4",
+        ])
+        #expect(disambiguated.selector.elementID == 4)
+    }
+
+    @Test("Browser click rejects incomplete and invalid selectors")
+    func browserClickRejectsInvalidSelector() {
+        #expect(throws: (any Error).self) {
+            try BrowserClickCommand.parse([
+                "--tab-id", "target-123",
+                "--role", "button",
+            ])
+        }
+        #expect(throws: (any Error).self) {
+            try BrowserClickCommand.parse([
+                "--tab-id", "target-123",
+                "--role", "button",
+                "--name", "Save",
+                "--element-id", "0",
+            ])
+        }
+    }
+
+    @Test("Browser key and scroll commands parse deterministic actions")
+    func browserInputOptions() throws {
+        let key = try BrowserKeyCommand.parse([
+            "command", "a",
+            "--tab-id", "target-123",
+        ])
+        #expect(key.keys == ["command", "a"])
+
+        let scroll = try BrowserScrollCommand.parse([
+            "--vertical", "-5",
+            "--horizontal", "2",
+            "--tab-id", "target-123",
+        ])
+        #expect(scroll.vertical == -5)
+        #expect(scroll.horizontal == 2)
+    }
+
+    @Test("Browser scroll rejects an empty movement")
+    func browserScrollRejectsEmptyMovement() {
+        #expect(throws: (any Error).self) {
+            try BrowserScrollCommand.parse(["--tab-id", "target-123"])
+        }
+    }
 }

--- a/plugins/swift-auto-gui/.claude-plugin/plugin.json
+++ b/plugins/swift-auto-gui/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "swift-auto-gui",
-  "description": "Control macOS GUI applications via mouse, keyboard, screenshots, image recognition, and AppleScript using the sagui CLI.",
+  "description": "Control macOS GUI applications and Chromium pages using the sagui CLI.",
   "version": "0.29.0",
   "author": {
     "name": "NakaokaRei"
@@ -14,6 +14,9 @@
     "gui",
     "mouse",
     "keyboard",
-    "screenshot"
+    "screenshot",
+    "browser",
+    "chromium",
+    "cdp"
   ]
 }

--- a/plugins/swift-auto-gui/skills/browser-control/SKILL.md
+++ b/plugins/swift-auto-gui/skills/browser-control/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: browser-control
+description: Control web pages in an existing Chromium remote-debugging session with the sagui browser-only AI Agent. Use when Claude Code needs to list Chromium tabs or complete a browser task through CDP without controlling native macOS UI, Accessibility, or CGEvent input.
+---
+
+# browser-control
+
+Use `sagui browser` to inspect and automate Chromium pages through the Chrome DevTools Protocol
+(CDP). Treat this as a browser-only environment: it never falls back to native macOS automation.
+
+## Preflight
+
+Run these checks before browser automation:
+
+```bash
+uname -s
+command -v sagui
+sagui browser --help
+```
+
+Stop if the platform is not macOS. If `sagui` is missing, or the installed version has no
+`browser` command, ask before installing or upgrading it:
+
+```bash
+brew update
+brew install NakaokaRei/tap/sagui
+# Use this instead when sagui is already installed:
+brew upgrade NakaokaRei/tap/sagui
+```
+
+Do not claim that Accessibility or Screen Recording permission is required for browser-only CDP
+actions. Those permissions apply to native `sagui` commands, not `sagui browser`.
+
+## Connect to Chromium
+
+List tabs on the default loopback endpoint:
+
+```bash
+sagui browser tabs
+```
+
+If no debugging endpoint is available, ask the user to start a dedicated Chromium profile, or
+obtain approval before launching it:
+
+```bash
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  --remote-debugging-address=127.0.0.1 \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/swift-auto-gui-browser-profile
+```
+
+Keep the endpoint on loopback. Do not expose or connect CDP to a LAN or public address. The browser
+session does not launch Chromium, manage profiles, bypass login, solve CAPTCHA, or handle 2FA.
+
+Use the target ID printed by `sagui browser tabs` when a specific tab matters. Re-list tabs after a
+tab closes, opens, or navigates unexpectedly because target IDs and page observations may become
+stale.
+
+## Choose the domain allowlist
+
+Build the narrowest allowlist that satisfies the user's stated goal:
+
+- `github.com` permits exactly `github.com`.
+- `'*.github.com'` permits subdomains but not the parent domain; quote wildcards in the shell.
+- Repeat `--domain` for multiple hosts.
+- Never use a global wildcard, a public suffix such as `com`, or unrelated domains.
+- Ask before adding a domain that is not clearly implied by the goal.
+
+An allowlist entry only makes a destination eligible. Cross-origin navigation is still denied
+unless `--allow-cross-origin` is present. Use that flag only when the goal requires navigation from
+another origin, such as from `chrome://newtab/` to an allowed website. It never permits navigation
+outside the allowlist. Downloads remain denied.
+
+## Handle the OpenAI API key
+
+The Agent uses the OpenAI API. Prefer `OPENAI_API_KEY`; never print the value, request it in chat, or
+put it in a command with `--api-key`, where it may enter shell history or process listings.
+
+Check only whether the variable exists:
+
+```bash
+if [ -n "${OPENAI_API_KEY:-}" ]; then
+  echo "OPENAI_API_KEY is configured"
+else
+  echo "OPENAI_API_KEY is not configured"
+fi
+```
+
+If it is absent, ask the user to configure it securely in their shell and stop until they confirm.
+
+## Run a browser-only Agent
+
+First list tabs, then run a narrowly scoped goal:
+
+```bash
+sagui browser tabs
+
+sagui browser agent \
+  "Open issue 118 in the NakaokaRei/SwiftAutoGUI repository" \
+  --domain github.com \
+  --domain '*.github.com' \
+  --allow-cross-origin \
+  --tab-id TARGET_ID
+```
+
+Omit `--tab-id` when the current active page is the intended starting point. Useful optional
+controls include:
+
+```bash
+--endpoint http://127.0.0.1:9222
+--model gpt-5.6-sol
+--reasoning-effort low
+--max-iterations 20
+--delay 1.0
+--vision-mode automatic
+```
+
+Use `automatic` as the normal vision mode. The Agent primarily observes semantic DOM and
+Accessibility data and re-observes after navigation, DOM changes, stale elements, or action
+failures.
+
+Before goals that submit forms, publish content, purchase items, change permissions, delete data,
+or otherwise have meaningful external effects, confirm the final consequential action with the
+user unless their request already authorized it explicitly.
+
+## Interpret results
+
+- `unsupportedAction`: The model requested a native-only action. Do not retry it through mouse or
+  keyboard fallback.
+- `staleElement`: The DOM node, frame, loader, or tab changed. List tabs or run a fresh Agent step;
+  never click an old coordinate.
+- `navigationNotAllowed`: Add the exact destination host only if it belongs to the user's goal.
+- `authorizationDenied`: Cross-origin navigation needs explicit `--allow-cross-origin` approval.
+- `disconnected`: Chromium exited or its debugging endpoint closed.
+
+Treat `Completed: true` as the Agent's completion report, then verify any important result from its
+printed actions or by listing/observing the relevant tab again.
+
+## Native macOS boundary
+
+This Skill controls page content only. It cannot operate Chromium window chrome, permission
+dialogs, file pickers implemented as native macOS UI, Finder, System Settings, or other apps. For
+those tasks, use the separate `macos-control` Skill in a distinct phase. Do not represent the two
+backends as one Agent run and do not silently fall back from CDP to Accessibility or CGEvent.

--- a/plugins/swift-auto-gui/skills/browser-control/SKILL.md
+++ b/plugins/swift-auto-gui/skills/browser-control/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser-control
-description: Control web pages in an existing Chromium remote-debugging session with the sagui browser-only AI Agent. Use when Claude Code needs to list Chromium tabs or complete a browser task through CDP without controlling native macOS UI, Accessibility, or CGEvent input.
+description: Control web pages in an existing Chromium remote-debugging session with deterministic sagui commands or the browser-only AI Agent. Use when Claude Code needs to inspect tabs, observe semantic elements, navigate, click, type, send keys, scroll, or complete a browser goal through CDP without controlling native macOS UI, Accessibility, or CGEvent input.
 ---
 
 # browser-control
@@ -70,6 +70,70 @@ An allowlist entry only makes a destination eligible. Cross-origin navigation is
 unless `--allow-cross-origin` is present. Use that flag only when the goal requires navigation from
 another origin, such as from `chrome://newtab/` to an allowed website. It never permits navigation
 outside the allowlist. Downloads remain denied.
+
+## Use deterministic commands
+
+Prefer direct commands when the requested action is known. They do not call the OpenAI API and do
+not require `OPENAI_API_KEY`.
+
+First list tabs and observe the intended tab:
+
+```bash
+sagui browser tabs
+sagui browser observe --tab-id TARGET_ID
+sagui browser observe --tab-id TARGET_ID --screenshot /tmp/page.jpg
+```
+
+The observation prints actionable elements as `[#N] role "name"`. Select elements by exact
+`--role` and `--name`. When multiple current elements share both values, also pass the observed
+`--element-id`; the command verifies all three values against a fresh observation before acting.
+
+```bash
+sagui browser click \
+  --tab-id TARGET_ID \
+  --role link \
+  --name "Issues" \
+  --domain github.com \
+  --allow-cross-origin
+
+sagui browser set-value "SwiftAutoGUI" \
+  --tab-id TARGET_ID \
+  --role searchbox \
+  --name "Search"
+```
+
+Other deterministic commands:
+
+```bash
+sagui browser activate-tab TARGET_ID
+
+sagui browser open "https://github.com/NakaokaRei/SwiftAutoGUI/issues" \
+  --tab-id TARGET_ID \
+  --domain github.com \
+  --allow-cross-origin
+
+sagui browser type "additional text" --tab-id TARGET_ID
+sagui browser key command a --tab-id TARGET_ID
+sagui browser key return --tab-id TARGET_ID
+sagui browser scroll --vertical -5 --tab-id TARGET_ID
+sagui browser scroll --horizontal 3 --tab-id TARGET_ID
+```
+
+| Command | Purpose | Required selection |
+|---|---|---|
+| `tabs` | List page targets | None |
+| `observe` | Print tabs and semantic elements | `--tab-id` |
+| `activate-tab` | Activate a page target | positional target ID |
+| `open` | Navigate to an allowed HTTP(S) URL | URL, `--tab-id`, `--domain` |
+| `click` | Click a freshly verified semantic element | `--tab-id`, `--role`, `--name` |
+| `set-value` | Replace an editable element value | value, `--tab-id`, `--role`, `--name` |
+| `type` | Insert text into the focused element | text, `--tab-id` |
+| `key` | Send a key or shortcut | keys, `--tab-id` |
+| `scroll` | Scroll the page | non-zero axis, `--tab-id` |
+
+After navigation, click, typing, keys, or scrolling, use the updated semantic map printed by the
+command. Do not reuse an old element ID after the page changes. Prefer `set-value` over `type` when
+the target textbox is known because `set-value` focuses and verifies the semantic element first.
 
 ## Handle the OpenAI API key
 

--- a/plugins/swift-auto-gui/skills/browser-control/agents/openai.yaml
+++ b/plugins/swift-auto-gui/skills/browser-control/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Browser Control"
+  short_description: "Control Chromium pages safely through sagui and CDP"
+  default_prompt: "Use $browser-control to control an existing Chromium tab safely."

--- a/plugins/swift-auto-gui/skills/browser-control/agents/openai.yaml
+++ b/plugins/swift-auto-gui/skills/browser-control/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Browser Control"
-  short_description: "Control Chromium pages safely through sagui and CDP"
-  default_prompt: "Use $browser-control to control an existing Chromium tab safely."
+  short_description: "Control Chromium safely with direct commands or AI"
+  default_prompt: "Use $browser-control to inspect and control an existing Chromium tab safely."


### PR DESCRIPTION
## Summary

- add deterministic sagui browser commands for observation, tab activation, navigation, semantic clicks, text input, key input, and scrolling
- add a browser-control Skill to the SwiftAutoGUI Claude Code plugin
- guide Claude through sagui capability checks, Chromium remote-debugging setup, tab selection, domain allowlists, direct commands, and browser Agent execution
- update the plugin metadata, README, quick-start guide, and DocC documentation

## Direct commands

The browser CLI now exposes:

- browser tabs and browser observe
- browser activate-tab and browser open
- browser click and browser set-value
- browser type, browser key, and browser scroll
- the existing browser agent command

Direct commands do not call the OpenAI API. Element actions resolve an exact semantic role and accessible name against a fresh observation. An optional step-local element ID can disambiguate duplicates, but it must also match the expected role and name.

## Safety

All commands remain browser-only and never fall back to Accessibility or CGEvent input. The Skill requires narrow domain allowlists, keeps CDP endpoints on loopback, avoids exposing API keys in command arguments, and documents cross-origin authorization. Downloads remain denied.

## Validation

- swift test: 186 tests passed across 24 suites
- new sagui command parsing tests passed
- sagui browser, click, and scroll help output verified
- SwiftAutoGUIBrowser DocC generation passed
- Skill quick validator passed
- claude plugin validate passed
- plugin manifest JSON validation passed
- git diff --check passed

Builds on #123.
