### PR TITLE
Add real-browser integration CI

### DIFF
--- a/.github/workflows/browser-integration.yml
+++ b/.github/workflows/browser-integration.yml
@@ -24,13 +24,19 @@ jobs:
         with:
           chrome-version: stable
 
-      - name: Start local fixture and Chrome
+      - name: Run browser integration tests
+        env:
+          SWIFTAUTOGUI_RUN_CDP_TESTS: "1"
+          SWIFTAUTOGUI_CDP_ENDPOINT: http://127.0.0.1:9222
+          SWIFTAUTOGUI_CDP_PAGE_URL: http://127.0.0.1:8765/index.html
         run: |
+          set -euo pipefail
+
           python3 -m http.server 8765 \
             --bind 127.0.0.1 \
             --directory Tests/Fixtures/Browser \
             >"${RUNNER_TEMP}/fixture.log" 2>&1 &
-          echo "$!" > "${RUNNER_TEMP}/fixture.pid"
+          fixture_pid=$!
 
           "${{ steps.chrome.outputs.chrome-path }}" \
             --headless \
@@ -40,38 +46,33 @@ jobs:
             --remote-debugging-port=9222 \
             http://127.0.0.1:8765/index.html \
             >"${RUNNER_TEMP}/chrome.log" 2>&1 &
-          echo "$!" > "${RUNNER_TEMP}/chrome.pid"
+          chrome_pid=$!
 
