### PR TITLE
Publish BrowserAgent documentation on GitHub Pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,8 +180,11 @@ jobs:
       - name: Build documentation
         run: |
           set -o pipefail
-          swift package generate-documentation --target SwiftAutoGUI 2>&1 | xcbeautify
-          swift package generate-documentation --target SwiftAutoGUIBrowser 2>&1 | xcbeautify
+          swift package generate-documentation \
+            --target SwiftAutoGUI \
+            --target SwiftAutoGUIBrowser \
+            --enable-experimental-combined-documentation \
+            2>&1 | xcbeautify
 
   sample-app:
     name: Build Sample App

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,8 @@ jobs:
         run: |
           swift package --allow-writing-to-directory ./docs generate-documentation \
           --target SwiftAutoGUI \
+          --target SwiftAutoGUIBrowser \
+          --enable-experimental-combined-documentation \
           --transform-for-static-hosting \
           --hosting-base-path SwiftAutoGUI \
           --output-path ./docs

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ sagui browser agent "Open issue 118" --domain github.com --allow-cross-origin
 
 # Example Usage
 
-If you would like to know more details, please refer to the [DocC Style Document](https://nakaokarei.github.io/SwiftAutoGUI/documentation/swiftautogui/).
+For complete API and module documentation, see the [SwiftAutoGUI DocC site](https://nakaokarei.github.io/SwiftAutoGUI/documentation/).
 
 ## AI Agent
 

--- a/Sources/SwiftAutoGUI/Documentation.docc/SwiftAutoGUI.md
+++ b/Sources/SwiftAutoGUI/Documentation.docc/SwiftAutoGUI.md
@@ -56,6 +56,9 @@ print("Completed: \(result.completed), Steps: \(result.iterationsUsed)")
 `Agent` uses ``NativeAutomationBackend`` by default. Optional modules can supply
 another ``AgentAutomationBackend`` explicitly while preserving the native default.
 
+To observe and control an existing Chromium session through the Chrome DevTools
+Protocol, see [Using a Browser Agent](https://nakaokarei.github.io/SwiftAutoGUI/documentation/swiftautoguibrowser/browseragent/).
+
 ### With Step Callback
 
 ```swift


### PR DESCRIPTION
## Summary
- publish SwiftAutoGUI and SwiftAutoGUIBrowser as one combined DocC site
- expose BrowserAgent from the package landing page and the SwiftAutoGUI guide
- make PR documentation CI validate the same combined archive used for deployment
- update the README documentation link to the package landing page

## Verification
- generated the combined static-hosting DocC archive locally
- confirmed both modules appear on the package landing page
- confirmed the Using a Browser Agent article is generated at the expected route
- confirmed the new BrowserAgent link is active in the generated SwiftAutoGUI page

Existing unrelated DocC symbol-comment warnings remain unchanged.