-      - name: Wait for browser endpoint
-        run: |
+          cleanup() {
+            kill "${chrome_pid}" 2>/dev/null || true
+            kill "${fixture_pid}" 2>/dev/null || true
+            wait "${chrome_pid}" 2>/dev/null || true
+            wait "${fixture_pid}" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          ready=0
           for attempt in {1..30}; do
             if curl --fail --silent http://127.0.0.1:8765/index.html >/dev/null \
               && curl --fail --silent http://127.0.0.1:9222/json/version >/dev/null; then
-              exit 0
+              ready=1
+              break
             fi
             sleep 1
           done
 
-          cat "${RUNNER_TEMP}/fixture.log"
-          cat "${RUNNER_TEMP}/chrome.log"
-          exit 1
-
-      - name: Run browser integration tests
-        env:
-          SWIFTAUTOGUI_RUN_CDP_TESTS: "1"
-          SWIFTAUTOGUI_CDP_ENDPOINT: http://127.0.0.1:9222
-          SWIFTAUTOGUI_CDP_PAGE_URL: http://127.0.0.1:8765/index.html
-        run: swift test --filter BrowserIntegrationTests
-
-      - name: Stop browser processes
-        if: always()
-        run: |
-          if [ -f "${RUNNER_TEMP}/chrome.pid" ]; then
-            kill "$(cat "${RUNNER_TEMP}/chrome.pid")" 2>/dev/null || true
+          if [ "${ready}" -ne 1 ]; then
+            cat "${RUNNER_TEMP}/fixture.log"
+            cat "${RUNNER_TEMP}/chrome.log"
+            exit 1
           fi
-          if [ -f "${RUNNER_TEMP}/fixture.pid" ]; then
-            kill "$(cat "${RUNNER_TEMP}/fixture.pid")" 2>/dev/null || true
-          fi
+
+          swift test --filter BrowserIntegrationTests
 
       - name: Upload browser logs
         if: always()

--- a/.github/workflows/browser-integration.yml
+++ b/.github/workflows/browser-integration.yml
@@ -22,7 +22,7 @@ jobs:
         id: chrome
         uses: browser-actions/setup-chrome@v2
         with:
-          chrome-version: 151.0.7922.137
+          chrome-version: stable
 
       - name: Start local fixture and Chrome
         run: |

--- a/.github/workflows/browser-integration.yml
+++ b/.github/workflows/browser-integration.yml
@@ -1,0 +1,83 @@
+name: Browser Integration
+
+on:
+  pull_request:
+    branches: [ "master" ]
+  push:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  browser-integration:
+    name: Browser Integration
+    runs-on: macos-26
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install Chrome for Testing
+        id: chrome
+        uses: browser-actions/setup-chrome@v2
+        with:
+          chrome-version: 151.0.7922.174
+
+      - name: Start local fixture and Chrome
+        run: |
+          python3 -m http.server 8765 \
+            --bind 127.0.0.1 \
+            --directory Tests/Fixtures/Browser \
+            >"${RUNNER_TEMP}/fixture.log" 2>&1 &
+          echo "$!" > "${RUNNER_TEMP}/fixture.pid"
+
+          "${{ steps.chrome.outputs.chrome-path }}" \
+            --headless \
+            --no-first-run \
+            --user-data-dir="${RUNNER_TEMP}/chrome-profile" \
+            --remote-debugging-address=127.0.0.1 \
+            --remote-debugging-port=9222 \
+            http://127.0.0.1:8765/index.html \
+            >"${RUNNER_TEMP}/chrome.log" 2>&1 &
+          echo "$!" > "${RUNNER_TEMP}/chrome.pid"
+
+      - name: Wait for browser endpoint
+        run: |
+          for attempt in {1..30}; do
+            if curl --fail --silent http://127.0.0.1:8765/index.html >/dev/null \
+              && curl --fail --silent http://127.0.0.1:9222/json/version >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          cat "${RUNNER_TEMP}/fixture.log"
+          cat "${RUNNER_TEMP}/chrome.log"
+          exit 1
+
+      - name: Run browser integration tests
+        env:
+          SWIFTAUTOGUI_RUN_CDP_TESTS: "1"
+          SWIFTAUTOGUI_CDP_ENDPOINT: http://127.0.0.1:9222
+          SWIFTAUTOGUI_CDP_PAGE_URL: http://127.0.0.1:8765/index.html
+        run: swift test --filter BrowserIntegrationTests
+
+      - name: Stop browser processes
+        if: always()
+        run: |
+          if [ -f "${RUNNER_TEMP}/chrome.pid" ]; then
+            kill "$(cat "${RUNNER_TEMP}/chrome.pid")" 2>/dev/null || true
+          fi
+          if [ -f "${RUNNER_TEMP}/fixture.pid" ]; then
+            kill "$(cat "${RUNNER_TEMP}/fixture.pid")" 2>/dev/null || true
+          fi
+
+      - name: Upload browser logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: browser-integration-logs
+          path: |
+            ${{ runner.temp }}/chrome.log
+            ${{ runner.temp }}/fixture.log

--- a/.github/workflows/browser-integration.yml
+++ b/.github/workflows/browser-integration.yml
@@ -14,15 +14,11 @@ jobs:
   browser-integration:
     name: Browser Integration
     runs-on: macos-26
+    env:
+      CHROME_PATH: /Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
-
-      - name: Install Chrome for Testing
-        id: chrome
-        uses: browser-actions/setup-chrome@v2
-        with:
-          chrome-version: stable
 
       - name: Run browser integration tests
         env:
@@ -32,13 +28,15 @@ jobs:
         run: |
           set -euo pipefail
 
+          "${CHROME_PATH}" --version
+
           python3 -m http.server 8765 \
             --bind 127.0.0.1 \
             --directory Tests/Fixtures/Browser \
             >"${RUNNER_TEMP}/fixture.log" 2>&1 &
           fixture_pid=$!
 
-          "${{ steps.chrome.outputs.chrome-path }}" \
+          "${CHROME_PATH}" \
             --headless \
             --no-first-run \
             --user-data-dir="${RUNNER_TEMP}/chrome-profile" \

--- a/.github/workflows/browser-integration.yml
+++ b/.github/workflows/browser-integration.yml
@@ -22,7 +22,7 @@ jobs:
         id: chrome
         uses: browser-actions/setup-chrome@v2
         with:
-          chrome-version: 151.0.7922.174
+          chrome-version: 151.0.7922.137
 
       - name: Start local fixture and Chrome
         run: |

--- a/Tests/Fixtures/Browser/index.html
+++ b/Tests/Fixtures/Browser/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>SwiftAutoGUI browser fixture</title>
+  <style>
+    body { font: 16px system-ui; margin: 40px; }
+    label, input, button, a { display: block; margin-block: 12px; }
+    input, button, a { width: 240px; min-height: 36px; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Browser integration fixture</h1>
+    <label for="name">Name</label>
+    <input id="name" name="name" type="text">
+    <button id="submit" type="button">Submit</button>
+    <a href="/second.html" target="_blank" rel="noopener">Open second tab</a>
+  </main>
+  <script>
+    document.querySelector('#submit').addEventListener('click', event => {
+      event.currentTarget.textContent = 'Submitted';
+    });
+  </script>
+</body>
+</html>

--- a/Tests/Fixtures/Browser/next.html
+++ b/Tests/Fixtures/Browser/next.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Allowed navigation</title>
+</head>
+<body>
+  <main>
+    <h1>Allowed navigation completed</h1>
+  </main>
+</body>
+</html>

--- a/Tests/Fixtures/Browser/second.html
+++ b/Tests/Fixtures/Browser/second.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Second tab</title>
+</head>
+<body>
+  <main>
+    <h1>Second tab fixture</h1>
+  </main>
+</body>
+</html>

--- a/Tests/SwiftAutoGUIBrowserTests/BrowserIntegrationTests.swift
+++ b/Tests/SwiftAutoGUIBrowserTests/BrowserIntegrationTests.swift
@@ -2,23 +2,87 @@ import Foundation
 import Testing
 @testable import SwiftAutoGUIBrowser
 
-@Suite("Browser integration")
+@Suite("Browser integration", .serialized)
 struct BrowserIntegrationTests {
-    @Test("connects to an explicitly enabled Chromium endpoint")
-    func optInConnection() async throws {
+    @Test("drives a local page through a real Chromium endpoint")
+    func localPageWorkflow() async throws {
         guard ProcessInfo.processInfo.environment["SWIFTAUTOGUI_RUN_CDP_TESTS"] == "1" else { return }
         let endpointValue = ProcessInfo.processInfo.environment["SWIFTAUTOGUI_CDP_ENDPOINT"]
             ?? "http://127.0.0.1:9222"
-        let domain = ProcessInfo.processInfo.environment["SWIFTAUTOGUI_CDP_DOMAIN"] ?? "example.com"
+        let pageValue = ProcessInfo.processInfo.environment["SWIFTAUTOGUI_CDP_PAGE_URL"]
+            ?? "http://127.0.0.1:8765/index.html"
         let endpoint = try #require(URL(string: endpointValue))
+        let pageURL = try #require(URL(string: pageValue))
+        let domain = try #require(pageURL.host)
         let browser = try await BrowserSession.connect(
             endpoint: endpoint,
             securityPolicy: BrowserSecurityPolicy(allowedDomains: [domain])
         )
-        let tabs = try await browser.listTabs()
-        #expect(!tabs.isEmpty)
-        let observation = try await browser.observe()
-        #expect(!observation.tab.id.isEmpty)
-        await browser.close()
+
+        do {
+            let initial = try await browser.observe()
+            #expect(initial.tab.url == pageURL.absoluteString)
+            let originalTabID = initial.tab.id
+
+            let textbox = try #require(initial.elements.first {
+                $0.role.lowercased() == "textbox" && $0.name == "Name"
+            })
+            let typed = await browser.execute(
+                .replaceText(elementID: textbox.elementID, value: "SwiftAutoGUI CI"),
+                against: initial
+            )
+            #expect(typed.succeeded)
+            #expect(typed.observation.elements.contains {
+                $0.role.lowercased() == "textbox" && $0.value == "SwiftAutoGUI CI"
+            })
+
+            let submit = try #require(typed.observation.elements.first { $0.name == "Submit" })
+            let clicked = await browser.execute(.click(elementID: submit.elementID), against: typed.observation)
+            #expect(clicked.succeeded)
+            #expect(clicked.observation.stateFingerprint != typed.observation.stateFingerprint)
+            #expect(clicked.observation.elements.contains { $0.name == "Submitted" })
+
+            let screenshot = try await browser.observe(includeScreenshot: true)
+            #expect((screenshot.screenshotJPEGData?.count ?? 0) > 100)
+
+            let tabLink = try #require(screenshot.elements.first { $0.name == "Open second tab" })
+            let opened = await browser.execute(.click(elementID: tabLink.elementID), against: screenshot)
+            #expect(opened.succeeded)
+            let secondTab = try await waitForTab(otherThan: originalTabID, in: browser)
+            try await browser.activateTab(secondTab.id)
+            let secondTabObservation = try await browser.observe()
+            #expect(secondTabObservation.tab.id == secondTab.id)
+            #expect(secondTabObservation.tab.url.hasSuffix("/second.html"))
+
+            try await browser.activateTab(originalTabID)
+            let beforeNavigation = try await browser.observe()
+            let allowedURL = try #require(URL(string: "/next.html", relativeTo: pageURL)?.absoluteURL)
+            let allowed = await browser.execute(.navigate(allowedURL), against: beforeNavigation)
+            #expect(allowed.succeeded)
+            #expect(allowed.observation.tab.url == allowedURL.absoluteString)
+
+            let blockedURL = try #require(URL(string: "https://blocked.invalid/"))
+            let blocked = await browser.execute(.navigate(blockedURL), against: allowed.observation)
+            #expect(!blocked.succeeded)
+            #expect(blocked.failure == .navigationNotAllowed(blockedURL.absoluteString))
+
+            await browser.close()
+        } catch {
+            await browser.close()
+            throw error
+        }
+    }
+
+    private func waitForTab(
+        otherThan tabID: String,
+        in browser: BrowserSession
+    ) async throws -> BrowserTab {
+        for _ in 0..<30 {
+            if let tab = try await browser.listTabs().first(where: { $0.id != tabID }) {
+                return tab
+            }
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        throw BrowserError.noPageTabs
     }
 }


### PR DESCRIPTION
## Summary
- add a standalone Browser Integration workflow that runs alongside the existing build workflow
- launch the macOS runner-provided Chrome for Testing with an isolated profile and loopback CDP endpoint
- exercise text input, clicking, DOM re-observation, screenshots, tab switching, and navigation policy against local HTML fixtures
- keep Chrome and the test process in one CI step and upload browser logs on every run

## Verification
- real Chrome end-to-end browser integration test passed locally
- swift test --parallel passed with 186 tests
- both workflow files passed YAML parsing
- git diff --check passed